### PR TITLE
Added carriage return replacing

### DIFF
--- a/bindings/gumjs/generate-bindings.py
+++ b/bindings/gumjs/generate-bindings.py
@@ -33,7 +33,7 @@ def generate_and_write_bindings(source_dir, output_dir):
         for arch, flavor in flavor_combos:
             api_header_path = os.path.join(source_dir, "arch-" + arch, "gum{0}{1}.h".format(flavor, name))
             with codecs.open(api_header_path, "r", 'utf-8') as f:
-                api_header = f.read()
+                api_header = f.read().replace("\r", "")
 
             bindings = generate_bindings(name, arch, flavor, api_header, options)
 


### PR DESCRIPTION
Added replace("\r", "") after reading gum headers contents to avoid issues with different OS/git configurations.