### PR TITLE
Add gum_query_page_allocation_range

### DIFF
--- a/gum/backend-darwin/gumcodesegment-darwin.c
+++ b/gum/backend-darwin/gumcodesegment-darwin.c
@@ -176,7 +176,8 @@ gum_code_segment_new (gsize size,
 
   segment->fd = -1;
 
-  gum_query_page_allocation_range (segment->data, segment->virtual_size, &range);
+  gum_query_page_allocation_range (segment->data, segment->virtual_size,
+      &range);
   gum_cloak_add_range (&range);
 
   return segment;
@@ -192,7 +193,8 @@ gum_code_segment_free (GumCodeSegment * segment)
 
   gum_free_pages (segment->data);
 
-  gum_query_page_allocation_range (segment->data, segment->virtual_size, &range);
+  gum_query_page_allocation_range (segment->data, segment->virtual_size,
+      &range);
   gum_cloak_remove_range (&range);
 
   g_slice_free (GumCodeSegment, segment);

--- a/gum/backend-darwin/gumcodesegment-darwin.c
+++ b/gum/backend-darwin/gumcodesegment-darwin.c
@@ -176,8 +176,7 @@ gum_code_segment_new (gsize size,
 
   segment->fd = -1;
 
-  range.base_address = GUM_ADDRESS (segment->data) - page_size;
-  range.size = segment->virtual_size + page_size;
+  gum_query_page_allocation_range (segment->data, segment->virtual_size, &range);
   gum_cloak_add_range (&range);
 
   return segment;
@@ -186,7 +185,6 @@ gum_code_segment_new (gsize size,
 void
 gum_code_segment_free (GumCodeSegment * segment)
 {
-  guint page_size;
   GumMemoryRange range;
 
   if (segment->fd != -1)
@@ -194,10 +192,7 @@ gum_code_segment_free (GumCodeSegment * segment)
 
   gum_free_pages (segment->data);
 
-  page_size = gum_query_page_size ();
-
-  range.base_address = GUM_ADDRESS (segment->data) - page_size;
-  range.size = segment->virtual_size + page_size;
+  gum_query_page_allocation_range (segment->data, segment->virtual_size, &range);
   gum_cloak_remove_range (&range);
 
   g_slice_free (GumCodeSegment, segment);

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -522,6 +522,16 @@ gum_try_alloc_in_range_if_near_enough (const GumMemoryRange * range,
 }
 
 void
+gum_query_page_allocation_range (gconstpointer mem, guint size,
+                                 GumMemoryRange * range)
+{
+  gsize page_size = gum_query_page_size ();
+
+  range->base_address = GUM_ADDRESS (mem - page_size);
+  range->size = size + page_size;
+}
+
+void
 gum_free_pages (gpointer mem)
 {
   gsize page_size;

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -522,7 +522,8 @@ gum_try_alloc_in_range_if_near_enough (const GumMemoryRange * range,
 }
 
 void
-gum_query_page_allocation_range (gconstpointer mem, guint size,
+gum_query_page_allocation_range (gconstpointer mem,
+                                 guint size,
                                  GumMemoryRange * range)
 {
   gsize page_size = gum_query_page_size ();

--- a/gum/backend-posix/gummemory-posix.c
+++ b/gum/backend-posix/gummemory-posix.c
@@ -146,7 +146,8 @@ gum_try_alloc_in_range_if_near_enough (const GumRangeDetails * details,
 }
 
 void
-gum_query_page_allocation_range (gconstpointer mem, guint size,
+gum_query_page_allocation_range (gconstpointer mem,
+                                 guint size,
                                  GumMemoryRange * range)
 {
   gsize page_size = gum_query_page_size ();

--- a/gum/backend-posix/gummemory-posix.c
+++ b/gum/backend-posix/gummemory-posix.c
@@ -146,6 +146,16 @@ gum_try_alloc_in_range_if_near_enough (const GumRangeDetails * details,
 }
 
 void
+gum_query_page_allocation_range (gconstpointer mem, guint size,
+                                 GumMemoryRange * range)
+{
+  gsize page_size = gum_query_page_size ();
+
+  range->base_address = GUM_ADDRESS (mem - page_size);
+  range->size = size + page_size;
+}
+
+void
 gum_free_pages (gpointer mem)
 {
   guint8 * start;

--- a/gum/backend-windows/gummemory-windows.c
+++ b/gum/backend-windows/gummemory-windows.c
@@ -235,6 +235,14 @@ gum_try_alloc_n_pages_near (guint n_pages,
 }
 
 void
+gum_query_page_allocation_range (gconstpointer mem, guint size,
+                                 GumMemoryRange * range)
+{
+  range->base_address = GUM_ADDRESS (mem);
+  range->size = size;
+}
+
+void
 gum_free_pages (gpointer mem)
 {
   BOOL success;

--- a/gum/backend-windows/gummemory-windows.c
+++ b/gum/backend-windows/gummemory-windows.c
@@ -235,7 +235,8 @@ gum_try_alloc_n_pages_near (guint n_pages,
 }
 
 void
-gum_query_page_allocation_range (gconstpointer mem, guint size,
+gum_query_page_allocation_range (gconstpointer mem,
+                                 guint size,
                                  GumMemoryRange * range)
 {
   range->base_address = GUM_ADDRESS (mem);

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -314,7 +314,8 @@ gum_on_thread_realize (void)
       gum_thread_try_get_range (&details->cloaked_range);
 
   gum_cloak_add_thread (details->thread_id);
-  gum_cloak_add_range (&details->cloaked_range);
+  if (details->has_cloaked_range)
+    gum_cloak_add_range (&details->cloaked_range);
 
   /* This allows us to free the data no matter how the thread exits */
   g_private_set (&gum_internal_thread_details_key, details);

--- a/gum/gumcodeallocator.c
+++ b/gum/gumcodeallocator.c
@@ -275,8 +275,7 @@ gum_code_allocator_try_alloc_batch_near (GumCodeAllocator * self,
       data = gum_alloc_n_pages (size_in_pages, protection);
     }
 
-    range.base_address = GUM_ADDRESS (data) - page_size;
-    range.size = size_in_bytes + page_size;
+    gum_query_page_allocation_range (data, size_in_bytes, &range);
     gum_cloak_add_range (&range);
   }
   else
@@ -344,15 +343,11 @@ gum_code_pages_unref (GumCodePages * self)
     }
     else
     {
-      gsize page_size;
       GumMemoryRange range;
 
       gum_free_pages (self->data);
 
-      page_size = gum_query_page_size ();
-
-      range.base_address = GUM_ADDRESS (self->data) - page_size;
-      range.size = self->size + page_size;
+      gum_query_page_allocation_range (self->data, self->size, &range);
       gum_cloak_remove_range (&range);
     }
 

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -109,6 +109,8 @@ GUM_API gpointer gum_alloc_n_pages_near (guint n_pages,
     GumPageProtection page_prot, const GumAddressSpec * address_spec);
 GUM_API gpointer gum_try_alloc_n_pages_near (guint n_pages,
     GumPageProtection page_prot, const GumAddressSpec * address_spec);
+GUM_API void gum_query_page_allocation_range (gconstpointer mem, guint size,
+    GumMemoryRange * range);
 GUM_API void gum_free_pages (gpointer mem);
 
 GUM_API gpointer gum_memory_allocate (gsize size, GumPageProtection page_prot,

--- a/gum/gummetalarray.c
+++ b/gum/gummetalarray.c
@@ -11,6 +11,8 @@
 
 #include <string.h>
 
+static guint gum_round_page (guint size);
+
 void
 gum_metal_array_init (GumMetalArray * array,
                       guint element_size)
@@ -85,14 +87,22 @@ gum_metal_array_get_extents (GumMetalArray * self,
                              gpointer * end)
 {
   GumMemoryRange range;
-  uint size;
+  guint size;
 
-  size = (guint) (gum_metal_array_element_at (self, self->capacity)
-      - self->data);
-  gum_query_page_allocation_range (self->data, size, &range);
+  size = (guint) (gum_metal_array_element_at (self, self->capacity) -
+      self->data);
+  gum_query_page_allocation_range (self->data, gum_round_page(size), &range);
 
   *start = (gpointer) range.base_address;
   *end = (gpointer) (range.base_address + range.size);
+}
+
+static guint
+gum_round_page (guint size)
+{
+  guint page_mask = gum_query_page_size () - 1;
+
+  return (size + page_mask) & ~page_mask;
 }
 
 void

--- a/gum/gummetalarray.c
+++ b/gum/gummetalarray.c
@@ -91,8 +91,8 @@ gum_metal_array_get_extents (GumMetalArray * self,
 
   size = (guint) (gum_metal_array_element_at (self, self->capacity) -
       self->data);
-  gum_query_page_allocation_range (self->data,
-      gum_round_up_to_page_size (size), &range);
+  gum_query_page_allocation_range (self->data, gum_round_up_to_page_size (size),
+      &range);
 
   *start = (gpointer) range.base_address;
   *end = (gpointer) (range.base_address + range.size);

--- a/gum/gummetalarray.c
+++ b/gum/gummetalarray.c
@@ -11,7 +11,7 @@
 
 #include <string.h>
 
-static guint gum_round_page (guint size);
+static guint gum_round_up_to_page_size (guint size);
 
 void
 gum_metal_array_init (GumMetalArray * array,
@@ -91,18 +91,11 @@ gum_metal_array_get_extents (GumMetalArray * self,
 
   size = (guint) (gum_metal_array_element_at (self, self->capacity) -
       self->data);
-  gum_query_page_allocation_range (self->data, gum_round_page(size), &range);
+  gum_query_page_allocation_range (self->data,
+      gum_round_up_to_page_size (size), &range);
 
   *start = (gpointer) range.base_address;
   *end = (gpointer) (range.base_address + range.size);
-}
-
-static guint
-gum_round_page (guint size)
-{
-  guint page_mask = gum_query_page_size () - 1;
-
-  return (size + page_mask) & ~page_mask;
 }
 
 void
@@ -127,4 +120,12 @@ gum_metal_array_ensure_capacity (GumMetalArray * self,
   gum_free_pages (self->data);
   self->data = new_data;
   self->capacity = (size_in_pages * page_size) / self->element_size;
+}
+
+static guint
+gum_round_up_to_page_size (guint size)
+{
+  guint page_mask = gum_query_page_size () - 1;
+
+  return (size + page_mask) & ~page_mask;
 }

--- a/gum/gummetalarray.c
+++ b/gum/gummetalarray.c
@@ -84,8 +84,15 @@ gum_metal_array_get_extents (GumMetalArray * self,
                              gpointer * start,
                              gpointer * end)
 {
-  *start = self->data;
-  *end = gum_metal_array_element_at (self, self->capacity);
+  GumMemoryRange range;
+  uint size;
+
+  size = (guint) (gum_metal_array_element_at (self, self->capacity)
+      - self->data);
+  gum_query_page_allocation_range (self->data, size, &range);
+
+  *start = (gpointer) range.base_address;
+  *end = (gpointer) (range.base_address + range.size);
 }
 
 void


### PR DESCRIPTION
This should be used to get the full extent of ranges allocated using `gum_alloc_n_pages` including the overhead (mostly useful for cloaking). This is implemented in the various backends.