### PR TITLE
Implement method to load classes at runtime

### DIFF
--- a/bindings/gumjs/gumscript-runtime-java.js
+++ b/bindings/gumjs/gumscript-runtime-java.js
@@ -273,8 +273,8 @@
             return classFactory.use(className);
         };
 
-        this.openDexFile = function (filePath) {
-            return classFactory.openDexFile(filePath);
+        this.openClassFile = function (filePath) {
+            return classFactory.openClassFile(filePath);
         };
 
         this.choose = function (className, callbacks) {
@@ -418,7 +418,7 @@
             }
         };
 
-        this.openDexFile = function (filePath) {
+        this.openClassFile = function (filePath) {
             return new DexFile(filePath);
         };
 

--- a/bindings/gumjs/gumscript-runtime-java.js
+++ b/bindings/gumjs/gumscript-runtime-java.js
@@ -378,15 +378,15 @@
                 if (loader === null) {
                     throw new Error("Not allowed outside Java.perform() callback");
                 }
-                const File = Dalvik.use("java.io.File");
+                const File = factory.use("java.io.File");
                 const f = File.$new(this[FILE_PATH]);
                 if (!f.exists()) {
                     throw new Error("File isn't available");
                 }
 
-                const currentApplication = Dalvik.use("android.app.ActivityThread").currentApplication();
+                const currentApplication = factory.use("android.app.ActivityThread").currentApplication();
                 const optimizedDexOutputPath = currentApplication.getDir("outdex", 0);
-                const DexClassLoader = Dalvik.use('dalvik.system.DexClassLoader');
+                const DexClassLoader = factory.use("dalvik.system.DexClassLoader");
 
                 let classLoader = null;
                 if (loader !== null) {
@@ -404,9 +404,9 @@
                     throw new Error("Not allowed outside Java.perform() callback");
                 }
                 const classNames = [];
-                const File = Dalvik.use("java.io.File");
-                const DexFile = Dalvik.use("dalvik.system.DexFile");
-                const currentApplication = Dalvik.use("android.app.ActivityThread").currentApplication();
+                const File = factory.use("java.io.File");
+                const DexFile = factory.use("dalvik.system.DexFile");
+                const currentApplication = factory.use("android.app.ActivityThread").currentApplication();
                 const dx = DexFile.loadDex(this[FILE_PATH], File.createTempFile("opt", "dex",
                     currentApplication.getCacheDir()).getPath(), 0);
 


### PR DESCRIPTION
```Java.openDexFile(filePath)``` will return an object with two methods
 - ```load()```: load the dex-file
 - ```getClassNames()```: get the class names