### PR TITLE
Potentially cloak more than one range for threads

### DIFF
--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -510,20 +510,19 @@ gum_read_malloc_memory (task_t remote_task,
 }
 
 guint
-gum_thread_try_get_ranges (GumMemoryRange ranges[],
+gum_thread_try_get_ranges (GumMemoryRange * ranges,
                            guint max_length)
 {
   pthread_t thread;
   uint64_t thread_id, real_thread_id;
-  size_t skew = 0;
+  size_t skew;
   GumMemoryRange * range;
   GumAddress stack_addr;
   size_t guard_size, stack_size;
   GumAddress stack_base;
 
-  if (max_length == 0) {
+  if (max_length == 0)
     return 0;
-  }
 
   range = &ranges[0];
 
@@ -532,17 +531,16 @@ gum_thread_try_get_ranges (GumMemoryRange ranges[],
   thread_id = GUM_PTHREAD_GET_FIELD (thread,
       GUM_PTHREAD_FIELD_THREADID, uint64_t);
   pthread_threadid_np (thread, &real_thread_id);
-  if (thread_id != real_thread_id)
-    skew = 8;
+
+  skew = (thread_id == real_thread_id) ? 0 : 8;
 
   range->base_address = GUM_ADDRESS (GUM_PTHREAD_GET_FIELD (thread,
       GUM_PTHREAD_FIELD_FREEADDR + skew, void *));
   range->size = GUM_PTHREAD_GET_FIELD (thread,
       GUM_PTHREAD_FIELD_FREESIZE + skew, size_t);
 
-  if (max_length == 1) {
+  if (max_length == 1)
     return 1;
-  }
 
   stack_addr = GUM_ADDRESS (GUM_PTHREAD_GET_FIELD (thread,
       GUM_PTHREAD_FIELD_STACKADDR + skew, void *));

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -37,8 +37,8 @@
 #define GUM_PTHREAD_FIELD_FREESIZE ((GLIB_SIZEOF_VOID_P == 8) ? 0xc8 : 0x94)
 #define GUM_PTHREAD_FIELD_GUARDSIZE ((GLIB_SIZEOF_VOID_P == 8) ? 0xd0 : 0x98)
 #define GUM_PTHREAD_FIELD_THREADID ((GLIB_SIZEOF_VOID_P == 8) ? 0xd8 : 0xa0)
-#define GUM_PTHREAD_GET_FIELD(thread, field, type)\
-    (* ((type *) ((char *) thread + field)))
+#define GUM_PTHREAD_GET_FIELD(thread, field, type) \
+    (*((type *) ((guint8 *) thread + field)))
 
 typedef struct _GumEnumerateImportsContext GumEnumerateImportsContext;
 typedef struct _GumEnumerateExportsContext GumEnumerateExportsContext;
@@ -515,7 +515,7 @@ gum_thread_try_get_ranges (GumMemoryRange * ranges,
 {
   pthread_t thread;
   uint64_t thread_id, real_thread_id;
-  size_t skew;
+  guint skew;
   GumMemoryRange * range;
   GumAddress stack_addr;
   size_t guard_size, stack_size;

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -31,6 +31,14 @@
 #define DYLD_IMAGE_INFO_64_SIZE 24
 #define GUM_THREAD_POLL_STEP 1000
 #define GUM_MAX_THREAD_POLL (20000000 / GUM_THREAD_POLL_STEP)
+#define GUM_PTHREAD_FIELD_STACKADDR ((GLIB_SIZEOF_VOID_P == 8) ? 0xb0 : 0x88)
+#define GUM_PTHREAD_FIELD_STACKSIZE ((GLIB_SIZEOF_VOID_P == 8) ? 0xb8 : 0x8c)
+#define GUM_PTHREAD_FIELD_FREEADDR ((GLIB_SIZEOF_VOID_P == 8) ? 0xc0 : 0x90)
+#define GUM_PTHREAD_FIELD_FREESIZE ((GLIB_SIZEOF_VOID_P == 8) ? 0xc8 : 0x94)
+#define GUM_PTHREAD_FIELD_GUARDSIZE ((GLIB_SIZEOF_VOID_P == 8) ? 0xd0 : 0x98)
+#define GUM_PTHREAD_FIELD_THREADID ((GLIB_SIZEOF_VOID_P == 8) ? 0xd8 : 0xa0)
+#define GUM_PTHREAD_GET_FIELD(thread, field, type)\
+    (* ((type *) ((char *) thread + field)))
 
 typedef struct _GumEnumerateImportsContext GumEnumerateImportsContext;
 typedef struct _GumEnumerateExportsContext GumEnumerateExportsContext;
@@ -501,23 +509,59 @@ gum_read_malloc_memory (task_t remote_task,
   return KERN_SUCCESS;
 }
 
-gboolean
-gum_thread_try_get_range (GumMemoryRange * range)
+guint
+gum_thread_try_get_ranges (GumMemoryRange ranges[],
+                           guint max_length)
 {
   pthread_t thread;
-  gpointer stack_top;
-  gsize stack_size, guard_size;
+  uint64_t thread_id, real_thread_id;
+  size_t skew = 0;
+  GumMemoryRange * range;
+  GumAddress stack_addr;
+  size_t guard_size, stack_size;
+  GumAddress stack_base;
+
+  if (max_length == 0) {
+    return 0;
+  }
+
+  range = &ranges[0];
 
   thread = pthread_self ();
 
-  stack_top = pthread_get_stackaddr_np (thread);
-  stack_size = pthread_get_stacksize_np (thread);
-  guard_size = gum_query_page_size ();
+  thread_id = GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_THREADID, uint64_t);
+  pthread_threadid_np (thread, &real_thread_id);
+  if (thread_id != real_thread_id)
+    skew = 8;
 
-  range->base_address = GUM_ADDRESS (stack_top) - stack_size - guard_size;
-  range->size = stack_size + guard_size;
+  range->base_address = GUM_ADDRESS (GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_FREEADDR + skew, void *));
+  range->size = GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_FREESIZE + skew, size_t);
 
-  return TRUE;
+  if (max_length == 1) {
+    return 1;
+  }
+
+  stack_addr = GUM_ADDRESS (GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_STACKADDR + skew, void *));
+  stack_size = GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_STACKSIZE + skew, size_t);
+  guard_size = GUM_PTHREAD_GET_FIELD (thread,
+      GUM_PTHREAD_FIELD_GUARDSIZE + skew, size_t);
+
+  stack_base = stack_addr - stack_size - guard_size;
+
+  if (stack_base == range->base_address)
+    return 1;
+
+  range = &ranges[1];
+
+  range->base_address = stack_base;
+  range->size = stack_addr - stack_base;
+
+  return 2;
 }
 
 gint

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1102,7 +1102,7 @@ gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
 }
 
 guint
