### PR TITLE
Fix bugs in gumarmrelocator and gumarmreader related to improper instruction assembly/decoding.

### DIFF
--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -25,7 +25,9 @@ TEST_LIST_BEGIN (interceptor)
   INTERCEPTOR_TESTENTRY (attach_one)
   INTERCEPTOR_TESTENTRY (attach_two)
   INTERCEPTOR_TESTENTRY (attach_to_special_function)
+#ifndef HAVE_QNX
   INTERCEPTOR_TESTENTRY (attach_to_heap_api)
+#endif
   INTERCEPTOR_TESTENTRY (attach_to_own_api)
 #ifdef G_OS_WIN32
   INTERCEPTOR_TESTENTRY (attach_detach_torture)

--- a/tests/gumtest.c
+++ b/tests/gumtest.c
@@ -109,7 +109,7 @@ main (gint argc, gchar * argv[])
   TEST_RUN_LIST (arm64writer);
   TEST_RUN_LIST (arm64relocator);
   TEST_RUN_LIST (interceptor);
-#if defined (HAVE_V8)
+#if defined (HAVE_V8) && !defined(HAVE_QNX)
   TEST_RUN_LIST (script);
 #endif
 #if defined (HAVE_I386) && defined (G_OS_WIN32)
@@ -121,7 +121,9 @@ main (gint argc, gchar * argv[])
 #ifdef HAVE_MAC
   TEST_RUN_LIST (stalker_mac);
 #endif
+#ifndef HAVE_QNX
   TEST_RUN_LIST (backtracer);
+#endif
 
   /* Heap */
   TEST_RUN_LIST (allocation_tracker);
@@ -157,8 +159,10 @@ main (gint argc, gchar * argv[])
   TEST_RUN_LIST (profiler);
 #endif
 
+#ifndef HAVE_QNX
   /* GUM++ */
   TEST_RUN_LIST (gumpp_backtracer);
+#endif
 
 #ifdef _MSC_VER
 #pragma warning (pop)

--- a/tests/heap/boundschecker.c
+++ b/tests/heap/boundschecker.c
@@ -17,8 +17,10 @@ TEST_LIST_BEGIN (boundschecker)
   BOUNDSCHECKER_TESTENTRY (protected_after_free)
   BOUNDSCHECKER_TESTENTRY (calloc_initializes_to_zero)
   BOUNDSCHECKER_TESTENTRY (custom_front_alignment)
+#ifndef HAVE_QNX
   BOUNDSCHECKER_TESTENTRY (output_report_on_access_beyond_end)
   BOUNDSCHECKER_TESTENTRY (output_report_on_access_after_free)
+#endif
 TEST_LIST_END ()
 
 BOUNDSCHECKER_TESTCASE (output_report_on_access_beyond_end)


### PR DESCRIPTION
Failing tests:
 - interceptor/attach_to_heap_api fails with segfault in malloc_init
 - script suite fails with segfault when trying to write to stack
 - backtracer suite fails with segfault in libfrida-gumpp: _ULarm_dwarf_find_save_locs (libunwind)
- Gum++/Backtracer/can_get_stack_trace_from_invocation_context fails assertion (return_addresses.len >= 1): (0 >= 1)
- boundschecker/output_report* tests hang the process