### PR TITLE
Skip DT_GNU_HASH in gum_store_symtab_params if unavailable

### DIFF
--- a/gum/backend-elf/gumelfmodule.c
+++ b/gum/backend-elf/gumelfmodule.c
@@ -505,6 +505,7 @@ gum_store_symtab_params (const GumElfDynamicEntryDetails * details,
 
       break;
     }
+#ifdef DT_GNU_HASH
     case DT_GNU_HASH:
     {
       const guint32 * hash_params;
@@ -551,6 +552,7 @@ gum_store_symtab_params (const GumElfDynamicEntryDetails * details,
 
       break;
     }
+#endif
     default:
       break;
   }


### PR DESCRIPTION
DT_GNU_HASH is not available on all ELF platforms and it is a GNU extension.

This corrects a build on NetBSD/amd64 8.99.12.