-gum_thread_try_get_ranges (GumMemoryRange ranges[],
+gum_thread_try_get_ranges (GumMemoryRange * ranges,
                            guint max_length)
 {
   /* Not implemented */

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1101,14 +1101,12 @@ gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
   /* Not implemented */
 }
 
-gboolean
-gum_thread_try_get_range (GumMemoryRange * range)
+guint
+gum_thread_try_get_ranges (GumMemoryRange ranges[],
+                           guint max_length)
 {
   /* Not implemented */
-  range->base_address = 0;
-  range->size = 0;
-
-  return FALSE;
+  return 0;
 }
 
 gint

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -268,7 +268,7 @@ gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
 }
 
 guint
-gum_thread_try_get_ranges (GumMemoryRange ranges[],
+gum_thread_try_get_ranges (GumMemoryRange * ranges,
                            guint max_length)
 {
   /* Not implemented */

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -267,14 +267,12 @@ gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
   g_assert_not_reached ();
 }
 
-gboolean
-gum_thread_try_get_range (GumMemoryRange * range)
+guint
+gum_thread_try_get_ranges (GumMemoryRange ranges[],
+                           guint max_length)
 {
   /* Not implemented */
-  range->base_address = 0;
-  range->size = 0;
-
-  return FALSE;
+  return 0;
 }
 
 gint

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -375,14 +375,12 @@ gum_process_enumerate_heap_ranges (HANDLE heap,
   return carry_on;
 }
 
-gboolean
-gum_thread_try_get_range (GumMemoryRange * range)
+guint
+gum_thread_try_get_ranges (GumMemoryRange ranges[],
+                           guint max_length)
 {
   /* Not implemented */
-  range->base_address = 0;
-  range->size = 0;
-
-  return FALSE;
+  return 0;
 }
 
 #if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -376,7 +376,7 @@ gum_process_enumerate_heap_ranges (HANDLE heap,
 }
 
 guint
