### PR TITLE
improve x86_writer calls generation

### DIFF
--- a/gum/arch-x86/gumx86writer.c
+++ b/gum/arch-x86/gumx86writer.c
@@ -47,7 +47,8 @@ struct _GumCpuRegInfo
 enum _GumX86LabelRefSize
 {
   GUM_LREF_SHORT,
-  GUM_LREF_NEAR
+  GUM_LREF_NEAR,
+  GUM_LREF_ABS
 };
 
 struct _GumX86LabelRef
@@ -218,9 +219,24 @@ gum_x86_writer_flush (GumX86Writer * self)
         goto error;
       *((gint8 *) (r->address - 1)) = distance;
     }
-    else
+    else if (r->size == GUM_LREF_NEAR)
     {
       *((gint32 *) (r->address - 4)) = GINT32_TO_LE (distance);
+    }
+    else if (r->size == GUM_LREF_ABS)
+    {
+      if (self->target_cpu == GUM_CPU_AMD64)
+      {
+        guint64 uint_addr = GUM_ADDRESS (target_address);
+        *((guint64 *) (r->address - 8)) = GUINT64_TO_LE (uint_addr);
+      }
+      else
+        *((guint32 *) (r->address - 4)) =
+            GUINT32_TO_LE (GUM_ADDRESS (target_address));
+    }
+    else
+    {
+        g_assert_not_reached();
     }
   }
   g_array_set_size (self->label_refs, 0);
@@ -784,11 +800,22 @@ gum_x86_writer_put_call_address (GumX86Writer * self,
   }
   else
   {
+    gpointer label_jmp, label_addr;
+
     if (self->target_cpu != GUM_CPU_AMD64)
       return FALSE;
 
-    gum_x86_writer_put_mov_reg_u64 (self, GUM_REG_RAX, address);
-    gum_x86_writer_put_call_reg (self, GUM_REG_RAX);
+    label_jmp = self->code + 1;
+    label_addr = self->code + 2;
+
+    gum_x86_writer_put_jmp_short_label (self, label_jmp);
+
+    gum_x86_writer_put_label (self, label_addr);
+    *((guint64 *) (self->code)) = GUINT64_TO_LE (address);
+    gum_x86_writer_commit (self, 8);
+
+    gum_x86_writer_put_label (self, label_jmp);
+    gum_x86_writer_put_call_indirect_label (self, label_addr);
   }
 
   return TRUE;
@@ -868,14 +895,43 @@ gum_x86_writer_put_call_reg_offset_ptr (GumX86Writer * self,
   return TRUE;
 }
 
-void
+gboolean
 gum_x86_writer_put_call_indirect (GumX86Writer * self,
-                                  gconstpointer * addr)
+                                  GumAddress address)
 {
-  self->code[0] = 0xff;
-  self->code[1] = 0x15;
-  *((guint32 *) (self->code + 2)) = GUINT32_TO_LE (GUM_ADDRESS (addr));
-  gum_x86_writer_commit (self, 6);
+  if (self->target_cpu == GUM_CPU_AMD64)
+  {
+    gint64 distance = (gssize) address - (gssize) (self->pc + 6);
+
+    if (! GUM_IS_WITHIN_INT32_RANGE (distance))
+      return false;
+
+    self->code[0] = 0xff;
+    self->code[1] = 0x15;
+    *((guint32 *) (self->code + 2)) = GINT32_TO_LE ((gint32) distance);
+    gum_x86_writer_commit (self, 6);
+  }
+  else
+  {
+    self->code[0] = 0xff;
+    self->code[1] = 0x15;
+    *((guint32 *) (self->code + 2)) = GUINT32_TO_LE (address);
+    gum_x86_writer_commit (self, 6);
+  }
+  return true;
+}
+
+gboolean
+gum_x86_writer_put_call_indirect_label (GumX86Writer * self,
+                                        gconstpointer label_id)
+{
+  if (! gum_x86_writer_put_call_indirect(self, self->pc))
+    return false;
+  if (self->target_cpu == GUM_CPU_AMD64)
+    gum_x86_writer_add_label_reference_here (self, label_id, GUM_LREF_NEAR);
+  else
+    gum_x86_writer_add_label_reference_here (self, label_id, GUM_LREF_ABS);
+  return true;
 }
 
 void

--- a/gum/arch-x86/gumx86writer.h
+++ b/gum/arch-x86/gumx86writer.h
@@ -162,8 +162,10 @@ GUM_API gboolean gum_x86_writer_put_call_reg (GumX86Writer * self,
     GumCpuReg reg);
 GUM_API gboolean gum_x86_writer_put_call_reg_offset_ptr (GumX86Writer * self,
     GumCpuReg reg, gssize offset);
