### PR TITLE
Add the possibility to monitor any combination of R, W or X operations

### DIFF
--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -1120,8 +1120,9 @@ gum_v8_memory_access_monitor_on_enable (
     g_object_unref (self->monitor);
     self->monitor = NULL;
   }
+
   self->monitor = gum_memory_access_monitor_new (ranges, num_ranges,
-      gum_v8_script_handle_memory_access, self, NULL);
+      GUM_PAGE_RWX, TRUE, gum_v8_script_handle_memory_access, self, NULL);
 
   g_free (ranges);
 

--- a/gum/gummemoryaccessmonitor.h
+++ b/gum/gummemoryaccessmonitor.h
@@ -61,8 +61,10 @@ struct _GumMemoryAccessDetails
 GUM_API GType gum_memory_access_monitor_get_type (void) G_GNUC_CONST;
 
 GUM_API GumMemoryAccessMonitor * gum_memory_access_monitor_new (
-    const GumMemoryRange * ranges, guint num_ranges, GumMemoryAccessNotify func,
-    gpointer data, GDestroyNotify data_destroy);
+    const GumMemoryRange * ranges, guint num_ranges, 
+    GumPageProtection access_mask, gboolean auto_reset, 
+    GumMemoryAccessNotify func, gpointer data, 
+    GDestroyNotify data_destroy);
 
 GUM_API gboolean gum_memory_access_monitor_enable (
     GumMemoryAccessMonitor * self, GError ** error);

--- a/tests/core/memoryaccessmonitor-fixture.c
+++ b/tests/core/memoryaccessmonitor-fixture.c
@@ -70,7 +70,7 @@ memory_access_notify_cb (GumMemoryAccessMonitor * monitor,
 #define ENABLE_MONITOR() \
     g_assert (fixture->monitor == NULL); \
     fixture->monitor = gum_memory_access_monitor_new (&fixture->range, 1, \
-        memory_access_notify_cb, fixture, NULL); \
+        GUM_PAGE_RWX, TRUE, memory_access_notify_cb, fixture, NULL); \
     g_assert (fixture->monitor != NULL); \
     g_assert (gum_memory_access_monitor_enable (fixture->monitor, NULL)); \
     g_assert_cmpuint (fixture->number_of_notifies, ==, 0)


### PR DESCRIPTION
Also add an auto-reset switch that can be used to monitor all the access
or only the first one.

Sorry, no new tests for this feature but it passes all the olds ones.