### PR TITLE
Add SystemFunction API

### DIFF
--- a/bindings/gumjs/gumdukcore.h
+++ b/bindings/gumjs/gumdukcore.h
@@ -16,6 +16,12 @@
 
 #define GUM_DUK_SCOPE_INIT(C) { C, 0, (C)->current_ctx, NULL }
 
+#ifdef G_OS_WIN32
+# define GUMJS_SYSTEM_ERROR_FIELD "lastError"
+#else
+# define GUMJS_SYSTEM_ERROR_FIELD "errno"
+#endif
+
 G_BEGIN_DECLS
 
 typedef struct _GumDukCore GumDukCore;
@@ -84,6 +90,8 @@ struct _GumDukCore
   GumDukHeapPtr native_resource;
   GumDukHeapPtr native_function;
   GumDukHeapPtr native_function_prototype;
+  GumDukHeapPtr system_function;
+  GumDukHeapPtr system_function_prototype;
   GumDukHeapPtr cpu_context;
 
   GumDukNativePointerImpl * cached_native_pointers;

--- a/bindings/gumjs/gumdukinterceptor.c
+++ b/bindings/gumjs/gumdukinterceptor.c
@@ -9,12 +9,6 @@
 #include "gumdukmacros.h"
 #include "gumdukscript-priv.h"
 
-#ifdef G_OS_WIN32
-# define GUM_SYSTEM_ERROR_FIELD "lastError"
-#else
-# define GUM_SYSTEM_ERROR_FIELD "errno"
-#endif
-
 #define GUM_DUK_INVOCATION_LISTENER_CAST(obj) \
     ((GumDukInvocationListener *) (obj))
 #define GUM_DUK_TYPE_CALL_LISTENER (gum_duk_call_listener_get_type ())
@@ -200,7 +194,7 @@ static const GumDukPropertyEntry gumjs_invocation_context_values[] =
     NULL
   },
   {
-    GUM_SYSTEM_ERROR_FIELD,
+    GUMJS_SYSTEM_ERROR_FIELD,
     gumjs_invocation_context_get_system_error,
     gumjs_invocation_context_set_system_error
   },

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -12,6 +12,12 @@
 #define GUMJS_CPU_CONTEXT_VALUE(o) \
     ((GumCpuContext *) (o)->GetInternalField (0).As<External> ()->Value ())
 
+#ifdef G_OS_WIN32
+# define GUMJS_SYSTEM_ERROR_FIELD "lastError"
+#else
+# define GUMJS_SYSTEM_ERROR_FIELD "errno"
+#endif
+
 #include "gumscriptscheduler.h"
 #include "gumv8script.h"
 #include "gumv8scriptbackend.h"

--- a/bindings/gumjs/gumv8interceptor.cpp
+++ b/bindings/gumjs/gumv8interceptor.cpp
@@ -13,12 +13,6 @@
 
 #define GUMJS_MODULE_NAME Interceptor
 
-#ifdef G_OS_WIN32
-# define GUM_SYSTEM_ERROR_FIELD "lastError"
-#else
-# define GUM_SYSTEM_ERROR_FIELD "errno"
-#endif
-
 #define GUM_V8_INVOCATION_LISTENER_CAST(obj) \
     ((GumV8InvocationListener *) (obj))
 #define GUM_V8_TYPE_CALL_LISTENER (gum_v8_call_listener_get_type ())
@@ -187,7 +181,7 @@ static const GumV8Property gumjs_invocation_context_values[] =
     NULL
   },
   {
-    GUM_SYSTEM_ERROR_FIELD,
+    GUMJS_SYSTEM_ERROR_FIELD,
     gumjs_invocation_context_get_system_error,
     gumjs_invocation_context_set_system_error
   },


### PR DESCRIPTION
One shortcoming of NativeFunction is that it is not possible to get
`errno` / `GetLastError()` reliably, as Frida may have clobbered it.

This new API is just like NativeFunction except that the return value
is an object containing `value` and `errno` (or `lastError` on Windows).

For example calling `open()` with a path that does not exist, the return
value on Darwin would be:

    { value: -1, errno: 2 /* ENOENT */ }