### PR TITLE
Add additional shortcuts for reading and writing memory.

### DIFF
--- a/gum/gumscript-runtime-core.js
+++ b/gum/gumscript-runtime-core.js
@@ -6,6 +6,8 @@
         dispatcher = new MessageDispatcher();
     };
 
+    const longSize = (Process.pointerSize == 8 && Process.platform !== 'windows') ? 64 : 32;
+
     Object.defineProperty(engine, 'recv', {
         enumerable: true,
         value: function recv() {
@@ -64,6 +66,90 @@
             var result = Memory.alloc(size);
             Memory.copy(result, mem, size);
             return result;
+        }
+    });
+
+    Object.defineProperty(Memory, 'readShort', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory.readS16(mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeShort', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory.writeS16(mem, value);
+        }
+    });
+
+    Object.defineProperty(Memory, 'readUShort', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory.readU16(mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeUShort', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory.writeU16(mem, value);
+        }
+    });
+
+    Object.defineProperty(Memory, 'readInt', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory.readS32(mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeInt', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory.writeS32(mem, value);
+        }
+    });
+
+    Object.defineProperty(Memory, 'readUInt', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory.readU32(mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeUInt', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory.writeU32(mem, value);
+        }
+    });
+
+    Object.defineProperty(Memory, 'readLong', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory['readS' + longSize](mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeLong', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory['writeS' + longSize](mem, value);
+        }
+    });
+
+    Object.defineProperty(Memory, 'readULong', {
+        enumerable: true,
+        value: function (mem) {
+            return Memory['readU' + longSize](mem);
+        }
+    });
+
+    Object.defineProperty(Memory, 'writeULong', {
+        enumerable: true,
+        value: function (mem, value) {
+            return Memory['writeU' + longSize](mem, value);
         }
     });
 

--- a/tests/core/script.c
+++ b/tests/core/script.c
@@ -53,6 +53,18 @@ TEST_LIST_BEGIN (script)
   SCRIPT_TESTENTRY (s64_can_be_written)
   SCRIPT_TESTENTRY (u64_can_be_read)
   SCRIPT_TESTENTRY (u64_can_be_written)
+  SCRIPT_TESTENTRY (short_can_be_read)
+  SCRIPT_TESTENTRY (short_can_be_written)
+  SCRIPT_TESTENTRY (ushort_can_be_read)
+  SCRIPT_TESTENTRY (ushort_can_be_written)
+  SCRIPT_TESTENTRY (int_can_be_read)
+  SCRIPT_TESTENTRY (int_can_be_written)
+  SCRIPT_TESTENTRY (uint_can_be_read)
+  SCRIPT_TESTENTRY (uint_can_be_written)
+  SCRIPT_TESTENTRY (long_can_be_read)
+  SCRIPT_TESTENTRY (long_can_be_written)
+  SCRIPT_TESTENTRY (ulong_can_be_read)
+  SCRIPT_TESTENTRY (ulong_can_be_written)
   SCRIPT_TESTENTRY (byte_array_can_be_read)
   SCRIPT_TESTENTRY (byte_array_can_be_written)
   SCRIPT_TESTENTRY (utf8_string_can_be_read)
@@ -1496,6 +1508,96 @@ SCRIPT_TESTCASE (u64_can_be_written)
   COMPILE_AND_LOAD_SCRIPT ("Memory.writeU64(" GUM_PTR_CONST
       ", 1201239876783);", &val);
   g_assert_cmpint (val, ==, G_GUINT64_CONSTANT (1201239876783));
+}
+
+SCRIPT_TESTCASE (short_can_be_read)
+{
+  short val = -12123;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readShort(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("-12123");
+}
+
+SCRIPT_TESTCASE (short_can_be_written)
+{
+  short val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeShort(" GUM_PTR_CONST ", -12123);",
+    &val);
+  g_assert_cmpint (val, ==, -12123);
+}
+
+SCRIPT_TESTCASE (ushort_can_be_read)
+{
+  unsigned short val = 12123;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readUShort(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("12123");
+}
+
+SCRIPT_TESTCASE (ushort_can_be_written)
+{
+  unsigned short val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeUShort(" GUM_PTR_CONST ", 12123);",
+    &val);
+  g_assert_cmpint (val, ==, 12123);
+}
+
+SCRIPT_TESTCASE (int_can_be_read)
+{
+  int val = -120123;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readInt(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("-120123");
+}
+
+SCRIPT_TESTCASE (int_can_be_written)
+{
+  int val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeInt(" GUM_PTR_CONST ", -120123);",
+    &val);
+  g_assert_cmpint (val, ==, -120123);
+}
+
+SCRIPT_TESTCASE (uint_can_be_read)
+{
+  unsigned int val = 120123;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readUInt(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("120123");
+}
+
+SCRIPT_TESTCASE (uint_can_be_written)
+{
+  unsigned int val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeUInt(" GUM_PTR_CONST ", 120123);",
+    &val);
+  g_assert_cmpint (val, ==, 120123);
+}
+
+SCRIPT_TESTCASE (long_can_be_read)
+{
+  long val = -2147483648;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readLong(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("-2147483648");
+}
+
+SCRIPT_TESTCASE (long_can_be_written)
+{
+  long val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeLong(" GUM_PTR_CONST ", 1350966097);",
+    &val);
+  g_assert_cmpint (val, ==, 1350966097);
+}
+
+SCRIPT_TESTCASE (ulong_can_be_read)
+{
+  unsigned long val = 4294967295;
+  COMPILE_AND_LOAD_SCRIPT ("send(Memory.readULong(" GUM_PTR_CONST "));", &val);
+  EXPECT_SEND_MESSAGE_WITH ("4294967295");
+}
+
+SCRIPT_TESTCASE (ulong_can_be_written)
+{
+  unsigned long val = 0;
+  COMPILE_AND_LOAD_SCRIPT ("Memory.writeULong(" GUM_PTR_CONST ", 4294967295);",
+    &val);
+  g_assert_cmpint (val, ==, 4294967295);
 }
 
 SCRIPT_TESTCASE (byte_array_can_be_read)


### PR DESCRIPTION
This PR adds the following methods to `Memory`

* readShort
* writeShort
* readUShort
* writeUShort
* readInt
* writeInt
* readUInt
* writeUInt
* readLong
* writeLong
* readULong
* writeULong

Not sure what your thoughts are, but I added `longSize` to the top of `gumscript-runtime-core.js` so it's only calculated once, and not each call.

Also, the tests for **\*Long** are missing, I'm not entirely sure how to get the proper sized value for the current platform in C. 