### PR TITLE
Do not ignore interception of NativeFunction calls

### DIFF
--- a/bindings/gumjs/gumdukcore.c
+++ b/bindings/gumjs/gumdukcore.c
@@ -2742,7 +2742,9 @@ gum_duk_native_function_invoke (GumDukNativeFunction * self,
 
     if (gum_exceptor_try (core->exceptor, &exceptor_scope))
     {
+      gum_interceptor_unignore_current_thread (core->interceptor);
       ffi_call (&self->cif, implementation, rvalue, avalue);
+      gum_interceptor_ignore_current_thread (core->interceptor);
 
       if (self->enable_detailed_return)
         system_error = gum_thread_get_system_error ();
@@ -2753,7 +2755,9 @@ gum_duk_native_function_invoke (GumDukNativeFunction * self,
 
   if (gum_exceptor_catch (core->exceptor, &exceptor_scope))
   {
+    gum_interceptor_ignore_current_thread (core->interceptor);
     _gum_duk_throw_native (ctx, &exceptor_scope.exception, core);
+    gum_interceptor_unignore_current_thread (core->interceptor);
   }
 
   if (self->enable_detailed_return)

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -89,7 +89,7 @@ struct _InterceptorThreadContext
   GumInvocationBackend listener_backend;
   GumInvocationBackend replacement_backend;
 
-  guint ignore_level;
+  gint ignore_level;
 
   GumInvocationStack * stack;
 
@@ -1194,7 +1194,7 @@ _gum_function_context_begin_invocation (GumFunctionContext * function_ctx,
 
   if (invoke_listeners)
   {
-    invoke_listeners = (interceptor_ctx->ignore_level == 0);
+    invoke_listeners = (interceptor_ctx->ignore_level <= 0);
   }
 
   will_trap_on_leave = function_ctx->replacement_function != NULL ||


### PR DESCRIPTION
Interception is ignored for frida's own threads. However, this does not
make sense when calling NativeFunction calls.

To make `gum_interceptor_unignore_current_thread` work before
`gum_interceptor_ignore_current_thread` for theads that aren't ignored
yet, also invoke listeners for negative ignore_levels.

From IRC (these are mostly cited freely from @oleavr ):
- [x] The Interceptor instance should be retrieved from `core`’s `interceptor` field, which has the interceptor impl. as a field (instead of calling `obtain()` and leaking the reference)
- [x] Ignoring again should also happen when the call throws a native exception that we handle
- [x] Style is off
- [x] the test-harness doesn’t ignore Frida’s JS thread. We’ll have to schedule an idle callback on the JS thread to ignore, then run the script, then undo the ignore by scheduling again (so other tests aren’t affected)