-GUM_API void gum_x86_writer_put_call_indirect (GumX86Writer * self,
-    gconstpointer * addr);
+GUM_API gboolean gum_x86_writer_put_call_indirect (GumX86Writer * self,
+    GumAddress addr);
+GUM_API gboolean gum_x86_writer_put_call_indirect_label (GumX86Writer * self,
+    gconstpointer label_id);
 GUM_API void gum_x86_writer_put_call_near_label (GumX86Writer * self,
     gconstpointer label_id);
 GUM_API void gum_x86_writer_put_leave (GumX86Writer * self);

--- a/tests/core/arch-x86/codewriter.c
+++ b/tests/core/arch-x86/codewriter.c
@@ -9,6 +9,8 @@
 TEST_LIST_BEGIN (codewriter)
   CODEWRITER_TESTENTRY (jump_label)
   CODEWRITER_TESTENTRY (call_label)
+  CODEWRITER_TESTENTRY (call_indirect)
+  CODEWRITER_TESTENTRY (call_indirect_label)
   CODEWRITER_TESTENTRY (call_capi_eax_with_xdi_argument_for_ia32)
   CODEWRITER_TESTENTRY (call_capi_xbx_plus_i8_offset_ptr_with_xcx_argument_for_ia32)
   CODEWRITER_TESTENTRY (call_capi_xbx_plus_i8_offset_ptr_with_xcx_argument_for_amd64)
@@ -135,6 +137,63 @@ CODEWRITER_TESTCASE (call_label)
   gum_x86_writer_put_ret (&fixture->cw);
 
   assert_output_equals (expected_code);
+}
+
+CODEWRITER_TESTCASE (call_indirect)
+{
+  const guint8 expected_ia32_code[] = {
+    0xff, 0x15, 0x78, 0x56, 0x34, 0x12 /* call [0x12345678] */
+  };
+  const guint8 expected_amd64_code[] = {
+    0xff, 0x15, 0x78, 0x56, 0x34, 0x12 /* call [rip + 6 + 0x12345678] */
+  };
+
+  gum_x86_writer_set_target_cpu (&fixture->cw, GUM_CPU_IA32);
+  gum_x86_writer_put_call_indirect (&fixture->cw, 0x12345678);
+  assert_output_equals (expected_ia32_code);
+
+  gum_x86_writer_reset (&fixture->cw, fixture->output);
+
+  gum_x86_writer_set_target_cpu (&fixture->cw, GUM_CPU_AMD64);
+  g_assert_false (gum_x86_writer_put_call_indirect (&fixture->cw,
+      GUM_ADDRESS (fixture->output) + 0x7FFFFFFFUL + 6 + 1));
+
+  gum_x86_writer_reset (&fixture->cw, fixture->output);
+
+  gum_x86_writer_put_call_indirect (&fixture->cw,
+      GUM_ADDRESS (fixture->output) + 0x12345678 + 6);
+  assert_output_equals (expected_amd64_code);
+}
+
+CODEWRITER_TESTCASE (call_indirect_label)
+{
+  const gchar * addr_lbl = "label";
+  const guint8 expected_amd64_code[] = {
+    0xff, 0x15, 0x01, 0x00, 0x00, 0x00, /* call [rip + label_delta] */
+    0xc3,                               /* retn                     */
+  /* label: */
+  };
+  guint8 expected_ia32_code[] = {
+    0xff, 0x15, 0x78, 0x56, 0x34, 0x12, /* call [label] */
+    0xc3,                               /* retn         */
+  /* label: */
+  };
+  *(guint32 *)&expected_ia32_code[2] =
+      (guint32)GUM_ADDRESS (fixture->output) + 7;
+
+  gum_x86_writer_set_target_cpu (&fixture->cw, GUM_CPU_AMD64);
+  gum_x86_writer_put_call_indirect_label (&fixture->cw, addr_lbl);
+  gum_x86_writer_put_ret (&fixture->cw);
+  gum_x86_writer_put_label (&fixture->cw, addr_lbl);
+  assert_output_equals (expected_amd64_code);
+
+  gum_x86_writer_reset (&fixture->cw, fixture->output);
+
+  gum_x86_writer_set_target_cpu (&fixture->cw, GUM_CPU_IA32);
+  gum_x86_writer_put_call_indirect_label (&fixture->cw, addr_lbl);
+  gum_x86_writer_put_ret (&fixture->cw);
+  gum_x86_writer_put_label (&fixture->cw, addr_lbl);
+  assert_output_equals (expected_ia32_code);
 }
 
 CODEWRITER_TESTCASE (call_capi_eax_with_xdi_argument_for_ia32)


### PR DESCRIPTION
indirect calls were not correctly generated for AMD64, I also added the possibility to make indirect calls with labels and used this last feature to fix calls to 64bits addresses that previously trashed rax.