### PR TITLE
Fix Interceptor thread context cleanup [WIP]

### DIFF
--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -55,6 +55,8 @@ struct _GumInterceptor
 struct _GumInterceptorClass
 {
   GObjectClass parent_class;
+
+  void (* flush_suggested) (GumInterceptor * interceptor);
 };
 
 G_BEGIN_DECLS

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -23,7 +23,7 @@
 #define MSPACES                   1
 #define ONLY_MSPACES              1
 #define USE_LOCKS                 1
-#define USE_SPIN_LOCKS            0
+#define USE_SPIN_LOCKS            1
 #define FOOTERS                   0
 #define INSECURE                  1
 #define NO_MALLINFO               0

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2015 Ole André Vadla Ravnås <ole.andre.ravnas@tillitech.com>
+ * Copyright (C) 2008-2017 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -12,6 +12,7 @@
 typedef gsize GumThreadId;
 typedef guint GumThreadState;
 typedef struct _GumThreadDetails GumThreadDetails;
+typedef struct _GumThreadLifetimeBeacon GumThreadLifetimeBeacon;
 typedef struct _GumModuleDetails GumModuleDetails;
 typedef guint GumImportType;
 typedef guint GumExportType;
@@ -35,6 +36,11 @@ struct _GumThreadDetails
   GumThreadId id;
   GumThreadState state;
   GumCpuContext cpu_context;
+};
+
+struct _GumThreadLifetimeBeacon
+{
+  gpointer data;
 };
 
 struct _GumModuleDetails
@@ -123,6 +129,9 @@ GUM_API void gum_process_enumerate_malloc_ranges (
 GUM_API gboolean gum_thread_try_get_range (GumMemoryRange * range);
 GUM_API gint gum_thread_get_system_error (void);
 GUM_API void gum_thread_set_system_error (gint value);
+GUM_API void gum_thread_create_beacon (GumThreadLifetimeBeacon * beacon);
+GUM_API void gum_thread_destroy_beacon (GumThreadLifetimeBeacon * beacon);
+GUM_API gboolean gum_thread_check_beacon (GumThreadLifetimeBeacon * beacon);
 GUM_API void gum_module_enumerate_imports (const gchar * module_name,
     GumFoundImportFunc func, gpointer user_data);
 GUM_API void gum_module_enumerate_exports (const gchar * module_name,

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -42,6 +42,8 @@ namespace Gum {
 
 		public void ignore_other_threads ();
 		public void unignore_other_threads ();
+
+		public signal void flush_suggested ();
 	}
 
 	public interface InvocationListener : GLib.Object {


### PR DESCRIPTION
We cannot clean it up when we get the TLS callback, as the application
might call an intercepted function in one of its TLS callbacks called
after ours. Instead we emit “flush-suggested” and defer cleanup until
a future gum_interceptor_flush(). At that point we check the lifetime
beacon and potentially perform the cleanup.