### PR TITLE
Move gum_try_mprotect from backend-posix to backend-linux

### DIFF
--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -6,6 +6,8 @@
 
 #include "gummemory.h"
 
+#include "gummemory-priv.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -78,15 +80,6 @@ gum_memory_write (GumAddress address,
   return success;
 }
 
-void
-gum_clear_cache (gpointer address,
-                 gsize size)
-{
-#ifdef HAVE_ARM
-  cacheflush (GPOINTER_TO_SIZE (address), GPOINTER_TO_SIZE (address + size), 0);
-#endif
-}
-
 gboolean
 gum_try_mprotect (gpointer address,
                   gsize size,
@@ -105,11 +98,20 @@ gum_try_mprotect (gpointer address,
       GPOINTER_TO_SIZE (address) & ~(page_size - 1));
   aligned_size =
       (1 + ((address + size - 1 - aligned_address) / page_size)) * page_size;
-  posix_page_prot = gum_page_protection_to_posix (page_prot);
+  posix_page_prot = _gum_page_protection_to_posix (page_prot);
 
   result = mprotect (aligned_address, aligned_size, posix_page_prot);
 
   return result == 0;
+}
+
+void
+gum_clear_cache (gpointer address,
+                 gsize size)
+{
+#ifdef HAVE_ARM
+  cacheflush (GPOINTER_TO_SIZE (address), GPOINTER_TO_SIZE (address + size), 0);
+#endif
 }
 
 static gboolean

--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -87,6 +87,31 @@ gum_clear_cache (gpointer address,
 #endif
 }
 
+gboolean
+gum_try_mprotect (gpointer address,
+                  gsize size,
+                  GumPageProtection page_prot)
+{
+  gsize page_size;
+  gpointer aligned_address;
+  gsize aligned_size;
+  gint posix_page_prot;
+  gint result;
+
+  g_assert (size != 0);
+
+  page_size = gum_query_page_size ();
+  aligned_address = GSIZE_TO_POINTER (
+      GPOINTER_TO_SIZE (address) & ~(page_size - 1));
+  aligned_size =
+      (1 + ((address + size - 1 - aligned_address) / page_size)) * page_size;
+  posix_page_prot = gum_page_protection_to_posix (page_prot);
+
+  result = mprotect (aligned_address, aligned_size, posix_page_prot);
+
+  return result == 0;
+}
+
 static gboolean
 gum_memory_get_protection (GumAddress address,
                            gsize n,

--- a/gum/backend-posix/gummemory-posix.c
+++ b/gum/backend-posix/gummemory-posix.c
@@ -6,6 +6,8 @@
 
 #include "gummemory.h"
 
+#include "gummemory-priv.h"
+
 #include "gumprocess.h"
 
 #include <unistd.h>
@@ -54,7 +56,7 @@ gum_alloc_n_pages (guint n_pages,
 
   page_size = gum_query_page_size ();
   size = (1 + n_pages) * page_size;
-  posix_page_prot = gum_page_protection_to_posix (page_prot);
+  posix_page_prot = _gum_page_protection_to_posix (page_prot);
 
   result = mmap (NULL, size, posix_page_prot, flags, -1, 0);
   g_assert (result != NULL);
@@ -78,7 +80,7 @@ gum_alloc_n_pages_near (guint n_pages,
 
   ctx.result = NULL;
   ctx.size = (1 + n_pages) * page_size;
-  ctx.posix_page_prot = gum_page_protection_to_posix (page_prot);
+  ctx.posix_page_prot = _gum_page_protection_to_posix (page_prot);
   ctx.address_spec = address_spec;
 
   gum_enumerate_free_ranges (gum_try_alloc_in_range_if_near_enough, &ctx);
@@ -189,7 +191,7 @@ gum_emit_free_range (const GumRangeDetails * details,
 }
 
 gint
-gum_page_protection_to_posix (GumPageProtection page_prot)
+_gum_page_protection_to_posix (GumPageProtection page_prot)
 {
   gint posix_page_prot = PROT_NONE;
 

--- a/gum/backend-posix/gummemory-posix.c
+++ b/gum/backend-posix/gummemory-posix.c
@@ -37,37 +37,10 @@ static void gum_enumerate_free_ranges (GumFoundRangeFunc func,
 static gboolean gum_emit_free_range (const GumRangeDetails * details,
     gpointer user_data);
 
-static gint gum_page_protection_to_posix (GumPageProtection page_prot);
-
 guint
 gum_query_page_size (void)
 {
   return sysconf (_SC_PAGE_SIZE);
-}
-
-gboolean
-gum_try_mprotect (gpointer address,
-                  gsize size,
-                  GumPageProtection page_prot)
-{
-  gsize page_size;
-  gpointer aligned_address;
-  gsize aligned_size;
-  gint posix_page_prot;
-  gint result;
-
-  g_assert (size != 0);
-
-  page_size = gum_query_page_size ();
-  aligned_address = GSIZE_TO_POINTER (
-      GPOINTER_TO_SIZE (address) & ~(page_size - 1));
-  aligned_size =
-      (1 + ((address + size - 1 - aligned_address) / page_size)) * page_size;
-  posix_page_prot = gum_page_protection_to_posix (page_prot);
-
-  result = mprotect (aligned_address, aligned_size, posix_page_prot);
-
-  return result == 0;
 }
 
 gpointer
@@ -215,7 +188,7 @@ gum_emit_free_range (const GumRangeDetails * details,
   return carry_on;
 }
 
-static gint
+gint
 gum_page_protection_to_posix (GumPageProtection page_prot)
 {
   gint posix_page_prot = PROT_NONE;

--- a/gum/gummemory-priv.h
+++ b/gum/gummemory-priv.h
@@ -31,4 +31,6 @@ struct _GumMatchToken
   guint offset;
 };
 
+G_GNUC_INTERNAL gint _gum_page_protection_to_posix (GumPageProtection page_prot);
+
 #endif

--- a/gum/gummemory-priv.h
+++ b/gum/gummemory-priv.h
@@ -31,6 +31,7 @@ struct _GumMatchToken
   guint offset;
 };
 
-G_GNUC_INTERNAL gint _gum_page_protection_to_posix (GumPageProtection page_prot);
+G_GNUC_INTERNAL gint _gum_page_protection_to_posix (
+    GumPageProtection page_prot);
 
 #endif

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -88,6 +88,8 @@ gpointer gum_alloc_n_pages (guint n_pages, GumPageProtection page_prot);
 gpointer gum_alloc_n_pages_near (guint n_pages, GumPageProtection page_prot, GumAddressSpec * address_spec);
 void gum_free_pages (gpointer mem);
 
+gint gum_page_protection_to_posix (GumPageProtection page_prot);
+
 G_END_DECLS
 
 #endif

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -88,8 +88,6 @@ gpointer gum_alloc_n_pages (guint n_pages, GumPageProtection page_prot);
 gpointer gum_alloc_n_pages_near (guint n_pages, GumPageProtection page_prot, GumAddressSpec * address_spec);
 void gum_free_pages (gpointer mem);
 
-gint gum_page_protection_to_posix (GumPageProtection page_prot);
-
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
In preparation for having an instance of this function in backend-qnx which behaves differently.