### PR TITLE
Expose import offset for i/macOS

### DIFF
--- a/bindings/gumjs/gumdukmodule.c
+++ b/bindings/gumjs/gumdukmodule.c
@@ -199,6 +199,13 @@ gum_emit_import (const GumImportDetails * details,
     duk_put_prop_string (ctx, -2, "address");
   }
 
+  if (details->offset != 0)
+  {
+    _gum_duk_push_native_pointer (ctx, GSIZE_TO_POINTER (details->offset),
+        scope->core);
+    duk_put_prop_string (ctx, -2, "offset");
+  }
+
   if (_gum_duk_scope_call_sync (scope, 1))
   {
     if (duk_is_string (ctx, -1))

--- a/bindings/gumjs/gumv8module.cpp
+++ b/bindings/gumjs/gumv8module.cpp
@@ -26,6 +26,7 @@ struct GumV8ImportsContext
   Local<String> name;
   Local<String> module;
   Local<String> address;
+  Local<String> offset;
   Local<String> variable;
 
   GumV8Core * core;
@@ -172,6 +173,8 @@ _gum_v8_module_realize (GumV8Module * self)
   self->module_key = new GumPersistent<String>::type (isolate, module_key);
   auto address_key = _gum_v8_string_new_ascii (isolate, "address");
   self->address_key = new GumPersistent<String>::type (isolate, address_key);
+  auto offset_key = _gum_v8_string_new_ascii (isolate, "offset");
+  self->offset_key = new GumPersistent<String>::type (isolate, offset_key);
 
   auto function_value = _gum_v8_string_new_ascii (isolate, "function");
   auto variable_value = _gum_v8_string_new_ascii (isolate, "variable");
@@ -212,11 +215,13 @@ _gum_v8_module_dispose (GumV8Module * self)
   delete self->name_key;
   delete self->module_key;
   delete self->address_key;
+  delete self->offset_key;
   delete self->variable_value;
   self->type_key = nullptr;
   self->name_key = nullptr;
   self->module_key = nullptr;
   self->address_key = nullptr;
+  self->offset_key = nullptr;
   self->variable_value = nullptr;
 }
 
@@ -275,6 +280,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_module_enumerate_imports)
   ic.name = Local<String>::New (isolate, *module->name_key);
   ic.module = Local<String>::New (isolate, *module->module_key);
   ic.address = Local<String>::New (isolate, *module->address_key);
+  ic.offset = Local<String>::New (isolate, *module->offset_key);
   ic.variable = Local<String>::New (isolate, *module->variable_value);
 
   ic.core = core;
@@ -351,6 +357,17 @@ gum_emit_import (const GumImportDetails * details,
   else
   {
     imp->Delete (context, ic->address).FromJust ();
+  }
+
+  if (details->offset != 0)
+  {
+    imp->ForceSet (context, ic->offset,
+        _gum_v8_native_pointer_new (GSIZE_TO_POINTER (details->offset), core),
+        attrs).FromJust ();
+  }
+  else
+  {
+    imp->Delete (context, ic->offset).FromJust ();
   }
 
   Handle<Value> argv[] = { imp };

--- a/bindings/gumjs/gumv8module.h
+++ b/bindings/gumjs/gumv8module.h
@@ -22,6 +22,7 @@ struct GumV8Module
   GumPersistent<v8::String>::type * name_key;
   GumPersistent<v8::String>::type * module_key;
   GumPersistent<v8::String>::type * address_key;
+  GumPersistent<v8::String>::type * offset_key;
   GumPersistent<v8::String>::type * variable_value;
 };
 

--- a/gum/backend-darwin/gumdarwinmodule.c
+++ b/gum/backend-darwin/gumdarwinmodule.c
@@ -532,6 +532,16 @@ gum_emit_import (const GumDarwinBindDetails * details,
   }
   d.address = 0;
 
+  if (details->segment != NULL)
+  {
+    d.offset = details->offset + details->segment->vm_address +
+        gum_darwin_module_slide (ctx->module);
+  }
+  else
+  {
+    d.offset = 0;
+  }
+
   key = g_strconcat (
       (d.module != NULL) ? d.module : "",
       "|",

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1557,6 +1557,7 @@ gum_emit_import (const GumImportDetails * details,
   d.name = gum_symbol_name_from_darwin (details->name);
   d.module = details->module;
   d.address = 0;
+  d.offset = details->offset;
 
   if (d.module == NULL)
   {

--- a/gum/backend-elf/gumelfmodule.c
+++ b/gum/backend-elf/gumelfmodule.c
@@ -329,6 +329,7 @@ gum_emit_elf_import (const GumElfSymbolDetails * details,
     d.name = details->name;
     d.module = NULL;
     d.address = 0;
+    d.offset = 0; /* TODO */
 
     if (!ctx->func (&d, ctx->user_data))
       return FALSE;

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1191,6 +1191,7 @@ gum_emit_import (const GumImportDetails * details,
 
   d.type = details->type;
   d.name = details->name;
+  d.offset = details->offset;
 
   exp = g_hash_table_lookup (ctx->dependency_exports, details->name);
   if (exp != NULL)

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -479,6 +479,7 @@ gum_module_enumerate_imports (const gchar * module_name,
     details.name = NULL;
     details.module = (const gchar *) (mod_base + desc->Name);
     details.address = 0;
+    details.offset = 0; /* TODO */
 
     thunk_data = (const IMAGE_THUNK_DATA *)
         (mod_base + desc->OriginalFirstThunk);

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -95,6 +95,7 @@ struct _GumImportDetails
   const gchar * name;
   const gchar * module;
   GumAddress address;
+  GumAddress offset;
 };
 
 struct _GumExportDetails


### PR DESCRIPTION
The offset is the address (in the module which imports the symbol) where it gets bound.

Initialized in darwin backend for now, for other architectures is set to 0 (not shown in javascript).