### PR TITLE
Update to the new GThread API

### DIFF
--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -357,7 +357,7 @@ gum_stalker_init (GumStalker * self)
   priv->page_size = gum_query_page_size ();
   g_mutex_init (&priv->mutex);
   priv->contexts = NULL;
-  priv->exec_ctx = gum_tls_key_new (NULL);
+  priv->exec_ctx = gum_tls_key_new ();
 }
 
 static void

--- a/gum/backend-darwin/gumtls-darwin.c
+++ b/gum/backend-darwin/gumtls-darwin.c
@@ -24,12 +24,12 @@ _gum_tls_deinit (void)
 }
 
 GumTlsKey
-gum_tls_key_new (GDestroyNotify notify)
+gum_tls_key_new (void)
 {
   pthread_key_t key;
   gint res;
 
-  res = pthread_key_create (&key, notify);
+  res = pthread_key_create (&key, NULL);
   g_assert_cmpint (res, ==, 0);
 
   return key;

--- a/gum/backend-posix/gumtls-posix.c
+++ b/gum/backend-posix/gumtls-posix.c
@@ -24,12 +24,12 @@ _gum_tls_deinit (void)
 }
 
 GumTlsKey
-gum_tls_key_new (GDestroyNotify notify)
+gum_tls_key_new (void)
 {
   pthread_key_t key;
   gint res;
 
-  res = pthread_key_create (&key, notify);
+  res = pthread_key_create (&key, NULL);
   g_assert_cmpint (res, ==, 0);
 
   return key;

--- a/gum/backend-qnx/gumtls-qnx.c
+++ b/gum/backend-qnx/gumtls-qnx.c
@@ -72,12 +72,12 @@ _gum_tls_deinit (void)
 
 
 GumTlsKey
-gum_tls_key_new (GDestroyNotify notify)
+gum_tls_key_new (void)
 {
   pthread_key_t key;
   gint res;
 
-  res = pthread_key_create (&key, notify);
+  res = pthread_key_create (&key, NULL);
   g_assert_cmpint (res, ==, 0);
 
   return key;

--- a/gum/backend-windows/gumtls-windows.c
+++ b/gum/backend-windows/gumtls-windows.c
@@ -38,11 +38,9 @@ static GumSpinlock _gum_tls_tmp_keys_lock;
 #endif
 
 GumTlsKey
-gum_tls_key_new (GDestroyNotify notify)
+gum_tls_key_new (void)
 {
   DWORD res;
-
-  (void) notify;
 
   res = TlsAlloc ();
   g_assert (res != TLS_OUT_OF_INDEXES);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -425,7 +425,7 @@ gum_stalker_init (GumStalker * self)
   priv->page_size = gum_query_page_size ();
   g_mutex_init (&priv->mutex);
   priv->contexts = NULL;
-  priv->exec_ctx = gum_tls_key_new (NULL);
+  priv->exec_ctx = gum_tls_key_new ();
 }
 
 static void

--- a/gum/gumtls.h
+++ b/gum/gumtls.h
@@ -13,7 +13,7 @@ G_BEGIN_DECLS
 
 typedef gsize GumTlsKey;
 
-GUM_API GumTlsKey gum_tls_key_new (GDestroyNotify notify);
+GUM_API GumTlsKey gum_tls_key_new (void);
 GUM_API void gum_tls_key_free (GumTlsKey key);
 
 GUM_API gpointer gum_tls_key_get_value (GumTlsKey key);

--- a/libs/gum/prof/gumcallcountsampler.c
+++ b/libs/gum/prof/gumcallcountsampler.c
@@ -93,7 +93,7 @@ gum_call_count_sampler_init (GumCallCountSampler * self)
 
   priv->interceptor = gum_interceptor_obtain ();
 
-  priv->tls_key = gum_tls_key_new (NULL);
+  priv->tls_key = gum_tls_key_new ();
   g_mutex_init (&priv->mutex);
 }
 

--- a/tests/core/tls.c
+++ b/tests/core/tls.c
@@ -29,7 +29,7 @@ TLS_TESTCASE (get_should_work_like_the_system_implementation)
 {
   GumTlsKey key;
 
-  key = gum_tls_key_new (NULL);
+  key = gum_tls_key_new ();
 
 #ifdef G_OS_WIN32
   TlsSetValue (key, GSIZE_TO_POINTER (0x11223344));
@@ -46,7 +46,7 @@ TLS_TESTCASE (set_should_work_like_the_system_implementation)
 {
   GumTlsKey key;
 
-  key = gum_tls_key_new (NULL);
+  key = gum_tls_key_new ();
 
   gum_tls_key_set_value (key, GSIZE_TO_POINTER (0x11223344));
 #ifdef G_OS_WIN32


### PR DESCRIPTION
Also get rid of the destructor support in GumTls, and rely on GPrivate
for such use-cases. Using GPrivate was previously not possible as any
intercepted function might be called from one of the application's own
thread-local storage destructor functions. Given how such destructors
are called in an unpredictable order, this would typically result in
memory leaks, where our own storage was allocated again right after
getting destroyed.