### PR TITLE
Stop worker thread before modifying old_ports

### DIFF
--- a/gum/backend-darwin/gumexceptor-darwin.c
+++ b/gum/backend-darwin/gumexceptor-darwin.c
@@ -312,7 +312,9 @@ gum_exceptor_backend_detach (GumExceptorBackend * self)
         old_ports->flavors[port_index]);
     g_assert_cmpint (kr, ==, KERN_SUCCESS);
   }
+
   gum_exceptor_backend_stop_worker_thread (self);
+
   gum_exception_port_set_mod_refs (old_ports, -1);
   old_ports->count = 0;
 

--- a/gum/backend-darwin/gumexceptor-darwin.c
+++ b/gum/backend-darwin/gumexceptor-darwin.c
@@ -312,10 +312,9 @@ gum_exceptor_backend_detach (GumExceptorBackend * self)
         old_ports->flavors[port_index]);
     g_assert_cmpint (kr, ==, KERN_SUCCESS);
   }
+  gum_exceptor_backend_stop_worker_thread (self);
   gum_exception_port_set_mod_refs (old_ports, -1);
   old_ports->count = 0;
-
-  gum_exceptor_backend_stop_worker_thread (self);
 
   mach_port_mod_refs (self_task, self->server_port, MACH_PORT_RIGHT_SEND, -1);
   mach_port_mod_refs (self_task, self->server_port, MACH_PORT_RIGHT_RECEIVE,


### PR DESCRIPTION
This is to avoid corrupting `old_ports->count` while the worker thread is potentially iterating on it. That could have produced an infinite loop in the worker thread leading to indefinite hang or memory corruption.