### PR TITLE
Fixed illegal instruction for physical devices

### DIFF
--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -1965,7 +1965,7 @@ gum_exec_block_write_call_event_code (GumExecBlock * block,
   /* save the target of the call event */
   gum_exec_ctx_write_push_branch_target_address (block->ctx, target, gc);
   /* previous function changes X15 */
-  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X14, ARM64_REG_X14);
+  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X14, ARM64_REG_X15);
 
   STALKER_STORE_REG_INTO_CTX_WITH_AO (ARM64_REG_X14, tmp_event,
       G_STRUCT_OFFSET (GumCallEvent, target));


### PR DESCRIPTION
Tested on Samsung S6 Edge Android API 24.
Executing a load pair instruction that use the same register for both register operands results in Illegal Instruction error.
Using a second register (X15) as second register operand, even if not used later in the code, fixes it.