### PR TITLE
Add testcases for repne jb (failing) and repne ret

### DIFF
--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -849,8 +849,8 @@ STALKER_TESTCASE (follow_repne_jb)
   gint ret;
 
   func = GUM_POINTER_TO_FUNCPTR (StalkerTestFunc,
-    test_stalker_fixture_dup_code(fixture, repne_jb_code,
-      sizeof(repne_jb_code)));
+    test_stalker_fixture_dup_code (fixture, repne_jb_code,
+      sizeof (repne_jb_code)));
 
   g_assert_cmpint (func(0), == , 0xbeef);
 

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -824,7 +824,7 @@ STALKER_TESTCASE (follow_repne_ret)
 
   g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_INSN_COUNT + 2);
 
-  g_assert_cmpint (ret, == , 0xbeef);
+  g_assert_cmpint (ret, ==, 0xbeef);
 }
 
 STALKER_TESTCASE (follow_repne_jb)

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -805,7 +805,7 @@ STALKER_TESTCASE (follow_stdcall)
   g_assert_cmpint (ret, ==, 0xbeef);
 }
 
-STALKER_TESTCASE(follow_repne_ret)
+STALKER_TESTCASE (follow_repne_ret)
 {
   const guint8 repne_ret_code[] =
   {
@@ -816,20 +816,20 @@ STALKER_TESTCASE(follow_repne_ret)
   StalkerTestFunc func;
   gint ret;
 
-  func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
-    test_stalker_fixture_dup_code(fixture, repne_ret_code,
-      sizeof(repne_ret_code)));
+  func = GUM_POINTER_TO_FUNCPTR (StalkerTestFunc,
+    test_stalker_fixture_dup_code (fixture, repne_ret_code,
+      sizeof (repne_ret_code)));
 
   fixture->sink->mask = GUM_EXEC;
-  ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+  ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
-  g_assert_cmpuint(fixture->sink->events->len,
+  g_assert_cmpuint (fixture->sink->events->len,
     == , INVOKER_INSN_COUNT + 2);
 
-  g_assert_cmpint(ret, == , 0xbeef);
+  g_assert_cmpint (ret, == , 0xbeef);
 }
 
-STALKER_TESTCASE(follow_repne_jb)
+STALKER_TESTCASE (follow_repne_jb)
 {
   const guint8 repne_jb_code[] =
   {
@@ -848,19 +848,19 @@ STALKER_TESTCASE(follow_repne_jb)
   StalkerTestFunc func;
   gint ret;
 
-  func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
+  func = GUM_POINTER_TO_FUNCPTR (StalkerTestFunc,
     test_stalker_fixture_dup_code(fixture, repne_jb_code,
       sizeof(repne_jb_code)));
 
-  g_assert_cmpint(func(0), == , 0xbeef);
+  g_assert_cmpint (func(0), == , 0xbeef);
 
   fixture->sink->mask = GUM_EXEC;
-  ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+  ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
-  g_assert_cmpuint(fixture->sink->events->len,
+  g_assert_cmpuint (fixture->sink->events->len,
     == , INVOKER_INSN_COUNT + 7);
 
-  g_assert_cmpint(ret, == , 0xbeef);
+  g_assert_cmpint (ret, == , 0xbeef);
 }
 
 #if GLIB_SIZEOF_VOID_P == 4

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -817,14 +817,14 @@ STALKER_TESTCASE (follow_repne_ret)
   gint ret;
 
   func = GUM_POINTER_TO_FUNCPTR (StalkerTestFunc,
-    test_stalker_fixture_dup_code (fixture, repne_ret_code,
-      sizeof (repne_ret_code)));
+      test_stalker_fixture_dup_code (fixture, repne_ret_code,
+          sizeof (repne_ret_code)));
 
   fixture->sink->mask = GUM_EXEC;
   ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
   g_assert_cmpuint (fixture->sink->events->len,
-    == , INVOKER_INSN_COUNT + 2);
+      == , INVOKER_INSN_COUNT + 2);
 
   g_assert_cmpint (ret, == , 0xbeef);
 }
@@ -849,16 +849,16 @@ STALKER_TESTCASE (follow_repne_jb)
   gint ret;
 
   func = GUM_POINTER_TO_FUNCPTR (StalkerTestFunc,
-    test_stalker_fixture_dup_code (fixture, repne_jb_code,
-      sizeof (repne_jb_code)));
+      test_stalker_fixture_dup_code (fixture, repne_jb_code,
+          sizeof (repne_jb_code)));
 
