### PR TITLE
Add OutputDebugString() to debug() strings on Windows

### DIFF
--- a/gum/gum.c
+++ b/gum/gum.c
@@ -390,13 +390,13 @@ gum_on_log_message (const gchar * log_domain,
                     const gchar * message,
                     gpointer user_data)
 {
-#if defined(HAVE_WINDOWS)
+#if defined (HAVE_WINDOWS)
   gunichar2 * message_utf16;
 
   message_utf16 = g_utf8_to_utf16 (message, -1, NULL, NULL, NULL);
   OutputDebugString (message_utf16);
   g_free (message_utf16);
-#elif defined(HAVE_ANDROID)
+#elif defined (HAVE_ANDROID)
   int priority;
 
   (void) user_data;
@@ -420,7 +420,8 @@ gum_on_log_message (const gchar * log_domain,
   }
 
   __android_log_write (priority, log_domain, message);
-#elif defined(HAVE_DARWIN)
+#else
+# ifdef HAVE_DARWIN
   static gsize api_value = 0;
   GumCFApi * api;
 
@@ -516,7 +517,7 @@ gum_on_log_message (const gchar * log_domain,
   }
 
   /* else: fall through to stdout/stderr logging */
-#else
+# endif
   FILE * file = NULL;
   const gchar * severity = NULL;
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -515,9 +515,9 @@ gum_on_log_message (const gchar * log_domain,
 
     return;
   }
-
   /* else: fall through to stdout/stderr logging */
 # endif
+
   FILE * file = NULL;
   const gchar * severity = NULL;
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -16,6 +16,9 @@
 #include <ffi.h>
 #include <glib-object.h>
 #include <gio/gio.h>
+#ifdef HAVE_WINDOWS
+  #include <windows.h>
+#endif
 
 #define DEBUG_HEAP_LEAKS 0
 
@@ -506,6 +509,18 @@ gum_on_log_message (const gchar * log_domain,
 
     return;
   }
+#else
+# ifdef HAVE_WINDOWS
+  gunichar2* utf16_message;
+  utf16_message = g_utf8_to_utf16 (message, -1, NULL, NULL, NULL);
+  if (utf16_message)
+  {
+    OutputDebugString (utf16_message);
+    g_free (utf16_message);
+
+    return;
+  }
+
   /* else: fall through to stdout/stderr logging */
 # endif
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -392,11 +392,10 @@ gum_on_log_message (const gchar * log_domain,
 {
 #if defined(HAVE_WINDOWS)
   gunichar2 * message_utf16;
+
   message_utf16 = g_utf8_to_utf16 (message, -1, NULL, NULL, NULL);
   OutputDebugString (message_utf16);
   g_free (message_utf16);
-
-  return;
 #elif defined(HAVE_ANDROID)
   int priority;
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -17,7 +17,7 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 #ifdef HAVE_WINDOWS
-#  include <windows.h>
+# include <windows.h>
 #endif
 
 #define DEBUG_HEAP_LEAKS 0


### PR DESCRIPTION
Currently `debug()` strings go to stdout/stderr on Windows, which means they're usually not visible.