### PR TITLE
Expose ModuleMap values() method

### DIFF
--- a/bindings/gumjs/gumdukmodule.c
+++ b/bindings/gumjs/gumdukmodule.c
@@ -50,7 +50,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_module_map_find)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_find_name)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_find_path)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_update)
-GUMJS_DECLARE_FUNCTION (gumjs_module_map_get_modules)
+GUMJS_DECLARE_FUNCTION (gumjs_module_map_copy_values)
 
 static void gum_duk_module_filter_free (GumDukModuleFilter * filter);
 static gboolean gum_duk_module_filter_matches (const GumModuleDetails * details,
@@ -69,17 +69,6 @@ static const duk_function_list_entry gumjs_module_functions[] =
   { NULL, NULL, 0 }
 };
 
-static const GumDukPropertyEntry gumjs_module_map_values[] =
-{
-  {
-    "modules",
-    gumjs_module_map_get_modules,
-    NULL
-  },
-
-  { NULL, NULL, NULL }
-};
-
 static const duk_function_list_entry gumjs_module_map_functions[] =
 {
   { "has", gumjs_module_map_has, 1 },
@@ -87,6 +76,7 @@ static const duk_function_list_entry gumjs_module_map_functions[] =
   { "findName", gumjs_module_map_find_name, 1 },
   { "findPath", gumjs_module_map_find_path, 1 },
   { "update", gumjs_module_map_update, 0 },
+  { "values", gumjs_module_map_copy_values, 0 },
 
   { NULL, NULL, 0 }
 };
@@ -480,8 +470,6 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_module_map_construct)
 
   duk_push_this (ctx);
   _gum_duk_put_data (ctx, -1, module_map);
-  _gum_duk_add_properties_to_class_by_heapptr (ctx,
-      duk_require_heapptr (ctx, -1), gumjs_module_map_values);
   duk_pop (ctx);
 
   return 0;
@@ -585,20 +573,20 @@ GUMJS_DEFINE_FUNCTION (gumjs_module_map_update)
   return 0;
 }
 
-GUMJS_DEFINE_GETTER (gumjs_module_map_get_modules)
+GUMJS_DEFINE_FUNCTION (gumjs_module_map_copy_values)
 {
   GumModuleDetails * details;
   int i;
-  const GArray * modules;
   GumModuleMap * self;
+  const GArray * values;
 
   self = gumjs_module_map_from_args (args);
-  modules = gum_module_map_get_modules (self);
+  values = gum_module_map_get_values (self);
 
   duk_push_array (ctx);
-  for (i = 0; i != modules->len; i++)
+  for (i = 0; i != values->len; i++)
   {
-    details = &g_array_index (modules, GumModuleDetails, i);
+    details = &g_array_index (values, GumModuleDetails, i);
     _gum_duk_push_module (ctx, details, args->core);
     duk_put_prop_index (ctx, -2, i);
   }

--- a/bindings/gumjs/gumdukmodule.c
+++ b/bindings/gumjs/gumdukmodule.c
@@ -575,10 +575,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_module_map_update)
 
 GUMJS_DEFINE_FUNCTION (gumjs_module_map_copy_values)
 {
-  GumModuleDetails * details;
-  int i;
   GumModuleMap * self;
   const GArray * values;
+  guint i;
 
   self = gumjs_module_map_from_args (args);
   values = gum_module_map_get_values (self);
@@ -586,6 +585,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_module_map_copy_values)
   duk_push_array (ctx);
   for (i = 0; i != values->len; i++)
   {
+    GumModuleDetails * details;
+
     details = &g_array_index (values, GumModuleDetails, i);
     _gum_duk_push_module (ctx, details, args->core);
     duk_put_prop_index (ctx, -2, i);

--- a/bindings/gumjs/gumv8module.cpp
+++ b/bindings/gumjs/gumv8module.cpp
@@ -755,7 +755,7 @@ GUMJS_DEFINE_CLASS_METHOD (gumjs_module_map_copy_values, GumV8ModuleMap)
     auto module = Object::New (isolate);
     _gum_v8_object_set_ascii (module, "name", details->name, core);
     _gum_v8_object_set_pointer (module, "base", details->range->base_address,
-      core);
+        core);
     _gum_v8_object_set_uint (module, "size", details->range->size, core);
     _gum_v8_object_set_utf8 (module, "path", details->path, core);
     result->Set (i, module);

--- a/bindings/gumjs/gumv8module.cpp
+++ b/bindings/gumjs/gumv8module.cpp
@@ -99,7 +99,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_module_map_find)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_find_name)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_find_path)
 GUMJS_DECLARE_FUNCTION (gumjs_module_map_update)
-GUMJS_DECLARE_GETTER (gumjs_module_map_get_modules)
+GUMJS_DECLARE_FUNCTION (gumjs_module_map_copy_values)
 
 static GumV8ModuleMap * gum_v8_module_map_new (Handle<Object> wrapper,
     GumModuleMap * handle, GumV8Module * module);
