### PR TITLE
Implement enumerate_threads and modify_thread for qnx

### DIFF
--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -115,7 +115,7 @@ gum_process_modify_thread (GumThreadId thread_id,
   gboolean success = FALSE;
   struct sigaction action, old_action;
 
-  ThreadCtl (_NTO_TCTL_ONE_THREAD_HOLD, (void *)thread_id);
+  ThreadCtl (_NTO_TCTL_ONE_THREAD_HOLD, (void *) thread_id);
   if (vfork () == 0)
   {
     gchar as_path[PATH_MAX];


### PR DESCRIPTION
Currently this implementation uses a vfork to spawn a new process which can then inspect the threads of the original process, as inspecting the currently running process with procfs is broken on qnx