### PR TITLE
Accommodate sourcemap changes in frida-compile/pull/2

### DIFF
--- a/bindings/gumjs/generate-runtime.py
+++ b/bindings/gumjs/generate-runtime.py
@@ -155,10 +155,7 @@ def extract_source_map(filename, source_code):
     return (stripped_source_code, raw_source_map)
 
 def to_canonical_source_path(path):
-    if path.startswith('../node_modules'):
-        return 'frida/' + path[3:]
-    else:
-        return 'frida/' + path
+    return os.path.join("frida", path).replace("\\", "/")
 
 def write_bytes(data, sink):
     sink.write("\n  ")
@@ -189,7 +186,7 @@ def identifier(filename):
     return result
 
 def node_script_path(name):
-    return os.path.join(".", "node_modules", ".bin", name + script_suffix())
+    return os.path.abspath(os.path.join(sys.path[0], "node_modules", ".bin", name + script_suffix()))
 
 def script_suffix():
     build_os = platform.system().lower()

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -3845,7 +3845,7 @@ SCRIPT_TESTCASE (source_maps_should_be_supported_for_our_runtime)
   COMPILE_AND_LOAD_SCRIPT ("hexdump(null);");
 
   item = test_script_fixture_pop_message (fixture);
-  g_assert (strstr (item->message, " (frida/hexdump.js:") != NULL);
+  g_assert (strstr (item->message, " (frida/runtime/hexdump.js:") != NULL);
   test_script_message_item_free (item);
 
   EXPECT_NO_MESSAGES ();


### PR DESCRIPTION
Depends on: https://github.com/frida/frida-compile/pull/2

frida-compile now, by default, encodes source locations relative to where its invoked, not where the scripts live. This ensures that a debugger can correctly resolve paths using the frida-compile invocation site as the root directory.

So with that, `../node_modules` handling is no longer required. For an input script `runtime\foo.js` that calls `require ('promiscuous')`, frida-compile will resolve to `node_modules/promiscuous`. The path then, as before, gets appended to a pseudo-fs-root `frida/`. To keep things tidy (and reduce debugger confusion), the path also has its slashes tweaked to fit canonical form.


