### PR TITLE
Add stream APIs for working with GIO streams

### DIFF
--- a/bindings/gumjs/Makefile.am
+++ b/bindings/gumjs/Makefile.am
@@ -37,6 +37,8 @@ v8_sources = \
 	gumv8file.cpp \
 	gumv8socket.h \
 	gumv8socket.cpp \
+	gumv8stream.h \
+	gumv8stream.cpp \
 	gumv8interceptor.h \
 	gumv8interceptor.cpp \
 	gumv8stalker.h \
@@ -76,6 +78,8 @@ duk_sources = \
 	gumdukfile.c \
 	gumduksocket.h \
 	gumduksocket.c \
+	gumdukstream.h \
+	gumdukstream.c \
 	gumdukinterceptor.h \
 	gumdukinterceptor.c \
 	gumdukstalker.h \

--- a/bindings/gumjs/gumdukmacros.h
+++ b/bindings/gumjs/gumdukmacros.h
@@ -24,7 +24,7 @@
   static int N (duk_context * ctx);
 
 #define GUMJS_DEFINE_CONSTRUCTOR(N) \
-  static int N##_impl (duk_context * ctx, GumDukArgs * args); \
+  static int N##_impl (duk_context * ctx, const GumDukArgs * args); \
   \
   static int \
   N (duk_context * ctx) \
@@ -44,9 +44,9 @@
   \
   static int \
   N##_impl (duk_context * ctx, \
-            GumDukArgs * args)
+            const GumDukArgs * args)
 #define GUMJS_DEFINE_FINALIZER(N) \
-  static int N##_impl (duk_context * ctx, GumDukArgs * args); \
+  static int N##_impl (duk_context * ctx, const GumDukArgs * args); \
   \
   static int \
   N (duk_context * ctx) \
@@ -66,9 +66,9 @@
   \
   static int \
   N##_impl (duk_context * ctx, \
-            GumDukArgs * args)
+            const GumDukArgs * args)
 #define GUMJS_DEFINE_FUNCTION(N) \
-  static int N##_impl (duk_context * ctx, GumDukArgs * args); \
+  static int N##_impl (duk_context * ctx, const GumDukArgs * args); \
   \
   static int \
   N (duk_context * ctx) \
@@ -88,9 +88,9 @@
   \
   static int \
   N##_impl (duk_context * ctx, \
-            GumDukArgs * args)
+            const GumDukArgs * args)
 #define GUMJS_DEFINE_GETTER(N) \
-  static int N##_impl (duk_context * ctx, GumDukArgs * args); \
+  static int N##_impl (duk_context * ctx, const GumDukArgs * args); \
   \
   static int \
   N (duk_context * ctx) \
@@ -110,9 +110,9 @@
   \
   static int \
   N##_impl (duk_context * ctx, \
-            GumDukArgs * args)
+            const GumDukArgs * args)
 #define GUMJS_DEFINE_SETTER(N) \
-  static int N##_impl (duk_context * ctx, GumDukArgs * args); \
+  static int N##_impl (duk_context * ctx, const GumDukArgs * args); \
   \
   static int \
   N (duk_context * ctx) \
@@ -132,7 +132,7 @@
   \
   static int \
   N##_impl (duk_context * ctx, \
-            GumDukArgs * args)
+            const GumDukArgs * args)
 
 #define GUMJS_ADD_GLOBAL_FUNCTION(N, F, NARGS) \
   duk_push_c_function (ctx, F, NARGS); \

--- a/bindings/gumjs/gumdukscript.c
+++ b/bindings/gumjs/gumdukscript.c
@@ -20,6 +20,7 @@
 #include "gumdukscript-runtime.h"
 #include "gumduksocket.h"
 #include "gumdukstalker.h"
+#include "gumdukstream.h"
 #include "gumduksymbol.h"
 #include "gumdukthread.h"
 #include "gumdukvalue.h"
@@ -57,6 +58,7 @@ struct _GumDukScriptPrivate
   GumDukModule module;
   GumDukFile file;
   GumDukSocket socket;
+  GumDukStream stream;
   GumDukInterceptor interceptor;
   GumDukStalker stalker;
   GumDukApiResolver api_resolver;
