### PR TITLE
Do not recycle the InvocationReturnValue object

### DIFF
--- a/bindings/gumjs/gumdukinterceptor.h
+++ b/bindings/gumjs/gumdukinterceptor.h
@@ -38,8 +38,7 @@ struct _GumDukInterceptor
   GumDukInvocationArgs * cached_invocation_args;
   gboolean cached_invocation_args_in_use;
 
-  GumDukInvocationReturnValue * cached_invocation_return_value;
-  gboolean cached_invocation_return_value_in_use;
+  GumDukInvocationReturnValue * cached_return_values;
 };
 
 struct _GumDukInvocationContext

--- a/bindings/gumjs/gumv8interceptor.h
+++ b/bindings/gumjs/gumv8interceptor.h
@@ -15,7 +15,6 @@
 typedef struct _GumV8Interceptor GumV8Interceptor;
 typedef struct _GumV8InvocationContext GumV8InvocationContext;
 typedef struct _GumV8InvocationArgs GumV8InvocationArgs;
-typedef struct _GumV8InvocationReturnValue GumV8InvocationReturnValue;
 
 struct _GumV8Interceptor
 {
@@ -37,9 +36,6 @@ struct _GumV8Interceptor
 
   GumV8InvocationArgs * cached_invocation_args;
   gboolean cached_invocation_args_in_use;
-
-  GumV8InvocationReturnValue * cached_invocation_return_value;
-  gboolean cached_invocation_return_value_in_use;
 };
 
 struct _GumV8InvocationContext

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -29,6 +29,7 @@ TEST_LIST_BEGIN (script)
   SCRIPT_TESTENTRY (argument_can_be_read)
   SCRIPT_TESTENTRY (argument_can_be_replaced)
   SCRIPT_TESTENTRY (return_value_can_be_read)
+  SCRIPT_TESTENTRY (return_value_can_be_kept)
   SCRIPT_TESTENTRY (return_value_can_be_replaced)
   SCRIPT_TESTENTRY (return_address_can_be_read)
   SCRIPT_TESTENTRY (register_can_be_read)
@@ -1978,6 +1979,24 @@ SCRIPT_TESTCASE (return_value_can_be_read)
   EXPECT_NO_MESSAGES ();
   target_function_int (7);
   EXPECT_SEND_MESSAGE_WITH ("315");
+}
+
+SCRIPT_TESTCASE (return_value_can_be_kept)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "var values = [];"
+      "Interceptor.attach(" GUM_PTR_CONST ", {"
+      "  onLeave: function (retval) {"
+      "    values.push(retval);"
+      "    if (values.length === 2)"
+      "      send(values.map(function (value) { return value.toInt32(); }));"
+      "  }"
+      "});", target_function_int);
+
+  EXPECT_NO_MESSAGES ();
+  target_function_int (7);
+  target_function_int (8);
+  EXPECT_SEND_MESSAGE_WITH ("[315,360]");
 }
 
 SCRIPT_TESTCASE (return_value_can_be_replaced)


### PR DESCRIPTION
It's counter-intuitive that `onLeave` implementors need to deep-copy the
value to use it outside the callback.