### PR TITLE
Add block and compile events to Stalker

### DIFF
--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -440,6 +440,8 @@ const stalkerEventType = {
   call: 1,
   ret: 2,
   exec: 4,
+  block: 8,
+  compile: 16,
 };
 
 Object.defineProperties(Stalker, {

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -319,6 +319,8 @@ static void gum_exec_block_write_ret_event_code (GumExecBlock * block,
     GumGeneratorContext * gc, GumCodeContext cc);
 static void gum_exec_block_write_exec_event_code (GumExecBlock * block,
     GumGeneratorContext * gc, GumCodeContext cc);
+static void gum_exec_block_write_block_event_code (GumExecBlock * block,
+    GumGeneratorContext * gc, GumCodeContext cc);
 static void gum_exec_block_write_event_init_code (GumExecBlock * block,
     GumEventType type, GumGeneratorContext * gc);
 static void gum_exec_block_write_event_submit_code (GumExecBlock * block,
@@ -1169,6 +1171,13 @@ gum_exec_ctx_obtain_block_for (GumExecCtx * ctx,
     if ((ctx->sink_mask & GUM_EXEC) != 0)
       gum_exec_block_write_exec_event_code (block, &gc, GUM_CODE_INTERRUPTIBLE);
 
+    if ((ctx->sink_mask & GUM_BLOCK) != 0 &&
+        gum_x86_relocator_eob (rl) &&
+        insn.ci->id != X86_INS_CALL)
+    {
+      gum_exec_block_write_block_event_code (block, &gc, GUM_CODE_INTERRUPTIBLE);
+    }
+
     switch (insn.ci->id)
     {
       case X86_INS_CALL:
@@ -1259,6 +1268,15 @@ gum_exec_ctx_obtain_block_for (GumExecCtx * ctx,
   block->real_end = (guint8 *) rl->input_cur;
 
   gum_exec_block_commit (block);
+
+  if ((ctx->sink_mask & GUM_COMPILE) != 0)
+  {
+    ctx->tmp_event.type = GUM_COMPILE;
+    ctx->tmp_event.compile.begin = block->real_begin;
+    ctx->tmp_event.compile.end = block->real_end;
+
+    gum_event_sink_process (ctx->sink, &ctx->tmp_event);
+  }
 
   return block;
 }
@@ -2426,6 +2444,32 @@ gum_exec_block_write_exec_event_code (GumExecBlock * block,
       GUM_ADDRESS (gc->instruction->begin));
   gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
       GUM_REG_XAX, G_STRUCT_OFFSET (GumExecEvent, location),
+      GUM_REG_XCX);
+
+  gum_exec_block_write_event_submit_code (block, gc, cc);
+}
+
+static void
+gum_exec_block_write_block_event_code (GumExecBlock * block,
+                                      GumGeneratorContext * gc,
+                                      GumCodeContext cc)
+{
+  GumX86Writer * cw = gc->code_writer;
+
+  gum_exec_block_open_prolog (block, GUM_PROLOG_MINIMAL, gc);
+
+  gum_exec_block_write_event_init_code (block, GUM_BLOCK, gc);
+
+  gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XCX,
+      GUM_ADDRESS (gc->relocator->input_start));
+  gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
+      GUM_REG_XAX, G_STRUCT_OFFSET (GumBlockEvent, begin),
+      GUM_REG_XCX);
+
+  gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XCX,
+      GUM_ADDRESS (gc->relocator->input_cur));
+  gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
+      GUM_REG_XAX, G_STRUCT_OFFSET (GumBlockEvent, end),
       GUM_REG_XCX);
 
   gum_exec_block_write_event_submit_code (block, gc, cc);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -2451,8 +2451,8 @@ gum_exec_block_write_exec_event_code (GumExecBlock * block,
 
 static void
 gum_exec_block_write_block_event_code (GumExecBlock * block,
-                                      GumGeneratorContext * gc,
-                                      GumCodeContext cc)
+                                       GumGeneratorContext * gc,
+                                       GumCodeContext cc)
 {
   GumX86Writer * cw = gc->code_writer;
 

--- a/gum/gumevent.h
+++ b/gum/gumevent.h
@@ -16,10 +16,12 @@ typedef guint GumEventType;
 
 typedef union _GumEvent GumEvent;
 
-typedef struct _GumAnyEvent   GumAnyEvent;
-typedef struct _GumCallEvent  GumCallEvent;
-typedef struct _GumRetEvent   GumRetEvent;
-typedef struct _GumExecEvent  GumExecEvent;
+typedef struct _GumAnyEvent     GumAnyEvent;
+typedef struct _GumCallEvent    GumCallEvent;
+typedef struct _GumRetEvent     GumRetEvent;
+typedef struct _GumExecEvent    GumExecEvent;
+typedef struct _GumBlockEvent   GumBlockEvent;
+typedef struct _GumCompileEvent GumCompileEvent;
 
 enum _GumEventType
 {
@@ -27,6 +29,8 @@ enum _GumEventType
   GUM_CALL        = 1 << 0,
   GUM_RET         = 1 << 1,
   GUM_EXEC        = 1 << 2,
+  GUM_BLOCK       = 1 << 3,
+  GUM_COMPILE     = 1 << 4,
 };
 
 struct _GumAnyEvent
@@ -59,6 +63,22 @@ struct _GumExecEvent
   gpointer location;
 };
 
+struct _GumBlockEvent
+{
+  GumEventType type;
+
+  gpointer begin;
+  gpointer end;
+};
+
+struct _GumCompileEvent
+{
+  GumEventType type;
+
+  gpointer begin;
+  gpointer end;
+};
+
 union _GumEvent
 {
   GumEventType type;
@@ -67,6 +87,8 @@ union _GumEvent
   GumCallEvent call;
   GumRetEvent ret;
   GumExecEvent exec;
+  GumBlockEvent block;
+  GumCompileEvent compile;
 };
 
 G_END_DECLS


### PR DESCRIPTION
- `compile` events are emitted as soon as a basic block gets compiled by the Stalker. This happens once per block, so it's useful to understand which parts of code gets executed but it's not a full live trace of the execution.
- `block` events are emitted each time a basic block is executed, so can be used to actually trace the execution.

