### PR TITLE
Ensure smaller allocations of memory are zero-initialized

### DIFF
--- a/bindings/gumjs/gumdukmemory.c
+++ b/bindings/gumjs/gumdukmemory.c
@@ -235,7 +235,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
 
   if (size < page_size)
   {
-    _gum_duk_push_native_resource (ctx, g_malloc (size), g_free, core);
+    _gum_duk_push_native_resource (ctx, g_malloc0 (size), g_free, core);
   }
   else
   {

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -227,7 +227,7 @@ _gum_v8_memory_finalize (GumV8Memory * self)
  * Memory.alloc(size)
  *
  * Docs:
- * Allocate a chunk of memory
+ * Allocate a zero-initialized chunk of memory
  *
  * Example:
  * TBW
@@ -249,7 +249,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
   gsize page_size = gum_query_page_size ();
   if (size < page_size)
   {
-    res = _gum_v8_native_resource_new (g_malloc (size), size, g_free, core);
+    res = _gum_v8_native_resource_new (g_malloc0 (size), size, g_free, core);
   }
   else
   {

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -3002,6 +3002,11 @@ SCRIPT_TESTCASE (memory_can_be_allocated)
   g_assert (p != 0);
   test_script_message_item_free (item);
   g_assert_cmpuint (p & (gum_query_page_size () - 1), ==, 0);
+
+  COMPILE_AND_LOAD_SCRIPT(
+      "var p = Memory.alloc(5);"
+      "send('p', Memory.readByteArray(p, 5));");
+  EXPECT_SEND_MESSAGE_WITH_PAYLOAD_AND_DATA("\"p\"", "00 00 00 00 00");
 }
 
 SCRIPT_TESTCASE (memory_can_be_copied)


### PR DESCRIPTION
Aligns smaller (less than page size) allocations with behavior of larger ones (i.e. zero initializes all the time). Sub-ms perf impact measured.

Smaller allocations are now zero-initialized via `g_malloc0`.

Verified larger allocations are already zero-initialized across all the major platforms:
- Windows
  - `VirtualAlloc` with `MEM_COMMIT`
- Linux
  - `mmap` with `MAP_ANONYMOUS`
- Mac
  - `mach_vm_allocate` ([source](https://opensource.apple.com/source/xnu/xnu-1456.1.26/osfmk/vm/vm_user.c)) 

Test added to catch any outliers.