### PR TITLE
Android gdbserver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,12 +70,12 @@ if ARCH_ARM64
 endif
 
 check: push
-	adb shell "\"${RPFX}/tests/gum-tests\" -p /Core/Arm64Stalker"
+	adb shell "\"${RPFX}/tests/gum-tests\""
 
 check-gdb: $(top_builddir)/tests/android-gdb.setup
 	adb shell "${RM} -f /data/local/tmp/tests/debug-socket"
 	adb push "${ANDROID_NDK_ROOT}/prebuilt/android-$(android_arch)/gdbserver/gdbserver" "${RPFX}/tests/"
-	adb shell "${RPFX}/tests/gdbserver :${DEBUG_PORT} ${RPFX}/tests/gum-tests -p /Core/Arm64Stalker/performance" &
+	adb shell "${RPFX}/tests/gdbserver :${DEBUG_PORT} ${RPFX}/tests/gum-tests" &
 	sleep 1
 	adb forward tcp:${DEBUG_PORT} tcp:${DEBUG_PORT}
 	${ANDROID_NDK_ROOT}/prebuilt/darwin-x86_64/bin/gdb -x "$(top_builddir)/tests/android-gdb.setup"

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,14 +70,14 @@ if ARCH_ARM64
 endif
 
 check: push
-	adb shell "\"${RPFX}/tests/gum-tests\""
+	adb shell "\"${RPFX}/tests/gum-tests\" -p /Core/Arm64Stalker"
 
 check-gdb: $(top_builddir)/tests/android-gdb.setup
 	adb shell "${RM} -f /data/local/tmp/tests/debug-socket"
 	adb push "${ANDROID_NDK_ROOT}/prebuilt/android-$(android_arch)/gdbserver/gdbserver" "${RPFX}/tests/"
-	adb shell "${RPFX}/tests/gdbserver +${RPFX}/tests/debug-socket ${RPFX}/tests/gum-tests" &
+	adb shell "${RPFX}/tests/gdbserver :${DEBUG_PORT} ${RPFX}/tests/gum-tests -p /Core/Arm64Stalker/performance" &
 	sleep 1
-	adb forward tcp:${DEBUG_PORT} localfilesystem:${RPFX}/tests/debug-socket
+	adb forward tcp:${DEBUG_PORT} tcp:${DEBUG_PORT}
 	${ANDROID_NDK_ROOT}/prebuilt/darwin-x86_64/bin/gdb -x "$(top_builddir)/tests/android-gdb.setup"
 
 pull:

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -1965,7 +1965,7 @@ gum_exec_block_write_call_event_code (GumExecBlock * block,
   /* save the target of the call event */
   gum_exec_ctx_write_push_branch_target_address (block->ctx, target, gc);
   /* previous function changes X15 */
-  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X14, ARM64_REG_X14);
+  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X14, ARM64_REG_X15);
 
   STALKER_STORE_REG_INTO_CTX_WITH_AO (ARM64_REG_X14, tmp_event,
       G_STRUCT_OFFSET (GumCallEvent, target));


### PR DESCRIPTION
Gdbserver based on tcp:PORT instead of files in order to properly work with gdb and target remote.