-  g_assert_cmpint (func(0), == , 0xbeef);
+  g_assert_cmpint (func (0), == , 0xbeef);
 
   fixture->sink->mask = GUM_EXEC;
   ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
   g_assert_cmpuint (fixture->sink->events->len,
-    == , INVOKER_INSN_COUNT + 7);
+      == , INVOKER_INSN_COUNT + 7);
 
   g_assert_cmpint (ret, == , 0xbeef);
 }

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -838,7 +838,7 @@ STALKER_TESTCASE(follow_repne_jb)
     0xb9, 0xfe, 0x00, 0x00, 0x00, /* mov ecx, 0xfe       */
     0x3b, 0xc8,                   /* cmp ecx, eax        */
     0xf2, 0x72, 0x02,             /* repne jb short func */
-    xc3,                          /* ret                 */
+    0xc3,                         /* ret                 */
     0xcc,                         /* int3                */
 
                                   /* func:               */

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -23,6 +23,8 @@ TEST_LIST_BEGIN (stalker)
   STALKER_TESTENTRY (long_conditional_jump)
   STALKER_TESTENTRY (follow_return)
   STALKER_TESTENTRY (follow_stdcall)
+  STALKER_TESTENTRY (follow_repne_ret)
+  STALKER_TESTENTRY (follow_repne_jb)
   STALKER_TESTENTRY (unfollow_deep)
   STALKER_TESTENTRY (call_followed_by_junk)
   STALKER_TESTENTRY (indirect_call_with_immediate)
@@ -801,6 +803,64 @@ STALKER_TESTCASE (follow_stdcall)
       ==, INVOKER_INSN_COUNT + 5);
 
   g_assert_cmpint (ret, ==, 0xbeef);
+}
+
+STALKER_TESTCASE(follow_repne_ret)
+{
+	const guint8 repne_ret_code[] =
+	{
+		0xb8, 0xef, 0xbe, 0x00, 0x00, /* mov eax, 0xbeef     */
+		0xf2, 0xc3,                   /* repne ret           */
+		0xcc,                         /* int3                */
+	};
+	StalkerTestFunc func;
+	gint ret;
+
+	func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
+		test_stalker_fixture_dup_code(fixture, repne_ret_code,
+			sizeof(repne_ret_code)));
+
+	fixture->sink->mask = GUM_EXEC;
+	ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+
+	g_assert_cmpuint(fixture->sink->events->len,
+		== , INVOKER_INSN_COUNT + 2);
+
+	g_assert_cmpint(ret, == , 0xbeef);
+}
+
+STALKER_TESTCASE(follow_repne_jb)
+{
+	const guint8 repne_jb_code[] =
+	{
+		0x68, 0xef, 0xbe, 0x00, 0x00, /* push dword 0xbeef   */
+		0xb8, 0xff, 0x00, 0x00, 0x00, /* mov eax, 0xff       */
+		0xb9, 0xfe, 0x00, 0x00, 0x00, /* mov ecx, 0xfe       */
+		0x3b, 0xc8,                   /* cmp ecx, eax        */
+		0xf2, 0x72, 0x02,             /* repne jb short func */
+		0xc3,                         /* ret                 */
+		0xcc,                         /* int3                */
+
+									  /* func:               */
+		0x58,                         /* pop eax             */
+		0xc3,                         /* ret                 */
+    };
+	StalkerTestFunc func;
+	gint ret;
+
+	func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
+		test_stalker_fixture_dup_code(fixture, repne_jb_code,
+			sizeof(repne_jb_code)));
+
+	g_assert_cmpint(func(0), == , 0xbeef);
+
+	fixture->sink->mask = GUM_EXEC;
+	ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+
+	g_assert_cmpuint(fixture->sink->events->len,
+		== , INVOKER_INSN_COUNT + 7);
+
+	g_assert_cmpint(ret, == , 0xbeef);
 }
 
 #if GLIB_SIZEOF_VOID_P == 4

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -799,8 +799,7 @@ STALKER_TESTCASE (follow_stdcall)
   fixture->sink->mask = GUM_EXEC;
   ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
-  g_assert_cmpuint (fixture->sink->events->len,
-      ==, INVOKER_INSN_COUNT + 5);
+  g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_INSN_COUNT + 5);
 
   g_assert_cmpint (ret, ==, 0xbeef);
 }
@@ -823,8 +822,7 @@ STALKER_TESTCASE (follow_repne_ret)
   fixture->sink->mask = GUM_EXEC;
   ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
-  g_assert_cmpuint (fixture->sink->events->len,
-      == , INVOKER_INSN_COUNT + 2);
+  g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_INSN_COUNT + 2);
 
   g_assert_cmpint (ret, == , 0xbeef);
 }
@@ -852,15 +850,14 @@ STALKER_TESTCASE (follow_repne_jb)
       test_stalker_fixture_dup_code (fixture, repne_jb_code,
           sizeof (repne_jb_code)));
 
-  g_assert_cmpint (func (0), == , 0xbeef);
+  g_assert_cmpint (func (0), ==, 0xbeef);
 
   fixture->sink->mask = GUM_EXEC;
   ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
 
