### PR TITLE
Fix x86writer’s sub_reg_reg, add cmp_reg_reg

### DIFF
--- a/gum/arch-x86/gumx86writer.h
+++ b/gum/arch-x86/gumx86writer.h
@@ -195,7 +195,7 @@ GUM_API gboolean gum_x86_writer_put_add_reg_near_ptr (GumX86Writer * self,
     GumCpuReg dst_reg, GumAddress src_address);
 GUM_API gboolean gum_x86_writer_put_sub_reg_imm (GumX86Writer * self,
     GumCpuReg reg, gssize imm_value);
-GUM_API void gum_x86_writer_put_sub_reg_reg (GumX86Writer * self,
+GUM_API gboolean gum_x86_writer_put_sub_reg_reg (GumX86Writer * self,
     GumCpuReg dst_reg, GumCpuReg src_reg);
 GUM_API gboolean gum_x86_writer_put_sub_reg_near_ptr (GumX86Writer * self,
     GumCpuReg dst_reg, GumAddress src_address);
@@ -305,6 +305,8 @@ GUM_API gboolean gum_x86_writer_put_cmp_reg_offset_ptr_reg (GumX86Writer * self,
     GumCpuReg reg_a, gssize offset, GumCpuReg reg_b);
 GUM_API void gum_x86_writer_put_cmp_imm_ptr_imm_u32 (GumX86Writer * self,
     gconstpointer imm_ptr, guint32 imm_value);
+GUM_API gboolean gum_x86_writer_put_cmp_reg_reg (GumX86Writer * self,
+    GumCpuReg dst_reg, GumCpuReg src_reg);
 GUM_API void gum_x86_writer_put_clc (GumX86Writer * self);
 GUM_API void gum_x86_writer_put_stc (GumX86Writer * self);
 GUM_API void gum_x86_writer_put_cld (GumX86Writer * self);


### PR DESCRIPTION
- make sub_reg_reg compatible with 64-bits registers, by adding REX prefix
- cmp_reg_reg is exactly the same, with different opcode