### PR TITLE
Make mprotect hack mmap with PROT_EXEC

### DIFF
--- a/gum/backend-qnx/gummemory-qnx.c
+++ b/gum/backend-qnx/gummemory-qnx.c
@@ -152,7 +152,7 @@ gum_try_mprotect (gpointer address,
     }
 
     address_mmaped = mmap (aligned_address, aligned_size,
-        PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, NOFD, 0);
+        PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_FIXED, NOFD, 0);
     g_assert (address_mmaped == aligned_address);
 
     memcpy (aligned_address, buffer, aligned_size);


### PR DESCRIPTION
This is better for the case where we are changing permissions for
the same page as something we are executing.