-  g_assert_cmpuint (fixture->sink->events->len,
-      == , INVOKER_INSN_COUNT + 7);
+  g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_INSN_COUNT + 7);
 
-  g_assert_cmpint (ret, == , 0xbeef);
+  g_assert_cmpint (ret, ==, 0xbeef);
 }
 
 #if GLIB_SIZEOF_VOID_P == 4

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -807,60 +807,60 @@ STALKER_TESTCASE (follow_stdcall)
 
 STALKER_TESTCASE(follow_repne_ret)
 {
-	const guint8 repne_ret_code[] =
-	{
-		0xb8, 0xef, 0xbe, 0x00, 0x00, /* mov eax, 0xbeef     */
-		0xf2, 0xc3,                   /* repne ret           */
-		0xcc,                         /* int3                */
-	};
-	StalkerTestFunc func;
-	gint ret;
+  const guint8 repne_ret_code[] =
+  {
+    0xb8, 0xef, 0xbe, 0x00, 0x00, /* mov eax, 0xbeef     */
+    0xf2, 0xc3,                   /* repne ret           */
+    0xcc,                         /* int3                */
+  };
+  StalkerTestFunc func;
+  gint ret;
 
-	func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
-		test_stalker_fixture_dup_code(fixture, repne_ret_code,
-			sizeof(repne_ret_code)));
+  func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
+    test_stalker_fixture_dup_code(fixture, repne_ret_code,
+      sizeof(repne_ret_code)));
 
-	fixture->sink->mask = GUM_EXEC;
-	ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+  fixture->sink->mask = GUM_EXEC;
+  ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
 
-	g_assert_cmpuint(fixture->sink->events->len,
-		== , INVOKER_INSN_COUNT + 2);
+  g_assert_cmpuint(fixture->sink->events->len,
+    == , INVOKER_INSN_COUNT + 2);
 
-	g_assert_cmpint(ret, == , 0xbeef);
+  g_assert_cmpint(ret, == , 0xbeef);
 }
 
 STALKER_TESTCASE(follow_repne_jb)
 {
-	const guint8 repne_jb_code[] =
-	{
-		0x68, 0xef, 0xbe, 0x00, 0x00, /* push dword 0xbeef   */
-		0xb8, 0xff, 0x00, 0x00, 0x00, /* mov eax, 0xff       */
-		0xb9, 0xfe, 0x00, 0x00, 0x00, /* mov ecx, 0xfe       */
-		0x3b, 0xc8,                   /* cmp ecx, eax        */
-		0xf2, 0x72, 0x02,             /* repne jb short func */
-		0xc3,                         /* ret                 */
-		0xcc,                         /* int3                */
+  const guint8 repne_jb_code[] =
+  {
+    0x68, 0xef, 0xbe, 0x00, 0x00, /* push dword 0xbeef   */
+    0xb8, 0xff, 0x00, 0x00, 0x00, /* mov eax, 0xff       */
+    0xb9, 0xfe, 0x00, 0x00, 0x00, /* mov ecx, 0xfe       */
+    0x3b, 0xc8,                   /* cmp ecx, eax        */
+    0xf2, 0x72, 0x02,             /* repne jb short func */
+    xc3,                          /* ret                 */
+    0xcc,                         /* int3                */
 
-									  /* func:               */
-		0x58,                         /* pop eax             */
-		0xc3,                         /* ret                 */
-    };
-	StalkerTestFunc func;
-	gint ret;
+                                  /* func:               */
+    0x58,                         /* pop eax             */
+    0xc3,                         /* ret                 */
+  };
+  StalkerTestFunc func;
+  gint ret;
 
-	func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
-		test_stalker_fixture_dup_code(fixture, repne_jb_code,
-			sizeof(repne_jb_code)));
+  func = GUM_POINTER_TO_FUNCPTR(StalkerTestFunc,
+    test_stalker_fixture_dup_code(fixture, repne_jb_code,
+      sizeof(repne_jb_code)));
 
-	g_assert_cmpint(func(0), == , 0xbeef);
+  g_assert_cmpint(func(0), == , 0xbeef);
 
-	fixture->sink->mask = GUM_EXEC;
-	ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
+  fixture->sink->mask = GUM_EXEC;
+  ret = test_stalker_fixture_follow_and_invoke(fixture, func, 0);
 
-	g_assert_cmpuint(fixture->sink->events->len,
-		== , INVOKER_INSN_COUNT + 7);
+  g_assert_cmpuint(fixture->sink->events->len,
+    == , INVOKER_INSN_COUNT + 7);
 
-	g_assert_cmpint(ret, == , 0xbeef);
+  g_assert_cmpint(ret, == , 0xbeef);
 }
 
 #if GLIB_SIZEOF_VOID_P == 4


### PR DESCRIPTION
Stalking a function using 'repne jb' currently causes frida-gum to generate invalid code.