@@ -375,6 +377,7 @@ gum_duk_script_create_context (GumDukScript * self,
   _gum_duk_module_init (&priv->module, &priv->core);
   _gum_duk_file_init (&priv->file, &priv->core);
   _gum_duk_socket_init (&priv->socket, &priv->core);
+  _gum_duk_stream_init (&priv->stream, &priv->core);
   _gum_duk_interceptor_init (&priv->interceptor, &priv->core);
   _gum_duk_stalker_init (&priv->stalker, &priv->core);
   _gum_duk_api_resolver_init (&priv->api_resolver, &priv->core);
@@ -402,6 +405,7 @@ gum_duk_script_destroy_context (GumDukScript * self)
 
   _gum_duk_stalker_flush (&priv->stalker);
   _gum_duk_interceptor_flush (&priv->interceptor);
+  _gum_duk_stream_flush (&priv->stream);
   _gum_duk_core_flush (&priv->core);
 
   g_rec_mutex_unlock (&priv->core.mutex);
@@ -413,6 +417,7 @@ gum_duk_script_destroy_context (GumDukScript * self)
   _gum_duk_api_resolver_dispose (&priv->api_resolver);
   _gum_duk_stalker_dispose (&priv->stalker);
   _gum_duk_interceptor_dispose (&priv->interceptor);
+  _gum_duk_stream_dispose (&priv->stream);
   _gum_duk_socket_dispose (&priv->socket);
   _gum_duk_file_dispose (&priv->file);
   _gum_duk_module_dispose (&priv->module);
@@ -437,6 +442,7 @@ gum_duk_script_destroy_context (GumDukScript * self)
   _gum_duk_api_resolver_finalize (&priv->api_resolver);
   _gum_duk_stalker_finalize (&priv->stalker);
   _gum_duk_interceptor_finalize (&priv->interceptor);
+  _gum_duk_stream_finalize (&priv->stream);
   _gum_duk_socket_finalize (&priv->socket);
   _gum_duk_file_finalize (&priv->file);
   _gum_duk_module_finalize (&priv->module);

--- a/bindings/gumjs/gumdukstream.c
+++ b/bindings/gumjs/gumdukstream.c
@@ -1,0 +1,793 @@
+/*
+ * Copyright (C) 2016 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gumdukstream.h"
+
+#include "gumdukmacros.h"
+
+#ifdef G_OS_WIN32
+# include <gio/gwin32inputstream.h>
+# include <gio/gwin32outputstream.h>
+
+# define GUM_NATIVE_INPUT_STREAM "Win32InputStream"
+# define GUM_NATIVE_OUTPUT_STREAM "Win32OutputStream"
+# define GUM_NATIVE_KIND "Windows file handle"
+typedef gpointer GumStreamHandle;
+#else
+# include <gio/gunixinputstream.h>
+# include <gio/gunixoutputstream.h>
+
+# define GUM_NATIVE_INPUT_STREAM "UnixInputStream"
+# define GUM_NATIVE_OUTPUT_STREAM "UnixOutputStream"
+# define GUM_NATIVE_KIND "file descriptor"
+typedef gint GumStreamHandle;
+#endif
+
+typedef struct _GumDukCloseInputOperation GumDukCloseInputOperation;
+typedef struct _GumDukReadOperation GumDukReadOperation;
+typedef guint GumDukReadStrategy;
+
+typedef struct _GumDukCloseOutputOperation GumDukCloseOutputOperation;
+typedef struct _GumDukWriteOperation GumDukWriteOperation;
+typedef guint GumDukWriteStrategy;
+
+struct _GumDukCloseInputOperation
+{
+  GInputStream * stream;
+  GumDukHeapPtr callback;
+  GumScriptJob * job;
+
+  GumDukStream * module;
+};
+
+struct _GumDukReadOperation
+{
+  GInputStream * stream;
+  GumDukReadStrategy strategy;
+  gpointer buffer;
+  gsize buffer_size;
+  GumDukHeapPtr callback;
+  GumScriptJob * job;
+
+  GumDukStream * module;
+};
+
+enum _GumDukReadStrategy
+{
+  GUM_DUK_READ_SOME,
+  GUM_DUK_READ_ALL
+};
+
+struct _GumDukCloseOutputOperation
+{
+  GOutputStream * stream;
+  GumDukHeapPtr callback;
+  GumScriptJob * job;
+
+  GumDukStream * module;
+};
+
+struct _GumDukWriteOperation
+{
+  GOutputStream * stream;
+  GumDukWriteStrategy strategy;
+  GBytes * bytes;
+  GumDukHeapPtr callback;
+  GumScriptJob * job;
+
+  GumDukStream * module;
+};
+
+enum _GumDukWriteStrategy
+{
+  GUM_DUK_WRITE_SOME,
+  GUM_DUK_WRITE_ALL
+};
+
+GUMJS_DECLARE_CONSTRUCTOR (gumjs_input_stream_construct)
+GUMJS_DECLARE_FINALIZER (gumjs_input_stream_finalize)
+GUMJS_DECLARE_FUNCTION (gumjs_input_stream_close)
+static void gum_duk_close_input_operation_free (GumDukCloseInputOperation * op);
+static void gum_duk_close_input_operation_start (
+    GumDukCloseInputOperation * self);
+static void gum_duk_close_input_operation_finish (GInputStream * stream,
+    GAsyncResult * result, GumDukCloseInputOperation * self);
+GUMJS_DECLARE_FUNCTION (gumjs_input_stream_read)
+GUMJS_DECLARE_FUNCTION (gumjs_input_stream_read_all)
+static gint gumjs_input_stream_read_with_strategy (duk_context * ctx,
+    const GumDukArgs * args, GumDukReadStrategy strategy);
+static void gum_duk_read_operation_free (GumDukReadOperation * op);
+static void gum_duk_read_operation_start (GumDukReadOperation * self);
+static void gum_duk_read_operation_finish (GInputStream * stream,
+    GAsyncResult * result, GumDukReadOperation * self);
+
+GUMJS_DECLARE_CONSTRUCTOR (gumjs_output_stream_construct)
+GUMJS_DECLARE_FINALIZER (gumjs_output_stream_finalize)
+GUMJS_DECLARE_FUNCTION (gumjs_output_stream_close)
+static void gum_duk_close_output_operation_free (
+    GumDukCloseOutputOperation * op);
+static void gum_duk_close_output_operation_start (
+    GumDukCloseOutputOperation * self);
+static void gum_duk_close_output_operation_finish (GOutputStream * stream,
+    GAsyncResult * result, GumDukCloseOutputOperation * self);
+GUMJS_DECLARE_FUNCTION (gumjs_output_stream_write)
+GUMJS_DECLARE_FUNCTION (gumjs_output_stream_write_all)
+static gint gumjs_output_stream_write_with_strategy (duk_context * ctx,
+    const GumDukArgs * args, GumDukWriteStrategy strategy);
+static void gum_duk_write_operation_free (GumDukWriteOperation * op);
+static void gum_duk_write_operation_start (GumDukWriteOperation * self);
+static void gum_duk_write_operation_finish (GOutputStream * stream,
+    GAsyncResult * result, GumDukWriteOperation * self);
+
+static void gum_duk_stream_constructor_args_parse (const GumDukArgs * args,
+    GumStreamHandle * handle, gboolean * auto_close);
+
+static const duk_function_list_entry gumjs_input_stream_functions[] =
+{
+  { "_close", gumjs_input_stream_close, 1 },
+  { "_read", gumjs_input_stream_read, 2 },
+  { "_readAll", gumjs_input_stream_read_all, 2 },
+
+  { NULL, NULL, 0 }
+};
+
+static const duk_function_list_entry gumjs_output_stream_functions[] =
+{
+  { "_close", gumjs_output_stream_close, 1 },
+  { "_write", gumjs_output_stream_write, 2 },
+  { "_writeAll", gumjs_output_stream_write_all, 2 },
+
+  { NULL, NULL, 0 }
+};
+
+void
+_gum_duk_stream_init (GumDukStream * self,
+                      GumDukCore * core)
+{
+  duk_context * ctx = core->ctx;
+
+  self->core = core;
+
+  _gum_duk_store_module_data (ctx, "stream", self);
+
+  duk_push_c_function (ctx, gumjs_input_stream_construct, 2);
+  duk_push_object (ctx);
+  duk_put_function_list (ctx, -1, gumjs_input_stream_functions);
+  duk_push_c_function (ctx, gumjs_input_stream_finalize, 1);
+  duk_set_finalizer (ctx, -2);
+  duk_put_prop_string (ctx, -2, "prototype");
+  duk_put_global_string (ctx, GUM_NATIVE_INPUT_STREAM);
+
+  duk_push_c_function (ctx, gumjs_output_stream_construct, 2);
+  duk_push_object (ctx);
+  duk_put_function_list (ctx, -1, gumjs_output_stream_functions);
+  duk_push_c_function (ctx, gumjs_output_stream_finalize, 1);
+  duk_set_finalizer (ctx, -2);
+  duk_put_prop_string (ctx, -2, "prototype");
+  duk_put_global_string (ctx, GUM_NATIVE_OUTPUT_STREAM);
+
+  self->cancellable = g_cancellable_new ();
+}
+
+void
+_gum_duk_stream_flush (GumDukStream * self)
+{
+  g_cancellable_cancel (self->cancellable);
+}
+
+void
+_gum_duk_stream_dispose (GumDukStream * self)
+{
+  (void) self;
+}
+
+void
+_gum_duk_stream_finalize (GumDukStream * self)
+{
+  g_clear_object (&self->cancellable);
+}
+
+static GumDukStream *
+gumjs_module_from_args (const GumDukArgs * args)
+{
+  return _gum_duk_load_module_data (args->ctx, "stream");
+}
+
+static gpointer
+gumjs_stream_from_args (const GumDukArgs * args)
+{
+  duk_context * ctx = args->ctx;
+  gpointer stream;
+
+  duk_push_this (ctx);
+  stream = _gum_duk_require_data (ctx, -1);
+  duk_pop (ctx);
+
+  return stream;
+}
+
+GUMJS_DEFINE_CONSTRUCTOR (gumjs_input_stream_construct)
+{
+  GumStreamHandle handle;
+  gboolean auto_close;
+
+  if (!duk_is_constructor_call (ctx))
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR,
+        "Use `new " GUM_NATIVE_INPUT_STREAM "()` to create a new instance");
+    duk_throw (ctx);
+  }
+
+  gum_duk_stream_constructor_args_parse (args, &handle, &auto_close);
+
+  GInputStream * stream;
+#ifdef G_OS_WIN32
+  stream = g_win32_input_stream_new (handle, auto_close);
+#else
+  stream = g_unix_input_stream_new (handle, auto_close);
+#endif
+
+  duk_push_this (ctx);
+  _gum_duk_put_data (ctx, -1, stream);
+  duk_pop (ctx);
+
+  return 0;
+}
+
+GUMJS_DEFINE_FINALIZER (gumjs_input_stream_finalize)
+{
+  GInputStream * stream;
+
+  (void) args;
+
+  if (_gum_duk_is_arg0_equal_to_prototype (ctx, GUM_NATIVE_INPUT_STREAM))
+    return 0;
+
+  stream = _gum_duk_steal_data (ctx, 0);
+  if (stream == NULL)
+    return 0;
+
+  g_object_unref (stream);
+
+  return 0;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_input_stream_close)
+{
+  GInputStream * stream;
+  GumDukStream * module;
+  GumDukCore * core;
+  GumDukHeapPtr callback;
+  GumDukCloseInputOperation * op;
+
+  stream = gumjs_stream_from_args (args);
+  module = gumjs_module_from_args (args);
+  core = module->core;
+
+  _gum_duk_args_parse (args, "F", &callback);
+
+  duk_push_heapptr (ctx, callback);
+
+  op = g_slice_new (GumDukCloseInputOperation);
+  op->stream = g_object_ref (stream);
+  op->callback = _gum_duk_require_heapptr (ctx, -1);
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_duk_close_input_operation_start, op,
+      (GDestroyNotify) gum_duk_close_input_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static void
+gum_duk_close_input_operation_free (GumDukCloseInputOperation * op)
+{
+  _gum_duk_release_heapptr (op->module->core->ctx, op->callback);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumDukCloseInputOperation, op);
+}
+
+static void
+gum_duk_close_input_operation_start (GumDukCloseInputOperation * self)
+{
+  g_input_stream_close_async (self->stream, G_PRIORITY_DEFAULT,
+      self->module->cancellable,
+      (GAsyncReadyCallback) gum_duk_close_input_operation_finish, self);
+}
+
+static void
+gum_duk_close_input_operation_finish (GInputStream * stream,
+                                      GAsyncResult * result,
+                                      GumDukCloseInputOperation * self)
+{
+  GumDukCore * core = self->module->core;
+  duk_context * ctx = core->ctx;
+  GError * error = NULL;
+  gboolean success;
+  GumDukScope scope;
+
+  success = g_input_stream_close_finish (stream, result, &error);
+
+  _gum_duk_scope_enter (&scope, core);
+
+  duk_push_heapptr (ctx, self->callback);
+  if (error == NULL)
+  {
+    duk_push_null (ctx);
+  }
+  else
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s", error->message);
+    g_error_free (error);
+  }
+  duk_push_boolean (ctx, success);
+  _gum_duk_scope_call (&scope, 2);
+  duk_pop (ctx);
+
+  gum_script_job_free (self->job);
+
+  _gum_duk_scope_leave (&scope);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_input_stream_read)
+{
+  return gumjs_input_stream_read_with_strategy (ctx, args, GUM_DUK_READ_SOME);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_input_stream_read_all)
+{
+  return gumjs_input_stream_read_with_strategy (ctx, args, GUM_DUK_READ_ALL);
+}
+
+static gint
+gumjs_input_stream_read_with_strategy (duk_context * ctx,
+                                       const GumDukArgs * args,
+                                       GumDukReadStrategy strategy)
+{
+  GInputStream * stream;
+  GumDukStream * module;
+  GumDukCore * core;
+  guint64 size;
+  GumDukHeapPtr callback;
+  GumDukReadOperation * op;
+
+  stream = gumjs_stream_from_args (args);
+  module = gumjs_module_from_args (args);
+  core = module->core;
+
+  _gum_duk_args_parse (args, "QF", &size, &callback);
+
+  duk_push_heapptr (ctx, callback);
+
+  op = g_slice_new (GumDukReadOperation);
+  op->stream = g_object_ref (stream);
+  op->strategy = strategy;
+  op->buffer = g_malloc (size);
+  op->buffer_size = size;
+  op->callback = _gum_duk_require_heapptr (ctx, -1);
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_duk_read_operation_start, op,
+      (GDestroyNotify) gum_duk_read_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static void
+gum_duk_read_operation_free (GumDukReadOperation * op)
+{
+  _gum_duk_release_heapptr (op->module->core->ctx, op->callback);
+  g_free (op->buffer);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumDukReadOperation, op);
+}
+
+static void
+gum_duk_read_operation_start (GumDukReadOperation * self)
+{
+  if (self->strategy == GUM_DUK_READ_SOME)
+  {
+    g_input_stream_read_async (self->stream, self->buffer, self->buffer_size,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_duk_read_operation_finish, self);
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_DUK_READ_ALL);
+
+    g_input_stream_read_all_async (self->stream, self->buffer,
+        self->buffer_size, G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_duk_read_operation_finish, self);
+  }
+}
+
+static void
+gum_duk_read_operation_finish (GInputStream * stream,
+                               GAsyncResult * result,
+                               GumDukReadOperation * self)
+{
+  GumDukCore * core = self->module->core;
+  duk_context * ctx = core->ctx;
+  gsize bytes_read = 0;
+  GError * error = NULL;
+  GumDukScope scope;
+  gboolean emit_data;
+
+  if (self->strategy == GUM_DUK_READ_SOME)
+  {
+    gsize n;
+
+    n = g_input_stream_read_finish (stream, result, &error);
+    if (n > 0)
+      bytes_read = n;
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_DUK_READ_ALL);
+
+    g_input_stream_read_all_finish (stream, result, &bytes_read, &error);
+  }
+
+  _gum_duk_scope_enter (&scope, core);
+
+  duk_push_heapptr (ctx, self->callback);
+
+  if (self->strategy == GUM_DUK_READ_ALL && bytes_read != self->buffer_size)
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s",
+        (error != NULL) ? error->message : "Short read");
+    emit_data = TRUE;
+  }
+  else if (error == NULL)
+  {
+    duk_push_null (ctx);
+    emit_data = TRUE;
+  }
+  else
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s", error->message);
+    emit_data = FALSE;
+  }
+
+  g_clear_error (&error);
+
+  if (emit_data)
+  {
+    if (bytes_read > 0)
+    {
+      gpointer buffer_data;
+
+      buffer_data = duk_push_fixed_buffer (ctx, bytes_read);
+      memcpy (buffer_data, self->buffer, bytes_read);
+    }
+    else
+    {
+      duk_push_fixed_buffer (ctx, 0);
+    }
+
+    duk_push_buffer_object (ctx, -1, 0, bytes_read, DUK_BUFOBJ_ARRAYBUFFER);
+    duk_swap (ctx, -2, -1);
+    duk_pop (ctx);
+  }
+  else
+  {
+    duk_push_null (ctx);
+  }
+
+  _gum_duk_scope_call (&scope, 2);
+  duk_pop (ctx);
+
+  gum_script_job_free (self->job);
+
+  _gum_duk_scope_leave (&scope);
+}
+
+GUMJS_DEFINE_CONSTRUCTOR (gumjs_output_stream_construct)
+{
+  GumStreamHandle handle;
+  gboolean auto_close;
+
+  if (!duk_is_constructor_call (ctx))
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR,
+        "Use `new " GUM_NATIVE_OUTPUT_STREAM "()` to create a new instance");
+    duk_throw (ctx);
+  }
+
+  gum_duk_stream_constructor_args_parse (args, &handle, &auto_close);
+
+  GOutputStream * stream;
+#ifdef G_OS_WIN32
+  stream = g_win32_output_stream_new (handle, auto_close);
+#else
+  stream = g_unix_output_stream_new (handle, auto_close);
+#endif
+
+  duk_push_this (ctx);
+  _gum_duk_put_data (ctx, -1, stream);
+  duk_pop (ctx);
+
+  return 0;
+}
+
+GUMJS_DEFINE_FINALIZER (gumjs_output_stream_finalize)
+{
+  GOutputStream * stream;
+
+  (void) args;
+
+  if (_gum_duk_is_arg0_equal_to_prototype (ctx, GUM_NATIVE_OUTPUT_STREAM))
+    return 0;
+
+  stream = _gum_duk_steal_data (ctx, 0);
+  if (stream == NULL)
+    return 0;
+
+  g_object_unref (stream);
+
+  return 0;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_output_stream_close)
+{
+  GInputStream * stream;
+  GumDukStream * module;
+  GumDukCore * core;
+  GumDukHeapPtr callback;
+  GumDukCloseOutputOperation * op;
+
+  stream = gumjs_stream_from_args (args);
+  module = gumjs_module_from_args (args);
+  core = module->core;
+
+  _gum_duk_args_parse (args, "F", &callback);
+
+  duk_push_heapptr (ctx, callback);
+
+  op = g_slice_new (GumDukCloseOutputOperation);
+  op->stream = g_object_ref (stream);
+  op->callback = _gum_duk_require_heapptr (ctx, -1);
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_duk_close_output_operation_start, op,
+      (GDestroyNotify) gum_duk_close_output_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static void
+gum_duk_close_output_operation_free (GumDukCloseOutputOperation * op)
+{
+  _gum_duk_release_heapptr (op->module->core->ctx, op->callback);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumDukCloseOutputOperation, op);
+}
+
+static void
+gum_duk_close_output_operation_start (GumDukCloseOutputOperation * self)
+{
+  g_output_stream_close_async (self->stream, G_PRIORITY_DEFAULT,
+      self->module->cancellable,
+      (GAsyncReadyCallback) gum_duk_close_output_operation_finish, self);
+}
+
+static void
+gum_duk_close_output_operation_finish (GOutputStream * stream,
+                                       GAsyncResult * result,
+                                       GumDukCloseOutputOperation * self)
+{
+  GumDukCore * core = self->module->core;
+  duk_context * ctx = core->ctx;
+  GError * error = NULL;
+  gboolean success;
+  GumDukScope scope;
+
+  success = g_output_stream_close_finish (stream, result, &error);
+
+  _gum_duk_scope_enter (&scope, core);
+
+  duk_push_heapptr (ctx, self->callback);
+  if (error == NULL)
+  {
+    duk_push_null (ctx);
+  }
+  else
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s", error->message);
+    g_error_free (error);
+  }
+  duk_push_boolean (ctx, success);
+  _gum_duk_scope_call (&scope, 2);
+  duk_pop (ctx);
+
+  gum_script_job_free (self->job);
+
+  _gum_duk_scope_leave (&scope);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_output_stream_write)
+{
+  return gumjs_output_stream_write_with_strategy (ctx, args,
+      GUM_DUK_WRITE_SOME);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_output_stream_write_all)
+{
+  return gumjs_output_stream_write_with_strategy (ctx, args,
+      GUM_DUK_WRITE_ALL);
+}
+
+static gint
+gumjs_output_stream_write_with_strategy (duk_context * ctx,
+                                         const GumDukArgs * args,
+                                         GumDukWriteStrategy strategy)
+{
+  GInputStream * stream;
+  GumDukStream * module;
+  GumDukCore * core;
+  GBytes * bytes;
+  GumDukHeapPtr callback;
+  GumDukWriteOperation * op;
+
+  stream = gumjs_stream_from_args (args);
+  module = gumjs_module_from_args (args);
+  core = module->core;
+
+  _gum_duk_args_parse (args, "BF", &bytes, &callback);
+
+  duk_push_heapptr (ctx, callback);
+
+  op = g_slice_new (GumDukWriteOperation);
+  op->stream = g_object_ref (stream);
+  op->strategy = strategy;
+  op->bytes = bytes;
+  op->callback = _gum_duk_require_heapptr (ctx, -1);
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_duk_write_operation_start, op,
+      (GDestroyNotify) gum_duk_write_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static void
+gum_duk_write_operation_free (GumDukWriteOperation * op)
+{
+  _gum_duk_release_heapptr (op->module->core->ctx, op->callback);
+  g_bytes_unref (op->bytes);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumDukWriteOperation, op);
+}
+
+static void
+gum_duk_write_operation_start (GumDukWriteOperation * self)
+{
+  if (self->strategy == GUM_DUK_WRITE_SOME)
+  {
+    g_output_stream_write_bytes_async (self->stream, self->bytes,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_duk_write_operation_finish, self);
+  }
+  else
+  {
+    gsize size;
+    gconstpointer data;
+
+    g_assert_cmpuint (self->strategy, ==, GUM_DUK_WRITE_ALL);
+
+    data = g_bytes_get_data (self->bytes, &size);
+
+    g_output_stream_write_all_async (self->stream, data, size,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_duk_write_operation_finish, self);
+  }
+}
+
+static void
+gum_duk_write_operation_finish (GOutputStream * stream,
+                                GAsyncResult * result,
+                                GumDukWriteOperation * self)
+{
+  GumDukCore * core = self->module->core;
+  duk_context * ctx = core->ctx;
+  gsize bytes_written = 0;
+  GError * error = NULL;
+  GumDukScope scope;
+
+  if (self->strategy == GUM_DUK_WRITE_SOME)
+  {
+    gssize n;
+
+    n = g_output_stream_write_bytes_finish (stream, result, &error);
+    if (n > 0)
+      bytes_written = n;
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_DUK_WRITE_ALL);
+
+    g_output_stream_write_all_finish (stream, result, &bytes_written, &error);
+  }
+
+  _gum_duk_scope_enter (&scope, core);
+
+  duk_push_heapptr (ctx, self->callback);
+
+  if (self->strategy == GUM_DUK_WRITE_ALL &&
+      bytes_written != g_bytes_get_size (self->bytes))
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s",
+        (error != NULL) ? error->message : "Short write");
+  }
+  else if (error == NULL)
+  {
+    duk_push_null (ctx);
+  }
+  else
+  {
+    duk_push_error_object (ctx, DUK_ERR_ERROR, "%s", error->message);
+  }
+
+  g_clear_error (&error);
+
+  duk_push_uint (ctx, bytes_written);
+
+  _gum_duk_scope_call (&scope, 2);
+  duk_pop (ctx);
+
+  gum_script_job_free (self->job);
+
+  _gum_duk_scope_leave (&scope);
+}
+
+static void
+gum_duk_stream_constructor_args_parse (const GumDukArgs * args,
+                                       GumStreamHandle * handle,
+                                       gboolean * auto_close)
+{
+  GumDukHeapPtr options = NULL;
+
+#ifdef G_OS_WIN32
+  _gum_duk_args_parse (args, "p|O", handle, &options);
+#else
+  _gum_duk_args_parse (args, "i|O", handle, &options);
+#endif
+
+  *auto_close = FALSE;
+  if (options != NULL)
+  {
+    duk_context * ctx = args->ctx;
+
+    duk_push_heapptr (ctx, options);
+    duk_get_prop_string (ctx, -1, "autoClose");
+    *auto_close = duk_to_boolean (ctx, -1);
+    duk_pop_2 (ctx);
+  }
+}

--- a/bindings/gumjs/gumdukstream.h
+++ b/bindings/gumjs/gumdukstream.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#ifndef __GUM_DUK_STREAM_H__
+#define __GUM_DUK_STREAM_H__
+
+#include "gumdukcore.h"
+
+G_BEGIN_DECLS
+
+typedef struct _GumDukStream GumDukStream;
+
+struct _GumDukStream
+{
+  GumDukCore * core;
+
+  GCancellable * cancellable;
+};
+
+G_GNUC_INTERNAL void _gum_duk_stream_init (GumDukStream * self,
+    GumDukCore * core);
+G_GNUC_INTERNAL void _gum_duk_stream_flush (GumDukStream * self);
+G_GNUC_INTERNAL void _gum_duk_stream_dispose (GumDukStream * self);
+G_GNUC_INTERNAL void _gum_duk_stream_finalize (GumDukStream * self);
+
+G_END_DECLS
+
+#endif

--- a/bindings/gumjs/gumjs-32.vcxproj.filters
+++ b/bindings/gumjs/gumjs-32.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="gumv8socket.cpp">
       <Filter>v8</Filter>
     </ClCompile>
+    <ClCompile Include="gumv8stream.cpp">
+      <Filter>v8</Filter>
+    </ClCompile>
     <ClCompile Include="gumv8stalker.cpp">
       <Filter>v8</Filter>
     </ClCompile>
@@ -104,6 +107,9 @@
       <Filter>duk</Filter>
     </ClCompile>
     <ClCompile Include="gumduksocket.c">
+      <Filter>duk</Filter>
+    </ClCompile>
+    <ClCompile Include="gumdukstream.c">
       <Filter>duk</Filter>
     </ClCompile>
     <ClCompile Include="gumdukstalker.c">
@@ -189,6 +195,9 @@
     <ClInclude Include="gumv8socket.h">
       <Filter>v8</Filter>
     </ClInclude>
+    <ClInclude Include="gumv8stream.h">
+      <Filter>v8</Filter>
+    </ClInclude>
     <ClInclude Include="gumv8stalker.h">
       <Filter>v8</Filter>
     </ClInclude>
@@ -244,6 +253,9 @@
       <Filter>duk</Filter>
     </ClInclude>
     <ClInclude Include="gumduksocket.h">
+      <Filter>duk</Filter>
+    </ClInclude>
+    <ClInclude Include="gumdukstream.h">
       <Filter>duk</Filter>
     </ClInclude>
     <ClInclude Include="gumdukstalker.h">

--- a/bindings/gumjs/gumjs-64.vcxproj.filters
+++ b/bindings/gumjs/gumjs-64.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClCompile Include="gumduksocket.c">
       <Filter>duk</Filter>
     </ClCompile>
+    <ClCompile Include="gumdukstream.c">
+      <Filter>duk</Filter>
+    </ClCompile>
     <ClCompile Include="gumdukstalker.c">
       <Filter>duk</Filter>
     </ClCompile>
@@ -107,6 +110,9 @@
       <Filter>v8</Filter>
     </ClCompile>
     <ClCompile Include="gumv8socket.cpp">
+      <Filter>v8</Filter>
+    </ClCompile>
+    <ClCompile Include="gumv8stream.cpp">
       <Filter>v8</Filter>
     </ClCompile>
     <ClCompile Include="gumv8stalker.cpp">
@@ -186,6 +192,9 @@
     <ClInclude Include="gumduksocket.h">
       <Filter>duk</Filter>
     </ClInclude>
+    <ClInclude Include="gumdukstream.h">
+      <Filter>duk</Filter>
+    </ClInclude>
     <ClInclude Include="gumdukstalker.h">
       <Filter>duk</Filter>
     </ClInclude>
@@ -247,6 +256,9 @@
       <Filter>v8</Filter>
     </ClInclude>
     <ClInclude Include="gumv8socket.h">
+      <Filter>v8</Filter>
+    </ClInclude>
+    <ClInclude Include="gumv8stream.h">
       <Filter>v8</Filter>
     </ClInclude>
     <ClInclude Include="gumv8stalker.h">

--- a/bindings/gumjs/gumjs-common.props
+++ b/bindings/gumjs/gumjs-common.props
@@ -38,6 +38,7 @@
     <ClInclude Include="gumv8module.h" />
     <ClInclude Include="gumv8file.h" />
     <ClInclude Include="gumv8socket.h" />
+    <ClInclude Include="gumv8stream.h" />
     <ClInclude Include="gumv8interceptor.h" />
     <ClInclude Include="gumv8stalker.h" />
     <ClInclude Include="gumv8eventsink.h" />
@@ -59,6 +60,7 @@
     <ClCompile Include="gumv8module.cpp" />
     <ClCompile Include="gumv8file.cpp" />
     <ClCompile Include="gumv8socket.cpp" />
+    <ClCompile Include="gumv8stream.cpp" />
     <ClCompile Include="gumv8interceptor.cpp" />
     <ClCompile Include="gumv8stalker.cpp" />
     <ClCompile Include="gumv8eventsink.cpp" />
@@ -82,6 +84,7 @@
     <ClInclude Include="gumdukmodule.h" />
     <ClInclude Include="gumdukfile.h" />
     <ClInclude Include="gumduksocket.h" />
+    <ClInclude Include="gumdukstream.h" />
     <ClInclude Include="gumdukinterceptor.h" />
     <ClInclude Include="gumdukstalker.h" />
     <ClInclude Include="gumdukapiresolver.h" />
@@ -102,6 +105,7 @@
     <ClCompile Include="gumdukmodule.c" />
     <ClCompile Include="gumdukfile.c" />
     <ClCompile Include="gumduksocket.c" />
+    <ClCompile Include="gumdukstream.c" />
     <ClCompile Include="gumdukinterceptor.c" />
     <ClCompile Include="gumdukstalker.c" />
     <ClCompile Include="gumdukapiresolver.c" />

--- a/bindings/gumjs/gumjs-core.js
+++ b/bindings/gumjs/gumjs-core.js
@@ -657,6 +657,91 @@
         }
     });
 
+    const InputStream = engine.UnixInputStream || engine.Win32InputStream;
+    const OutputStream = engine.UnixOutputStream || engine.Win32OutputStream;
+
+    const _closeInput = InputStream.prototype._close;
+    InputStream.prototype.close = function () {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _closeInput.call(stream, function (error, success) {
+                if (error === null)
+                    resolve(success);
+                else
+                    reject(error);
+            });
+        });
+    };
+
+    const _read = InputStream.prototype._read;
+    InputStream.prototype.read = function (size) {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _read.call(stream, size, function (error, data) {
+                if (error === null)
+                    resolve(data);
+                else
+                    reject(error);
+            });
+        });
+    };
+
+    const _readAll = InputStream.prototype._readAll;
+    InputStream.prototype.readAll = function (size) {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _readAll.call(stream, size, function (error, data) {
+                if (error === null) {
+                    resolve(data);
+                } else {
+                    error.partialData = data;
+                    reject(error);
+                }
+            });
+        });
+    };
+
+    const _closeOutput = OutputStream.prototype._close;
+    OutputStream.prototype.close = function () {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _closeOutput.call(stream, function (error, success) {
+                if (error === null)
+                    resolve(success);
+                else
+                    reject(error);
+            });
+        });
+    };
+
+    const _write = OutputStream.prototype._write;
+    OutputStream.prototype.write = function (data) {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _write.call(stream, data, function (error, size) {
+                if (error === null)
+                    resolve(size);
+                else
+                    reject(error);
+            });
+        });
+    };
+
+    const _writeAll = OutputStream.prototype._writeAll;
+    OutputStream.prototype.writeAll = function (data) {
+        const stream = this;
+        return new Promise(function (resolve, reject) {
+            _writeAll.call(stream, data, function (error, size) {
+                if (error === null) {
+                    resolve(size);
+                } else {
+                    error.partialSize = size;
+                    reject(error);
+                }
+            });
+        });
+    };
+
     Object.defineProperty(engine, 'rpc', {
         enumerable: true,
         value: {

--- a/bindings/gumjs/gumv8script-priv.h
+++ b/bindings/gumjs/gumv8script-priv.h
@@ -22,6 +22,7 @@
 #include "gumv8scriptbackend.h"
 #include "gumv8socket.h"
 #include "gumv8stalker.h"
+#include "gumv8stream.h"
 #include "gumv8symbol.h"
 #include "gumv8thread.h"
 
@@ -43,6 +44,7 @@ struct _GumV8ScriptPrivate
   GumV8Module module;
   GumV8File file;
   GumV8Socket socket;
+  GumV8Stream stream;
   GumV8Interceptor interceptor;
   GumV8Stalker stalker;
   GumV8ApiResolver api_resolver;

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -284,6 +284,7 @@ gum_v8_script_create_context (GumV8Script * self,
     _gum_v8_module_init (&priv->module, &priv->core, global_templ);
     _gum_v8_file_init (&priv->file, &priv->core, global_templ);
     _gum_v8_socket_init (&priv->socket, &priv->core, global_templ);
+    _gum_v8_stream_init (&priv->stream, &priv->core, global_templ);
     _gum_v8_interceptor_init (&priv->interceptor, &priv->core,
         global_templ);
     _gum_v8_stalker_init (&priv->stalker, &priv->core, global_templ);
@@ -303,6 +304,7 @@ gum_v8_script_create_context (GumV8Script * self,
     _gum_v8_module_realize (&priv->module);
     _gum_v8_file_realize (&priv->file);
     _gum_v8_socket_realize (&priv->socket);
+    _gum_v8_stream_realize (&priv->stream);
     _gum_v8_interceptor_realize (&priv->interceptor);
     _gum_v8_stalker_realize (&priv->stalker);
     _gum_v8_api_resolver_realize (&priv->api_resolver);
@@ -361,6 +363,7 @@ gum_v8_script_destroy_context (GumV8Script * self)
 
     _gum_v8_stalker_flush (&priv->stalker);
     _gum_v8_interceptor_flush (&priv->interceptor);
+    _gum_v8_stream_flush (&priv->stream);
     _gum_v8_core_flush (&priv->core);
 
     _gum_v8_instruction_dispose (&priv->instruction);
@@ -368,6 +371,7 @@ gum_v8_script_destroy_context (GumV8Script * self)
     _gum_v8_api_resolver_dispose (&priv->api_resolver);
     _gum_v8_stalker_dispose (&priv->stalker);
     _gum_v8_interceptor_dispose (&priv->interceptor);
+    _gum_v8_stream_dispose (&priv->stream);
     _gum_v8_socket_dispose (&priv->socket);
     _gum_v8_file_dispose (&priv->file);
     _gum_v8_module_dispose (&priv->module);
@@ -388,6 +392,7 @@ gum_v8_script_destroy_context (GumV8Script * self)
   _gum_v8_api_resolver_finalize (&priv->api_resolver);
   _gum_v8_stalker_finalize (&priv->stalker);
   _gum_v8_interceptor_finalize (&priv->interceptor);
+  _gum_v8_stream_finalize (&priv->stream);
   _gum_v8_socket_finalize (&priv->socket);
   _gum_v8_file_finalize (&priv->file);
   _gum_v8_module_finalize (&priv->module);

--- a/bindings/gumjs/gumv8stream.cpp
+++ b/bindings/gumjs/gumv8stream.cpp
@@ -1,0 +1,863 @@
+/*
+ * Copyright (C) 2016 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gumv8stream.h"
+
+#include "gumv8scope.h"
+
+using namespace v8;
+
+#ifdef G_OS_WIN32
+# include <gio/gwin32inputstream.h>
+# include <gio/gwin32outputstream.h>
+
+# define GUM_NATIVE_INPUT_STREAM "Win32InputStream"
+# define GUM_NATIVE_OUTPUT_STREAM "Win32OutputStream"
+# define GUM_NATIVE_KIND "Windows file handle"
+typedef gpointer GumStreamHandle;
+#else
+# include <gio/gunixinputstream.h>
+# include <gio/gunixoutputstream.h>
+
+# define GUM_NATIVE_INPUT_STREAM "UnixInputStream"
+# define GUM_NATIVE_OUTPUT_STREAM "UnixOutputStream"
+# define GUM_NATIVE_KIND "file descriptor"
+typedef gint GumStreamHandle;
+#endif
+
+typedef struct _GumV8CloseInputOperation GumV8CloseInputOperation;
+typedef struct _GumV8ReadOperation GumV8ReadOperation;
+typedef guint GumV8ReadStrategy;
+
+typedef struct _GumV8CloseOutputOperation GumV8CloseOutputOperation;
+typedef struct _GumV8WriteOperation GumV8WriteOperation;
+typedef guint GumV8WriteStrategy;
+
+struct _GumV8CloseInputOperation
+{
+  GInputStream * stream;
+  GumPersistent<Function>::type * callback;
+  GumScriptJob * job;
+
+  GumV8Stream * module;
+};
+
+struct _GumV8ReadOperation
+{
+  GInputStream * stream;
+  GumV8ReadStrategy strategy;
+  gpointer buffer;
+  gsize buffer_size;
+  GumPersistent<Function>::type * callback;
+  GumScriptJob * job;
+
+  GumV8Stream * module;
+};
+
+enum _GumV8ReadStrategy
+{
+  GUM_V8_READ_SOME,
+  GUM_V8_READ_ALL
+};
+
+struct _GumV8CloseOutputOperation
+{
+  GOutputStream * stream;
+  GumPersistent<Function>::type * callback;
+  GumScriptJob * job;
+
+  GumV8Stream * module;
+};
+
+struct _GumV8WriteOperation
+{
+  GOutputStream * stream;
+  GumV8WriteStrategy strategy;
+  GBytes * bytes;
+  GumPersistent<Function>::type * callback;
+  GumScriptJob * job;
+
+  GumV8Stream * module;
+};
+
+enum _GumV8WriteStrategy
+{
+  GUM_V8_WRITE_SOME,
+  GUM_V8_WRITE_ALL
+};
+
+static void gum_v8_input_stream_on_new (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_input_stream_on_close (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_close_input_operation_free (GumV8CloseInputOperation * op);
+static void gum_v8_close_input_operation_start (GumV8CloseInputOperation * self);
+static void gum_v8_close_input_operation_finish (GInputStream * stream,
+    GAsyncResult * result, GumV8CloseInputOperation * self);
+static void gum_v8_input_stream_on_read (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_input_stream_on_read_all (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_input_stream_on_read_with_strategy (
+    const FunctionCallbackInfo<Value> & info, GumV8ReadStrategy strategy);
+static void gum_v8_read_operation_free (GumV8ReadOperation * op);
+static void gum_v8_read_operation_start (GumV8ReadOperation * self);
+static void gum_v8_read_operation_finish (GInputStream * stream,
+    GAsyncResult * result, GumV8ReadOperation * self);
+
+static void gum_v8_output_stream_on_new (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_output_stream_on_close (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_close_output_operation_free (GumV8CloseOutputOperation * op);
+static void gum_v8_close_output_operation_start (
+    GumV8CloseOutputOperation * self);
+static void gum_v8_close_output_operation_finish (GOutputStream * stream,
+    GAsyncResult * result, GumV8CloseOutputOperation * self);
+static void gum_v8_output_stream_on_write (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_output_stream_on_write_all (
+    const FunctionCallbackInfo<Value> & info);
+static void gum_v8_output_stream_on_write_with_strategy (
+    const FunctionCallbackInfo<Value> & info, GumV8WriteStrategy strategy);
+static void gum_v8_write_operation_free (GumV8WriteOperation * op);
+static void gum_v8_write_operation_start (GumV8WriteOperation * self);
+static void gum_v8_write_operation_finish (GOutputStream * stream,
+    GAsyncResult * result, GumV8WriteOperation * self);
+
+static gboolean gum_v8_stream_constructor_args_parse (
+    const FunctionCallbackInfo<Value> & info, GumStreamHandle * handle,
+    gboolean * auto_close);
+
+static void gum_v8_stream_on_weak_notify (
+    const WeakCallbackData<Object, GumV8Stream> & data);
+static void gum_v8_stream_handle_free (gpointer data);
+
+void
+_gum_v8_stream_init (GumV8Stream * self,
+                     GumV8Core * core,
+                     Handle<ObjectTemplate> scope)
+{
+  Isolate * isolate = core->isolate;
+
+  self->core = core;
+
+  Local<External> data (External::New (isolate, self));
+
+  Local<FunctionTemplate> input_stream = FunctionTemplate::New (isolate,
+      gum_v8_input_stream_on_new, data);
+  input_stream->SetClassName (String::NewFromUtf8 (isolate,
+      GUM_NATIVE_INPUT_STREAM));
+  Local<ObjectTemplate> input_stream_proto = input_stream->PrototypeTemplate ();
+  input_stream_proto->Set (String::NewFromUtf8 (isolate, "_close"),
+      FunctionTemplate::New (isolate, gum_v8_input_stream_on_close, data));
+  input_stream_proto->Set (String::NewFromUtf8 (isolate, "_read"),
+      FunctionTemplate::New (isolate, gum_v8_input_stream_on_read, data));
+  input_stream_proto->Set (String::NewFromUtf8 (isolate, "_readAll"),
+      FunctionTemplate::New (isolate, gum_v8_input_stream_on_read_all, data));
+  input_stream->InstanceTemplate ()->SetInternalFieldCount (1);
+  scope->Set (String::NewFromUtf8 (isolate, GUM_NATIVE_INPUT_STREAM),
+      input_stream);
+
+  Local<FunctionTemplate> output_stream = FunctionTemplate::New (isolate,
+      gum_v8_output_stream_on_new, data);
+  output_stream->SetClassName (String::NewFromUtf8 (isolate,
+      GUM_NATIVE_OUTPUT_STREAM));
+  Local<ObjectTemplate> output_stream_proto =
+      output_stream->PrototypeTemplate ();
+  output_stream_proto->Set (String::NewFromUtf8 (isolate, "_close"),
+      FunctionTemplate::New (isolate, gum_v8_output_stream_on_close, data));
+  output_stream_proto->Set (String::NewFromUtf8 (isolate, "_write"),
+      FunctionTemplate::New (isolate, gum_v8_output_stream_on_write, data));
+  output_stream_proto->Set (String::NewFromUtf8 (isolate, "_writeAll"),
+      FunctionTemplate::New (isolate, gum_v8_output_stream_on_write_all, data));
+  output_stream->InstanceTemplate ()->SetInternalFieldCount (1);
+  scope->Set (String::NewFromUtf8 (isolate, GUM_NATIVE_OUTPUT_STREAM),
+      output_stream);
+
+  self->streams = g_hash_table_new_full (NULL, NULL, g_object_unref,
+      gum_v8_stream_handle_free);
+  self->cancellable = g_cancellable_new ();
+}
+
+void
+_gum_v8_stream_realize (GumV8Stream * self)
+{
+  (void) self;
+}
+
+void
+_gum_v8_stream_flush (GumV8Stream * self)
+{
+  g_cancellable_cancel (self->cancellable);
+}
+
+void
+_gum_v8_stream_dispose (GumV8Stream * self)
+{
+  g_hash_table_remove_all (self->streams);
+}
+
+void
+_gum_v8_stream_finalize (GumV8Stream * self)
+{
+  g_clear_object (&self->cancellable);
+  g_clear_pointer (&self->streams, g_hash_table_unref);
+}
+
+static void
+gum_v8_input_stream_on_new (const FunctionCallbackInfo<Value> & info)
+{
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  Isolate * isolate = info.GetIsolate ();
+
+  if (!info.IsConstructCall ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "Use `new " GUM_NATIVE_INPUT_STREAM "()` to create a new "
+        "instance")));
+    return;
+  }
+
+  GumStreamHandle handle;
+  gboolean auto_close;
+  if (!gum_v8_stream_constructor_args_parse (info, &handle, &auto_close))
+    return;
+
+  GInputStream * stream;
+#ifdef G_OS_WIN32
+  stream = g_win32_input_stream_new (handle, auto_close);
+#else
+  stream = g_unix_input_stream_new (handle, auto_close);
+#endif
+
+  Local<Object> instance (info.Holder ());
+  instance->SetAlignedPointerInInternalField (0, stream);
+
+  GumPersistent<Object>::type * instance_handle =
+      new GumPersistent<Object>::type (module->core->isolate, instance);
+  instance_handle->MarkIndependent ();
+  instance_handle->SetWeak (module, gum_v8_stream_on_weak_notify);
+
+  g_hash_table_insert (module->streams, stream, instance_handle);
+}
+
+static void
+gum_v8_input_stream_on_close (
+    const FunctionCallbackInfo<Value> & info)
+{
+  GInputStream * stream = static_cast<GInputStream *> (
+      info.Holder ()->GetAlignedPointerFromInternalField (0));
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  GumV8Core * core = module->core;
+  Isolate * isolate = info.GetIsolate ();
+  GumV8CloseInputOperation * op;
+
+  if (info.Length () < 1)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "expected callback")));
+    return;
+  }
+
+  Local<Value> callback_value = info[0];
+  if (!callback_value->IsFunction ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "invalid callback")));
+    return;
+  }
+
+  op = g_slice_new (GumV8CloseInputOperation);
+  op->stream = stream;
+  g_object_ref (stream);
+  op->callback = new GumPersistent<Function>::type (isolate,
+      callback_value.As<Function> ());
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_v8_close_input_operation_start, op,
+      (GDestroyNotify) gum_v8_close_input_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+}
+
+static void
+gum_v8_close_input_operation_free (GumV8CloseInputOperation * op)
+{
+  delete op->callback;
+  g_object_unref (op->stream);
+
+  g_slice_free (GumV8CloseInputOperation, op);
+}
+
+static void
+gum_v8_close_input_operation_start (GumV8CloseInputOperation * self)
+{
+  g_input_stream_close_async (self->stream, G_PRIORITY_DEFAULT,
+      self->module->cancellable,
+      (GAsyncReadyCallback) gum_v8_close_input_operation_finish, self);
+}
+
+static void
+gum_v8_close_input_operation_finish (GInputStream * stream,
+                                     GAsyncResult * result,
+                                     GumV8CloseInputOperation * self)
+{
+  GError * error = NULL;
+  gboolean success;
+
+  success = g_input_stream_close_finish (stream, result, &error);
+
+  {
+    GumV8Core * core = self->module->core;
+    ScriptScope scope (core->script);
+    Isolate * isolate = core->isolate;
+
+    Local<Value> error_value;
+    Local<Value> success_value = success ? True (isolate) : False (isolate);
+    Local<Value> null_value = Null (isolate);
+    if (error == NULL)
+    {
+      error_value = null_value;
+    }
+    else
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate, error->message));
+      g_error_free (error);
+    }
+
+    Handle<Value> argv[] = { error_value, success_value };
+    Local<Function> callback (Local<Function>::New (isolate, *self->callback));
+    callback->Call (null_value, G_N_ELEMENTS (argv), argv);
+
+    gum_script_job_free (self->job);
+  }
+}
+
+static void
+gum_v8_input_stream_on_read (
+    const FunctionCallbackInfo<Value> & info)
+{
+  gum_v8_input_stream_on_read_with_strategy (info, GUM_V8_READ_SOME);
+}
+
+static void
+gum_v8_input_stream_on_read_all (
+    const FunctionCallbackInfo<Value> & info)
+{
+  gum_v8_input_stream_on_read_with_strategy (info, GUM_V8_READ_ALL);
+}
+
+static void
+gum_v8_input_stream_on_read_with_strategy (
+    const FunctionCallbackInfo<Value> & info,
+    GumV8ReadStrategy strategy)
+{
+  GInputStream * stream = static_cast<GInputStream *> (
+      info.Holder ()->GetAlignedPointerFromInternalField (0));
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  GumV8Core * core = module->core;
+  Isolate * isolate = info.GetIsolate ();
+  GumV8ReadOperation * op;
+
+  if (info.Length () < 2)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "expected size and callback")));
+    return;
+  }
+
+  guint64 size;
+  if (!_gum_v8_uint64_get (info[0], &size, core))
+    return;
+  if (size == 0)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "invalid size")));
+    return;
+  }
+
+  Local<Value> callback_value = info[1];
+  if (!callback_value->IsFunction ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "invalid callback")));
+    return;
+  }
+
+  op = g_slice_new (GumV8ReadOperation);
+  op->stream = stream;
+  g_object_ref (stream);
+  op->strategy = strategy;
+  op->buffer = g_malloc (size);
+  op->buffer_size = size;
+  op->callback = new GumPersistent<Function>::type (isolate,
+      callback_value.As<Function> ());
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_v8_read_operation_start, op,
+      (GDestroyNotify) gum_v8_read_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+}
+
+static void
+gum_v8_read_operation_free (GumV8ReadOperation * op)
+{
+  delete op->callback;
+  g_free (op->buffer);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumV8ReadOperation, op);
+}
+
+static void
+gum_v8_read_operation_start (GumV8ReadOperation * self)
+{
+  if (self->strategy == GUM_V8_READ_SOME)
+  {
+    g_input_stream_read_async (self->stream, self->buffer, self->buffer_size,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_v8_read_operation_finish, self);
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_V8_READ_ALL);
+
+    g_input_stream_read_all_async (self->stream, self->buffer,
+        self->buffer_size, G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_v8_read_operation_finish, self);
+  }
+}
+
+static void
+gum_v8_read_operation_finish (GInputStream * stream,
+                              GAsyncResult * result,
+                              GumV8ReadOperation * self)
+{
+  gsize bytes_read = 0;
+  GError * error = NULL;
+
+  if (self->strategy == GUM_V8_READ_SOME)
+  {
+    gsize n;
+
+    n = g_input_stream_read_finish (stream, result, &error);
+    if (n > 0)
+      bytes_read = n;
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_V8_READ_ALL);
+
+    g_input_stream_read_all_finish (stream, result, &bytes_read, &error);
+  }
+
+  {
+    GumV8Core * core = self->module->core;
+    ScriptScope scope (core->script);
+    Isolate * isolate = core->isolate;
+
+    Local<Value> error_value, data_value, null_value;
+    null_value = Null (isolate);
+    if (self->strategy == GUM_V8_READ_ALL && bytes_read != self->buffer_size)
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate,
+              (error != NULL) ? error->message : "Short read"));
+      data_value = ArrayBuffer::New (isolate, self->buffer, bytes_read,
+          ArrayBufferCreationMode::kInternalized);
+      self->buffer = NULL; /* steal it */
+    }
+    else if (error == NULL)
+    {
+      error_value = null_value;
+      data_value = ArrayBuffer::New (isolate, self->buffer, bytes_read,
+          ArrayBufferCreationMode::kInternalized);
+      self->buffer = NULL; /* steal it */
+    }
+    else
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate, error->message));
+      data_value = null_value;
+    }
+
+    g_clear_error (&error);
+
+    Handle<Value> argv[] = { error_value, data_value };
+    Local<Function> callback (Local<Function>::New (isolate, *self->callback));
+    callback->Call (null_value, G_N_ELEMENTS (argv), argv);
+
+    gum_script_job_free (self->job);
+  }
+}
+
+static void
+gum_v8_output_stream_on_new (const FunctionCallbackInfo<Value> & info)
+{
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  Isolate * isolate = info.GetIsolate ();
+
+  if (!info.IsConstructCall ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "Use `new " GUM_NATIVE_OUTPUT_STREAM "()` to create a new "
+        "instance")));
+    return;
+  }
+
+  GumStreamHandle handle;
+  gboolean auto_close;
+  if (!gum_v8_stream_constructor_args_parse (info, &handle, &auto_close))
+    return;
+
+  GOutputStream * stream;
+#ifdef G_OS_WIN32
+  stream = g_win32_output_stream_new (handle, auto_close);
+#else
+  stream = g_unix_output_stream_new (handle, auto_close);
+#endif
+
+  Local<Object> instance (info.Holder ());
+  instance->SetAlignedPointerInInternalField (0, stream);
+
+  GumPersistent<Object>::type * instance_handle =
+      new GumPersistent<Object>::type (module->core->isolate, instance);
+  instance_handle->MarkIndependent ();
+  instance_handle->SetWeak (module, gum_v8_stream_on_weak_notify);
+
+  g_hash_table_insert (module->streams, stream, instance_handle);
+}
+
+static void
+gum_v8_output_stream_on_close (
+    const FunctionCallbackInfo<Value> & info)
+{
+  GOutputStream * stream = static_cast<GOutputStream *> (
+      info.Holder ()->GetAlignedPointerFromInternalField (0));
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  GumV8Core * core = module->core;
+  Isolate * isolate = info.GetIsolate ();
+  GumV8CloseOutputOperation * op;
+
+  if (info.Length () < 1)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "expected callback")));
+    return;
+  }
+
+  Local<Value> callback_value = info[0];
+  if (!callback_value->IsFunction ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "invalid callback")));
+    return;
+  }
+
+  op = g_slice_new (GumV8CloseOutputOperation);
+  op->stream = stream;
+  g_object_ref (stream);
+  op->callback = new GumPersistent<Function>::type (isolate,
+      callback_value.As<Function> ());
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_v8_close_output_operation_start, op,
+      (GDestroyNotify) gum_v8_close_output_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+}
+
+static void
+gum_v8_close_output_operation_free (GumV8CloseOutputOperation * op)
+{
+  delete op->callback;
+  g_object_unref (op->stream);
+
+  g_slice_free (GumV8CloseOutputOperation, op);
+}
+
+static void
+gum_v8_close_output_operation_start (GumV8CloseOutputOperation * self)
+{
+  g_output_stream_close_async (self->stream, G_PRIORITY_DEFAULT,
+      self->module->cancellable,
+      (GAsyncReadyCallback) gum_v8_close_output_operation_finish, self);
+}
+
+static void
+gum_v8_close_output_operation_finish (GOutputStream * stream,
+                                      GAsyncResult * result,
+                                      GumV8CloseOutputOperation * self)
+{
+  GError * error = NULL;
+  gboolean success;
+
+  success = g_output_stream_close_finish (stream, result, &error);
+
+  {
+    GumV8Core * core = self->module->core;
+    ScriptScope scope (core->script);
+    Isolate * isolate = core->isolate;
+
+    Local<Value> error_value;
+    Local<Value> success_value = success ? True (isolate) : False (isolate);
+    Local<Value> null_value = Null (isolate);
+    if (error == NULL)
+    {
+      error_value = null_value;
+    }
+    else
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate, error->message));
+      g_error_free (error);
+    }
+
+    Handle<Value> argv[] = { error_value, success_value };
+    Local<Function> callback (Local<Function>::New (isolate, *self->callback));
+    callback->Call (null_value, G_N_ELEMENTS (argv), argv);
+
+    gum_script_job_free (self->job);
+  }
+}
+
+static void
+gum_v8_output_stream_on_write (
+    const FunctionCallbackInfo<Value> & info)
+{
+  gum_v8_output_stream_on_write_with_strategy (info, GUM_V8_WRITE_SOME);
+}
+
+static void
+gum_v8_output_stream_on_write_all (
+    const FunctionCallbackInfo<Value> & info)
+{
+  gum_v8_output_stream_on_write_with_strategy (info, GUM_V8_WRITE_ALL);
+}
+
+static void
+gum_v8_output_stream_on_write_with_strategy (
+    const FunctionCallbackInfo<Value> & info,
+    GumV8WriteStrategy strategy)
+{
+  GOutputStream * stream = static_cast<GOutputStream *> (
+      info.Holder ()->GetAlignedPointerFromInternalField (0));
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      info.Data ().As<External> ()->Value ());
+  GumV8Core * core = module->core;
+  Isolate * isolate = info.GetIsolate ();
+  GumV8WriteOperation * op;
+
+  if (info.Length () < 2)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "expected data and callback")));
+    return;
+  }
+
+  GBytes * bytes = _gum_v8_byte_array_get (info[0], core);
+  if (bytes == NULL)
+    return;
+
+  Local<Value> callback_value = info[1];
+  if (!callback_value->IsFunction ())
+  {
+    g_bytes_unref (bytes);
+
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+        isolate, "invalid callback")));
+    return;
+  }
+
+  op = g_slice_new (GumV8WriteOperation);
+  op->stream = stream;
+  g_object_ref (stream);
+  op->strategy = strategy;
+  op->bytes = bytes;
+  op->callback = new GumPersistent<Function>::type (isolate,
+      callback_value.As<Function> ());
+  op->job = gum_script_job_new (core->scheduler,
+      (GumScriptJobFunc) gum_v8_write_operation_start, op,
+      (GDestroyNotify) gum_v8_write_operation_free, core);
+
+  op->module = module;
+
+  gum_script_job_start_on_js_thread (op->job);
+}
+
+static void
+gum_v8_write_operation_free (GumV8WriteOperation * op)
+{
+  delete op->callback;
+  g_bytes_unref (op->bytes);
+  g_object_unref (op->stream);
+
+  g_slice_free (GumV8WriteOperation, op);
+}
+
+static void
+gum_v8_write_operation_start (GumV8WriteOperation * self)
+{
+  if (self->strategy == GUM_V8_WRITE_SOME)
+  {
+    g_output_stream_write_bytes_async (self->stream, self->bytes,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_v8_write_operation_finish, self);
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_V8_WRITE_ALL);
+
+    gsize size;
+    gconstpointer data = g_bytes_get_data (self->bytes, &size);
+
+    g_output_stream_write_all_async (self->stream, data, size,
+        G_PRIORITY_DEFAULT, self->module->cancellable,
+        (GAsyncReadyCallback) gum_v8_write_operation_finish, self);
+  }
+}
+
+static void
+gum_v8_write_operation_finish (GOutputStream * stream,
+                               GAsyncResult * result,
+                               GumV8WriteOperation * self)
+{
+  gsize bytes_written = 0;
+  GError * error = NULL;
+
+  if (self->strategy == GUM_V8_WRITE_SOME)
+  {
+    gssize n;
+
+    n = g_output_stream_write_bytes_finish (stream, result, &error);
+    if (n > 0)
+      bytes_written = n;
+  }
+  else
+  {
+    g_assert_cmpuint (self->strategy, ==, GUM_V8_WRITE_ALL);
+
+    g_output_stream_write_all_finish (stream, result, &bytes_written, &error);
+  }
+
+  {
+    GumV8Core * core = self->module->core;
+    ScriptScope scope (core->script);
+    Isolate * isolate = core->isolate;
+
+    Local<Value> error_value;
+    Local<Value> size_value = Integer::NewFromUnsigned (isolate, bytes_written);
+    Local<Value> null_value = Null (isolate);
+    if (self->strategy == GUM_V8_WRITE_ALL &&
+        bytes_written != g_bytes_get_size (self->bytes))
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate,
+              (error != NULL) ? error->message : "Short write"));
+    }
+    else if (error == NULL)
+    {
+      error_value = null_value;
+    }
+    else
+    {
+      error_value = Exception::Error (
+          String::NewFromUtf8 (isolate, error->message));
+    }
+
+    g_clear_error (&error);
+
+    Handle<Value> argv[] = { error_value, size_value };
+    Local<Function> callback (Local<Function>::New (isolate, *self->callback));
+    callback->Call (null_value, G_N_ELEMENTS (argv), argv);
+
+    gum_script_job_free (self->job);
+  }
+}
+
+static gboolean
+gum_v8_stream_constructor_args_parse (const FunctionCallbackInfo<Value> & info,
+                                      GumStreamHandle * handle,
+                                      gboolean * auto_close)
+{
+  Isolate * isolate = info.GetIsolate ();
+
+  gint num_args = info.Length ();
+  if (num_args < 1)
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (isolate,
+        "expected a " GUM_NATIVE_KIND)));
+    return FALSE;
+  }
+
+  Local<Value> handle_value = info[0];
+#ifdef G_OS_WIN32
+  if (!_gum_v8_native_pointer_get (handle_value, handle, self->core))
+    return FALSE;
+#else
+  if (!handle_value->IsNumber ())
+  {
+    isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (isolate,
+        "expected a " GUM_NATIVE_KIND)));
+    return FALSE;
+  }
+  *handle = static_cast<gint> (handle_value.As<Number> ()->Value ());
+#endif
+
+  *auto_close = FALSE;
+  if (num_args >= 2)
+  {
+    Local<Value> options_value = info[1];
+    if (!options_value->IsObject ())
+    {
+      isolate->ThrowException (Exception::TypeError (String::NewFromUtf8 (
+          isolate, "options argument must be an object")));
+      return FALSE;
+    }
+
+    Local<Object> options = options_value.As<Object> ();
+
+    Local<String> auto_close_key (String::NewFromOneByte (isolate,
+        reinterpret_cast<const uint8_t *> ("autoClose")));
+    if (options->Has (auto_close_key))
+    {
+      *auto_close =
+          options->Get (auto_close_key)->ToBoolean ()->BooleanValue ();
+    }
+  }
+
+  return TRUE;
+}
+
+static void
+gum_v8_stream_on_weak_notify (
+    const WeakCallbackData<Object, GumV8Stream> & data)
+{
+  HandleScope handle_scope (data.GetIsolate ());
+  GumV8Stream * module = static_cast<GumV8Stream *> (
+      data.GetParameter ());
+  gpointer stream = data.GetValue ()->GetAlignedPointerFromInternalField (0);
+  g_hash_table_remove (module->streams, stream);
+}
+
+static void
+gum_v8_stream_handle_free (gpointer data)
+{
+  GumPersistent<Object>::type * instance_handle =
+      static_cast<GumPersistent<Object>::type *> (data);
+  delete instance_handle;
+}

