### PR TITLE
Add capstone to armrelocator; implement PC relative ldr rewrite.

### DIFF
--- a/gum/arch-arm/gumarm.h
+++ b/gum/arch-arm/gumarm.h
@@ -34,7 +34,8 @@ enum _GumArmMnemonic
   GUM_ARM_PUSH,
   GUM_ARM_POP,
   GUM_ARM_LDRPC,
-  GUM_ARM_MOV
+  GUM_ARM_MOV,
+  GUM_ARM_LDR
 };
 
 enum _GumArmReg

--- a/gum/arch-arm/gumarmrelocator.h
+++ b/gum/arch-arm/gumarmrelocator.h
@@ -11,12 +11,16 @@
 
 #include "gumarmwriter.h"
 
+#include <capstone/capstone.h>
+
 G_BEGIN_DECLS
 
 typedef struct _GumArmRelocator GumArmRelocator;
 
 struct _GumArmRelocator
 {
+  csh capstone;
+
   const guint8 * input_start;
   const guint8 * input_cur;
   GumAddress input_pc;

--- a/gum/arch-arm/gumarmwriter.c
+++ b/gum/arch-arm/gumarmwriter.c
@@ -157,6 +157,26 @@ gum_arm_writer_put_ldr_reg_u32 (GumArmWriter * self,
 }
 
 void
+gum_arm_writer_put_add_reg_reg_imm (GumArmWriter * self,
+                                    GumArmReg dst_reg,
+                                    GumArmReg src_reg,
+                                    guint32 imm_val)
+{
+  gum_arm_writer_put_instruction (self, 0xe2800000 | dst_reg << 12 |
+      src_reg << 16 | (imm_val & 0xfff));
+}
+
+void
+gum_arm_writer_put_ldr_reg_reg_imm (GumArmWriter * self,
+                                    GumArmReg dst_reg,
+                                    GumArmReg src_reg,
+                                    guint32 imm_val)
+{
+  gum_arm_writer_put_instruction (self, 0xe5900000 | dst_reg << 12 |
+      src_reg << 16 | (imm_val & 0xfff));
+}
+
+void
 gum_arm_writer_put_nop (GumArmWriter * self)
 {
   gum_arm_writer_put_instruction (self, 0xe1a00000);

--- a/gum/arch-arm/gumarmwriter.h
+++ b/gum/arch-arm/gumarmwriter.h
@@ -43,6 +43,11 @@ void gum_arm_writer_flush (GumArmWriter * self);
 void gum_arm_writer_put_ldr_reg_address (GumArmWriter * self, GumArmReg reg, GumAddress address);
 void gum_arm_writer_put_ldr_reg_u32 (GumArmWriter * self, GumArmReg reg, guint32 val);
 
+void gum_arm_writer_put_add_reg_reg_imm (GumArmWriter * self, GumArmReg dst_reg,
+    GumArmReg src_reg, guint32 imm_val);
+void gum_arm_writer_put_ldr_reg_reg_imm (GumArmWriter * self, GumArmReg dst_reg,
+    GumArmReg src_reg, guint32 imm_val);
+
 void gum_arm_writer_put_nop (GumArmWriter * self);
 void gum_arm_writer_put_breakpoint (GumArmWriter * self);
 


### PR DESCRIPTION
Add capstone to the ARM Relocator, allowing for parsing instructions
using the capstone API.

Also, implement rewrite of PC relative ldr instructions (where PC
is the base register for the second operand).