@@ -124,17 +124,6 @@ static const GumV8Function gumjs_module_functions[] =
   { NULL, NULL }
 };
 
-static const GumV8Property gumjs_module_map_values[] =
-{
-  {
-    "modules",
-    gumjs_module_map_get_modules,
-    NULL
-  },
-
-  { NULL, NULL, NULL }
-};
-
 static const GumV8Function gumjs_module_map_functions[] =
 {
   { "has", gumjs_module_map_has },
@@ -142,6 +131,7 @@ static const GumV8Function gumjs_module_map_functions[] =
   { "findName", gumjs_module_map_find_name },
   { "findPath", gumjs_module_map_find_path },
   { "update", gumjs_module_map_update },
+  { "values", gumjs_module_map_copy_values },
 
   { NULL, NULL }
 };
@@ -163,7 +153,6 @@ _gum_v8_module_init (GumV8Module * self,
   auto map = _gum_v8_create_class ("ModuleMap", gumjs_module_map_construct,
       scope, module, isolate);
   _gum_v8_class_add (map, gumjs_module_map_functions, module, isolate);
-  _gum_v8_class_add (map, gumjs_module_map_values, module, isolate);
 }
 
 void
@@ -755,14 +744,14 @@ GUMJS_DEFINE_CLASS_METHOD (gumjs_module_map_update, GumV8ModuleMap)
   gum_module_map_update (self->handle);
 }
 
-GUMJS_DEFINE_CLASS_GETTER (gumjs_module_map_get_modules, GumV8ModuleMap)
+GUMJS_DEFINE_CLASS_METHOD (gumjs_module_map_copy_values, GumV8ModuleMap)
 {
-  auto modules = gum_module_map_get_modules (self->handle);
-  auto result = Array::New (isolate, modules->len);
+  auto values = gum_module_map_get_values (self->handle);
+  auto result = Array::New (isolate, values->len);
 
-  for (guint i = 0; i != modules->len; i++)
+  for (guint i = 0; i != values->len; i++)
   {
-    auto details = &g_array_index (modules, GumModuleDetails, i);
+    auto details = &g_array_index (values, GumModuleDetails, i);
     auto module = Object::New (isolate);
     _gum_v8_object_set_ascii (module, "name", details->name, core);
     _gum_v8_object_set_pointer (module, "base", details->range->base_address,

--- a/gum/gummodulemap.c
+++ b/gum/gummodulemap.c
@@ -121,7 +121,7 @@ gum_module_map_update (GumModuleMap * self)
 }
 
 const GArray *
-gum_module_map_get_modules (GumModuleMap * self)
+gum_module_map_get_values (GumModuleMap * self)
 {
     return self->modules;
 }

--- a/gum/gummodulemap.c
+++ b/gum/gummodulemap.c
@@ -120,10 +120,10 @@ gum_module_map_update (GumModuleMap * self)
   g_array_sort (self->modules, (GCompareFunc) gum_module_details_compare_base);
 }
 
-const GArray *
+GArray *
 gum_module_map_get_values (GumModuleMap * self)
 {
-    return self->modules;
+  return self->modules;
 }
 
 static void

--- a/gum/gummodulemap.c
+++ b/gum/gummodulemap.c
@@ -120,6 +120,12 @@ gum_module_map_update (GumModuleMap * self)
   g_array_sort (self->modules, (GCompareFunc) gum_module_details_compare_base);
 }
 
+const GArray *
+gum_module_map_get_modules (GumModuleMap * self)
+{
+    return self->modules;
+}
+
 static void
 gum_module_map_clear (GumModuleMap * self)
 {

--- a/gum/gummodulemap.h
+++ b/gum/gummodulemap.h
@@ -27,7 +27,7 @@ GUM_API const GumModuleDetails * gum_module_map_find (GumModuleMap * self,
 
 GUM_API void gum_module_map_update (GumModuleMap * self);
 
-GUM_API const GArray * gum_module_map_get_values (GumModuleMap * self);
+GUM_API GArray * gum_module_map_get_values (GumModuleMap * self);
 
 G_END_DECLS
 

--- a/gum/gummodulemap.h
+++ b/gum/gummodulemap.h
@@ -27,7 +27,7 @@ GUM_API const GumModuleDetails * gum_module_map_find (GumModuleMap * self,
 
 GUM_API void gum_module_map_update (GumModuleMap * self);
 
-GUM_API const GArray * gum_module_map_get_modules (GumModuleMap * self);
+GUM_API const GArray * gum_module_map_get_values (GumModuleMap * self);
 
 G_END_DECLS
 

--- a/gum/gummodulemap.h
+++ b/gum/gummodulemap.h
@@ -27,6 +27,8 @@ GUM_API const GumModuleDetails * gum_module_map_find (GumModuleMap * self,
 
 GUM_API void gum_module_map_update (GumModuleMap * self);
 
+GUM_API const GArray * gum_module_map_get_modules (GumModuleMap * self);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
It returns a copy of the current internal `modules` array. Example:

```
var mm = new ModuleMap();
mm.values(); // get a copy of current modules array
```
  