### PR TITLE
Add gum_process_enumerate_malloc_ranges

### DIFF
--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -401,6 +401,13 @@ gum_linux_enumerate_ranges (pid_t pid,
 }
 
 void
+gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
+                                     gpointer user_data)
+{
+  /* Not implemented */
+}
+
+void
 gum_module_enumerate_exports (const gchar * module_name,
                               GumFoundExportFunc func,
                               gpointer user_data)

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -221,6 +221,13 @@ gum_process_enumerate_ranges (GumPageProtection prot,
 }
 
 void
+gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
+                                     gpointer user_data)
+{
+  /* Not implemented */
+}
+
+void
 gum_process_enumerate_modules (GumFoundModuleFunc func,
                                gpointer user_data)
 {

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -277,6 +277,13 @@ gum_process_enumerate_ranges (GumPageProtection prot,
 }
 
 void
+gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
+                                     gpointer user_data)
+{
+  /* Not implemented */
+}
+
+void
 gum_module_enumerate_exports (const gchar * module_name,
                               GumFoundExportFunc func,
                               gpointer user_data)

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -17,6 +17,7 @@ typedef guint GumExportType;
 typedef struct _GumExportDetails GumExportDetails;
 typedef struct _GumRangeDetails GumRangeDetails;
 typedef struct _GumFileMapping GumFileMapping;
+typedef struct _GumMallocRangeDetails GumMallocRangeDetails;
 
 enum _GumThreadState
 {
@@ -67,6 +68,11 @@ struct _GumFileMapping
   guint64 offset;
 };
 
+struct _GumMallocRangeDetails
+{
+  const GumMemoryRange * range;
+};
+
 G_BEGIN_DECLS
 
 typedef void (* GumModifyThreadFunc) (GumThreadId thread_id,
@@ -79,6 +85,8 @@ typedef gboolean (* GumFoundExportFunc) (const GumExportDetails * details,
     gpointer user_data);
 typedef gboolean (* GumFoundRangeFunc) (const GumRangeDetails * details,
     gpointer user_data);
+typedef gboolean (* GumFoundMallocRangeFunc) (
+    const GumMallocRangeDetails * details, gpointer user_data);
 
 GUM_API GumOS gum_process_get_native_os (void);
 GUM_API gboolean gum_process_is_debugger_attached (void);
@@ -91,6 +99,8 @@ GUM_API void gum_process_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
 GUM_API void gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
+GUM_API void gum_process_enumerate_malloc_ranges (
+    GumFoundMallocRangeFunc func, gpointer user_data);
 GUM_API void gum_module_enumerate_exports (const gchar * module_name,
     GumFoundExportFunc func, gpointer user_data);
 GUM_API void gum_module_enumerate_ranges (const gchar * module_name,


### PR DESCRIPTION
I have only implemented the function for OS X.

I also added some new test cases for `gum_process_enumerate_ranges` that checks if a given range could be found.

Fixes #20 (at least for OS X).