### PR TITLE
Fix replace_function test case

### DIFF
--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -478,7 +478,7 @@ INTERCEPTOR_TESTCASE (replace_function)
 {
   gpointer (* malloc_impl) (gsize size);
   guint counter = 0;
-  gpointer ret;
+  volatile gpointer ret;
 
 #ifdef HAVE_LINUX
   /*


### PR DESCRIPTION
The ret variable in this case needs to be volatile so that the
compiler doesn't aggressively optimize, resulting in an assert
0x42 == 0x42.