-gum_thread_try_get_ranges (GumMemoryRange ranges[],
+gum_thread_try_get_ranges (GumMemoryRange * ranges,
                            guint max_length)
 {
   /* Not implemented */

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -312,7 +312,8 @@ gum_on_thread_realize (void)
   details = g_slice_new (GumInternalThreadDetails);
   details->thread_id = gum_process_get_current_thread_id ();
   details->n_cloaked_ranges =
-      gum_thread_try_get_ranges (details->cloaked_ranges, GUM_MAX_THREAD_RANGES);
+      gum_thread_try_get_ranges (details->cloaked_ranges,
+          GUM_MAX_THREAD_RANGES);
 
   gum_cloak_add_thread (details->thread_id);
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -27,8 +27,8 @@ typedef struct _GumInternalThreadDetails GumInternalThreadDetails;
 struct _GumInternalThreadDetails
 {
   GumThreadId thread_id;
-  gboolean has_cloaked_range;
-  GumMemoryRange cloaked_range;
+  guint n_cloaked_ranges;
+  GumMemoryRange cloaked_ranges[GUM_MAX_THREAD_RANGES];
 };
 
 static void gum_destructor_invoke (GumDestructorFunc destructor);
@@ -305,16 +305,19 @@ static void
 gum_on_thread_realize (void)
 {
   GumInternalThreadDetails * details;
+  guint i;
 
   gum_interceptor_ignore_current_thread (gum_cached_interceptor);
 
   details = g_slice_new (GumInternalThreadDetails);
   details->thread_id = gum_process_get_current_thread_id ();
-  details->has_cloaked_range =
-      gum_thread_try_get_range (&details->cloaked_range);
+  details->n_cloaked_ranges =
+      gum_thread_try_get_ranges (details->cloaked_ranges, GUM_MAX_THREAD_RANGES);
 
   gum_cloak_add_thread (details->thread_id);
-  gum_cloak_add_range (&details->cloaked_range);
+
+  for (i = 0; i < details->n_cloaked_ranges; i++)
+    gum_cloak_add_range (&details->cloaked_ranges[i]);
 
   /* This allows us to free the data no matter how the thread exits */
   g_private_set (&gum_internal_thread_details_key, details);
@@ -338,11 +341,12 @@ static void
 gum_internal_thread_details_free (GumInternalThreadDetails * details)
 {
   GumThreadId thread_id;
+  guint i;
 
   thread_id = details->thread_id;
 
-  if (details->has_cloaked_range)
-    gum_cloak_remove_range (&details->cloaked_range);
+  for (i = 0; i < details->n_cloaked_ranges; i++)
+    gum_cloak_remove_range (&details->cloaked_ranges[i]);
 
   g_slice_free (GumInternalThreadDetails, details);
 

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -317,7 +317,7 @@ gum_on_thread_realize (void)
 
   gum_cloak_add_thread (details->thread_id);
 
-  for (i = 0; i < details->n_cloaked_ranges; i++)
+  for (i = 0; i != details->n_cloaked_ranges; i++)
     gum_cloak_add_range (&details->cloaked_ranges[i]);
 
   /* This allows us to free the data no matter how the thread exits */
@@ -346,7 +346,7 @@ gum_internal_thread_details_free (GumInternalThreadDetails * details)
 
   thread_id = details->thread_id;
 
-  for (i = 0; i < details->n_cloaked_ranges; i++)
+  for (i = 0; i != details->n_cloaked_ranges; i++)
     gum_cloak_remove_range (&details->cloaked_ranges[i]);
 
   g_slice_free (GumInternalThreadDetails, details);

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -276,6 +276,8 @@ enum _GumRelocationScenario
 #define GUM_MAX_LISTENERS_PER_FUNCTION 2
 #define GUM_MAX_LISTENER_DATA        512
 
+#define GUM_MAX_THREAD_RANGES 2
+
 #if GLIB_SIZEOF_VOID_P == 8
 #define GUM_CPU_MODE CS_MODE_64
 #define GUM_THUNK

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -173,7 +173,8 @@ GUM_API void gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 GUM_API void gum_process_enumerate_malloc_ranges (
     GumFoundMallocRangeFunc func, gpointer user_data);
-GUM_API guint gum_thread_try_get_ranges (GumMemoryRange ranges[], guint max_length);
+GUM_API guint gum_thread_try_get_ranges (GumMemoryRange * ranges,
+    guint max_length);
 GUM_API gint gum_thread_get_system_error (void);
 GUM_API void gum_thread_set_system_error (gint value);
 GUM_API gboolean gum_module_ensure_initialized (const gchar * module_name);

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -173,7 +173,7 @@ GUM_API void gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 GUM_API void gum_process_enumerate_malloc_ranges (
     GumFoundMallocRangeFunc func, gpointer user_data);
-GUM_API gboolean gum_thread_try_get_range (GumMemoryRange * range);
+GUM_API guint gum_thread_try_get_ranges (GumMemoryRange ranges[], guint max_length);
 GUM_API gint gum_thread_get_system_error (void);
 GUM_API void gum_thread_set_system_error (gint value);
 GUM_API gboolean gum_module_ensure_initialized (const gchar * module_name);

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -156,7 +156,7 @@ namespace Gum {
 	}
 
 	namespace Thread {
-		public bool try_get_range (out Gum.MemoryRange range);
+		public uint try_get_ranges (Gum.MemoryRange[] ranges);
 	}
 
 	namespace Module {


### PR DESCRIPTION
Implemented only on i/macOS for now.

The default behaviour when apple’s libpthread allocates resources for a thread is to create a contiguous range made of guard + stack + pthread. There’s also the possiblity to create a thread providing a separated stack, in that case no guard page will be provided by default and only the pthread structure will be allocated internally.

In any case, both the internal allocation extents and the stack itself can be retrieved by picking the right values out of the opaque pthread structure.

The `gum_thread_try_get_ranges` function detects if the allocation is contiguous or not. If it’s contiguous only one range is filled, otherwise there will be one range for stack and one for pthread structure. The number of produced ranges is returned. In backends which don’t implement this logic yet, a number of 0 ranges is returned.

Offsets in pthread structure have been pretty stable so far, the most notable change is that at some point (around iOS 10.x) the `thread_id` field has been moved after the fields we use. To account for this and provide compatibility with older versions of pthread structure, we check if `thread_id` is at the newer offset, if it’s not a skew of 8 bytes is added to all other offsets.