### PR TITLE
Check method type just for the invoked method, instead of method[0]

### DIFF
--- a/bindings/gumjs/gumjs-java.js
+++ b/bindings/gumjs/gumjs-java.js
@@ -1041,12 +1041,6 @@
                 function f() {
                     /* jshint validthis: true */
                     const isInstance = this.$handle !== null;
-                    if (methods[0].type === INSTANCE_METHOD && !isInstance) {
-                        if (name === 'toString') {
-                            return "<" + this.$classWrapper.__name__ + ">";
-                        }
-                        throw new Error(name + ": cannot call instance method without an instance");
-                    }
                     const group = candidates[arguments.length];
                     if (!group) {
                         throw new Error(name + ": argument count does not match any overload");
@@ -1054,6 +1048,12 @@
                     for (let i = 0; i !== group.length; i++) {
                         const method = group[i];
                         if (method.canInvokeWith(arguments)) {
+                            if (method.type === INSTANCE_METHOD && !isInstance) {
+                                if (name === 'toString') {
+                                    return "<" + this.$classWrapper.__name__ + ">";
+                                }
+                                throw new Error(name + ": cannot call instance method without an instance");
+                            }
                             return method.apply(this, arguments);
                         }
                     }


### PR DESCRIPTION
tech/yusi/fridademo/Jingdong.java
`public class Jingdong {
        public static String a(String arg0, String arg1)   { return arg0 + arg1;  }
        public static int a(int arg0, int arg1)  {   return arg0 + arg1;   }
}`

frida js
`Java.perform(function () {
    var Jingdong = Java.use("tech.yusi.fridademo.Jingdong");
    var ret = Jingdong.a(1, 2);
    send(ret);
}
`
It works well

if change Jingdong.java, remove one static 
`public class Jingdong {
        public String a(String arg0, String arg1)   { return arg0 + arg1;  }
        public static int a(int arg0, int arg1)  {   return arg0 + arg1;   }
}`

It  complains:
        Error: a: cannot call instance method without an instance

In fact, 
      Jingdong.a.overload('int', 'int').type is staic
      Jingdong.a.overload("java.lang.String", "java.lang.String").type is instaic, 
     methods[0]  == Jingdong.a.overload("java.lang.String", "java.lang.String")