--- a/bindings/gumjs/gumv8stream.h
+++ b/bindings/gumjs/gumv8stream.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#ifndef __GUM_V8_STREAM_H__
+#define __GUM_V8_STREAM_H__
+
+#include "gumv8core.h"
+
+#include <v8.h>
+
+typedef struct _GumV8Stream GumV8Stream;
+
+struct _GumV8Stream
+{
+  GumV8Core * core;
+
+  GHashTable * streams;
+  GCancellable * cancellable;
+};
+
+G_GNUC_INTERNAL void _gum_v8_stream_init (GumV8Stream * self, GumV8Core * core,
+    v8::Handle<v8::ObjectTemplate> scope);
+G_GNUC_INTERNAL void _gum_v8_stream_realize (GumV8Stream * self);
+G_GNUC_INTERNAL void _gum_v8_stream_flush (GumV8Stream * self);
+G_GNUC_INTERNAL void _gum_v8_stream_dispose (GumV8Stream * self);
+G_GNUC_INTERNAL void _gum_v8_stream_finalize (GumV8Stream * self);
+
+#endif

--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,8 @@ AC_CHECK_MEMBER([struct mallinfo.arena],
 GLIB_VERSION=2.46.0
 CAPSTONE_VERSION=4.0
 pkg_modules="glib-2.0 >= $GLIB_VERSION, gobject-2.0 >= $GLIB_VERSION,
-    gio-2.0 >= $GLIB_VERSION, capstone >= $CAPSTONE_VERSION"
+    gio-2.0 >= $GLIB_VERSION, gio-unix-2.0 >= $GLIB_VERSION,
+    capstone >= $CAPSTONE_VERSION"
 PKG_CHECK_MODULES(GUM, [$pkg_modules])
 
 PKG_CHECK_MODULES(LIBUNWIND, [libunwind], [HAVE_LIBUNWIND=yes], [HAVE_LIBUNWIND=no])


### PR DESCRIPTION
For now we only expose constructors for the lowest level streams that
allow working with file-descriptors (UNIX) and HANDLEs (Windows), but
the JavaScript wrappers can obviously be used with any GInputStream and
GOutputStream implementation.