### PR TITLE
Use os.linesep instead of plain \n in generate-bindings

### DIFF
--- a/bindings/gumjs/generate-bindings.py
+++ b/bindings/gumjs/generate-bindings.py
@@ -2685,7 +2685,7 @@ def parse_api(name, flavor, api_header, options):
         if method_name in ignored_methods:
             continue
 
-        raw_args = [raw_arg.strip() for raw_arg in raw_arglist.replace("\n", " ").split(", ")]
+        raw_args = [raw_arg.strip() for raw_arg in raw_arglist.replace(os.linesep, " ").split(", ")]
         if raw_args[-1] == "...":
             continue
 


### PR DESCRIPTION
This is a fix for a Windows build issue (someone else reported it as [Frida issue 327](https://github.com/frida/frida/issues/327)) due to line endings somehow being converted into CRLF. `generate-bindings.py` only replaces `\n` in the argument list, so the `\r` is still left there. Using `os.linesep` *should* handle different cases, but I haven't tried building on Linux or macOS, so can't say for sure.

I suspect some Windows Git client is responsible for this. I use the posh-git setup provided with GitHub for Windows, which I think does CRLF<->LF conversion behind the scenes.