### PR TITLE
Remove "0x" prefix from hexdump offsets

### DIFF
--- a/bindings/gumjs/gumjs-core.js
+++ b/bindings/gumjs/gumjs-core.js
@@ -168,7 +168,7 @@
                 result.push("\n");
 
             result.push(
-                offsetColor, "0x", pad(offset.toString(16), leftColumnWidth, "0"), resetColor,
+                offsetColor, pad(offset.toString(16), leftColumnWidth, "0"), resetColor,
                 columnPadding
             );
 


### PR DESCRIPTION
hexdump() is now reversible with "xxd -r"