### PR TITLE
Expose sqlite open flags

### DIFF
--- a/bindings/gumjs/gumdukdatabase.c
+++ b/bindings/gumjs/gumdukdatabase.c
@@ -49,7 +49,7 @@ static void gum_push_column (duk_context * ctx, sqlite3_stmt * statement,
 
 static const duk_function_list_entry gumjs_database_module_functions[] =
 {
-  { "open", gumjs_database_open, 1 },
+  { "_open", gumjs_database_open, 2 },
   { "openInline", gumjs_database_open_inline, 1 },
 
   { NULL, NULL, 0 }
@@ -138,16 +138,16 @@ GUMJS_DEFINE_FUNCTION (gumjs_database_open)
 {
   GumDukDatabase * self;
   const gchar * path;
+  gint flags;
   sqlite3 * handle;
   gint status;
 
   self = gumjs_module_from_args (args);
 
-  _gum_duk_args_parse (args, "s", &path);
+  _gum_duk_args_parse (args, "si", &path, &flags);
 
   handle = NULL;
-  status = sqlite3_open_v2 (path, &handle,
-      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+  status = sqlite3_open_v2 (path, &handle, flags, NULL);
   if (status != SQLITE_OK)
     goto invalid_database;
 

--- a/bindings/gumjs/gumv8database.cpp
+++ b/bindings/gumjs/gumv8database.cpp
@@ -64,7 +64,7 @@ static Local<Value> gum_parse_column (Isolate * isolate,
 
 static const GumV8Function gumjs_database_module_functions[] =
 {
-  { "open", gumjs_database_open },
+  { "_open", gumjs_database_open },
   { "openInline", gumjs_database_open_inline },
 
   { NULL, NULL }
@@ -157,16 +157,16 @@ _gum_v8_database_finalize (GumV8Database * self)
 GUMJS_DEFINE_FUNCTION (gumjs_database_open)
 {
   gchar * path;
+  gint flags;
   sqlite3 * handle;
   gint status;
   Local<Object> object;
 
-  if (!_gum_v8_args_parse (args, "s", &path))
+  if (!_gum_v8_args_parse (args, "si", &path, &flags))
     return;
 
   handle = NULL;
-  status = sqlite3_open_v2 (path, &handle, SQLITE_OPEN_READWRITE |
-      SQLITE_OPEN_CREATE, NULL);
+  status = sqlite3_open_v2 (path, &handle, flags, NULL);
   if (status != SQLITE_OK)
     goto invalid_database;
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -771,10 +771,7 @@ const sqliteOpenFlags = {
 Object.defineProperties(SqliteDatabase, {
   open: {
     enumerable: true,
-    value: function (file, options) {
-      if (options === undefined)
-        options = {};
-
+    value: function (file, options = {}) {
       if (typeof file !== 'string' || (options === null || typeof options !== 'object'))
         throw new Error('invalid argument');
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -762,4 +762,43 @@ SourceMap.prototype.resolve = function (generatedPosition) {
   return {source, line, column, name};
 };
 
+const sqliteOpenFlags = {
+  readonly: 1,
+  readwrite: 2,
+  create: 4,
+};
+
+Object.defineProperties(SqliteDatabase, {
+  open: {
+    enumerable: true,
+    value: function (file, options) {
+      if (options === undefined)
+        options = {};
+
+      if (typeof file !== 'string' || (options === null || typeof options !== 'object'))
+        throw new Error('invalid argument');
+
+      const {
+        flags = ['readwrite', 'create'],
+      } = options;
+
+      if (!(flags instanceof Array) || flags.length === 0)
+        throw new Error('flags must be a non-empty array');
+
+      const flagsValue = flags.reduce((result, name) => {
+        const value = sqliteOpenFlags[name];
+        if (value === undefined)
+          throw new Error(`unknown flag: ${name}`);
+
+        return result | value;
+      }, 0);
+
+      if (flagsValue === 3 || flagsValue === 5 || flagsValue === 7)
+        throw new Error(`invalid flags combination: ${flags.join(' | ')}`);
+
+      return SqliteDatabase._open(file, flagsValue);
+    }
+  }
+});
+
 initialize();


### PR DESCRIPTION
Example: `SqliteDatabase.open(fileName, {flags: [‘readwrite’, ‘create’]})`

Possible flags are `readonly`, `readwrite`, `create`. The `create` flag can be combined only with `readwrite`. The default flags are `[‘readwrite’, ‘create’]`.