### PR TITLE
Get object classname

### DIFF
--- a/bindings/gumjs/gumscript-runtime-dalvik.js
+++ b/bindings/gumjs/gumscript-runtime-dalvik.js
@@ -272,11 +272,12 @@
             let handle = obj.hasOwnProperty('$handle') ? obj.$handle : obj;
             if (handle instanceof NativePointer) {
                 let env = vm.getEnv();
-                let jklass = env.getObjectClass(obj);
                 let invokeObjectMethodNoArgs = env.method('pointer', []);
 
+                let jklass = env.getObjectClass(handle);
                 let stringObj = invokeObjectMethodNoArgs(env.handle, jklass, env.javaLangClass().getName);
                 let clsStr = env.stringFromJni(stringObj);
+                
                 env.deleteLocalRef(stringObj);
                 env.deleteLocalRef(jklass);
                 return clsStr;


### PR DESCRIPTION
It's useful:
- if you have a reference to an object and you don't know the class of it
- if you call a generic method in Java and you want to determine the class of the result
- to determine the real class if it's type is an interface

```
...
let instance = Dalvik.cast(p, klass);
console.log(instance.constructor.name);
console.log(instance.class);
console.log(Dalvik.getObjectClassname(instance));
console.log(Dalvik.getObjectClassname(p));
```

Results
```
ITest
interface com.example.example.ITest
com.example.example.Test1
com.example.example.Test1
```
