### PR TITLE
Improve Frida Kernel

### DIFF
--- a/bindings/gumjs/gumdukkernel.c
+++ b/bindings/gumjs/gumdukkernel.c
@@ -25,6 +25,8 @@ static gboolean gum_emit_range (const GumRangeDetails * details,
     GumDukMatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_read_byte_array)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_write_byte_array)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 
 static void gum_duk_kernel_check_api_available (duk_context * ctx);
 
@@ -40,6 +42,8 @@ static const duk_function_list_entry gumjs_kernel_functions[] =
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges, 2 },
   { "readByteArray", gumjs_kernel_read_byte_array, 2 },
   { "writeByteArray", gumjs_kernel_write_byte_array, 2 },
+  { "alloc", gumjs_kernel_alloc, 2 },
+  { "protect", gumjs_kernel_protect, 3 },
 
   { NULL, NULL, 0 }
 };
@@ -56,6 +60,8 @@ _gum_duk_kernel_init (GumDukKernel * self,
   duk_push_c_function (ctx, gumjs_kernel_construct, 0);
   duk_push_object (ctx);
   duk_put_function_list (ctx, -1, gumjs_kernel_functions);
+  duk_push_uint (ctx, gum_kernel_query_page_size ());
+  duk_put_prop_string (ctx, -2, "pageSize");
   duk_put_prop_string (ctx, -2, "prototype");
   duk_new (ctx, 0);
   _gum_duk_add_properties_to_class_by_heapptr (ctx,
@@ -211,6 +217,53 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_write_byte_array)
   }
 
   return 0;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
+{
+  gpointer address;
+  gssize length;
+  gsize page_size;
+  guint n_pages;
+  GumDukCore * core = args->core;
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "Z", &length);
+
+  if (length == 0 || length > 0x7fffffff)
+    _gum_duk_throw (ctx, "invalid size");
+
+  page_size = gum_kernel_query_page_size ();
+  n_pages = ((length + page_size - 1) & ~(page_size - 1)) / page_size;
+
+  address = gum_kernel_alloc_n_pages (n_pages);
+  _gum_duk_push_native_pointer (ctx, address, core);
+
+  return 1;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
+{
+  gpointer address;
+  gsize size;
+  GumPageProtection prot;
+  gboolean success;
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "pZm", &address, &size, &prot);
+
+  if (size > 0x7fffffff)
+    _gum_duk_throw (ctx, "invalid size");
+
+  if (size != 0)
+    success = gum_kernel_try_mprotect (address, size, prot);
+  else
+    success = TRUE;
+
+  duk_push_boolean (ctx, success);
+  return 1;
 }
 
 static void

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -31,6 +31,8 @@ static gboolean gum_emit_range (const GumRangeDetails * details,
     GumV8MatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_read_byte_array)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_write_byte_array)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 
 static gboolean gum_v8_kernel_check_api_available (Isolate * isolate);
 
@@ -46,6 +48,8 @@ static const GumV8Function gumjs_kernel_functions[] =
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges },
   { "readByteArray", gumjs_kernel_read_byte_array },
   { "writeByteArray", gumjs_kernel_write_byte_array },
+  { "alloc", gumjs_kernel_alloc },
+  { "protect", gumjs_kernel_protect },
 
   { NULL, NULL }
 };
@@ -62,6 +66,8 @@ _gum_v8_kernel_init (GumV8Kernel * self,
   auto module = External::New (isolate, self);
 
   auto kernel = _gum_v8_create_module ("Kernel", scope, isolate);
+  kernel->Set (_gum_v8_string_new_ascii (isolate, "pageSize"),
+      Number::New (isolate, gum_kernel_query_page_size ()), ReadOnly);
   _gum_v8_module_add (module, kernel, gumjs_kernel_values, isolate);
   _gum_v8_module_add (module, kernel, gumjs_kernel_functions, isolate);
 }
@@ -242,6 +248,74 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_write_byte_array)
   }
 
   g_bytes_unref (bytes);
+}
+
+/*
+ * Prototype:
+ * Kernel.alloc(size)
+ *
+ * Docs:
+ * TBW
+ *
+ * Example:
+ * TBW
+ */
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
+{
+  if (!gum_v8_kernel_check_api_available (isolate))
+    return;
+
+  gssize length;
+  if (!_gum_v8_args_parse (args, "Z", &length))
+    return;
+
+  if (length == 0 || length > 0x7fffffff)
+  {
+    _gum_v8_throw_ascii_literal (isolate, "invalid size");
+    return;
+  }
+
+  gsize page_size = gum_kernel_query_page_size ();
+  guint n_pages = ((length + page_size - 1) & ~(page_size - 1)) / page_size;
+
+  gpointer address = gum_kernel_alloc_n_pages (n_pages);
+  info.GetReturnValue ().Set (_gum_v8_native_pointer_new (address, core));
+}
+
+/*
+ * Prototype:
+ * Kernel.protect(address, size, protection)
+ *
+ * Docs:
+ * TBW
+ *
+ * Example:
+ * TBW
+ */
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
+{
+  if (!gum_v8_kernel_check_api_available (isolate))
+    return;
+
+  gpointer address;
+  gsize size;
+  GumPageProtection prot;
+  if (!_gum_v8_args_parse (args, "pZm", &address, &size, &prot))
+    return;
+
+  if (size > 0x7fffffff)
+  {
+    _gum_v8_throw_ascii_literal (isolate, "invalid size");
+    return;
+  }
+
+  bool success;
+  if (size != 0)
+    success = !!gum_kernel_try_mprotect (address, size, prot);
+  else
+    success = true;
+
+  info.GetReturnValue ().Set (success);
 }
 
 static gboolean

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -129,12 +129,12 @@ gum_kernel_try_mprotect (gpointer address,
                          gsize size,
                          GumPageProtection page_prot)
 {
+  mach_port_t task;
   gsize page_size;
   gpointer aligned_address;
   gsize aligned_size;
   vm_prot_t mach_page_prot;
   kern_return_t kr;
-  mach_port_t task;
 
   g_assert (size != 0);
 

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -21,18 +21,64 @@ gum_kernel_api_is_available (void)
   return gum_kernel_get_task () != MACH_PORT_NULL;
 }
 
+guint
+gum_kernel_query_page_size (void)
+{
+  return vm_kernel_page_size;
+}
+
 guint8 *
 gum_kernel_read (GumAddress address,
                  gsize len,
                  gsize * n_bytes_read)
 {
   mach_port_t task;
+  guint page_size;
+  guint8 * result;
+  gsize offset;
+  kern_return_t kr;
 
   task = gum_kernel_get_task ();
   if (task == MACH_PORT_NULL)
     return NULL;
 
-  return gum_darwin_read (task, address, len, n_bytes_read);
+  /* failsafe size, smaller than kernel page size */
+  page_size = 2048;
+  result = g_malloc (len);
+  offset = 0;
+
+  while (offset != len)
+  {
+    GumAddress chunk_address, page_address;
+    gsize chunk_size, page_offset;
+
+    chunk_address = address + offset;
+    page_address = chunk_address & ~(GumAddress) (page_size - 1);
+    page_offset = chunk_address - page_address;
+    chunk_size = MIN (len - offset, page_size - page_offset);
+
+    mach_vm_size_t n_bytes_read;
+
+    /* mach_vm_read corrupts memory on iOS */
+    kr = mach_vm_read_overwrite (task, chunk_address, chunk_size,
+        (vm_address_t) (result + offset), &n_bytes_read);
+    if (kr != KERN_SUCCESS)
+      break;
+    g_assert_cmpuint (n_bytes_read, ==, chunk_size);
+
+    offset += chunk_size;
+  }
+
+  if (offset == 0)
+  {
+    g_free (result);
+    result = NULL;
+  }
+
+  if (n_bytes_read != NULL)
+    *n_bytes_read = offset;
+
+  return result;
 }
 
 gboolean
@@ -47,6 +93,66 @@ gum_kernel_write (GumAddress address,
     return FALSE;
 
   return gum_darwin_write (task, address, bytes, len);
+}
+
+gpointer
+gum_kernel_alloc_n_pages (guint n_pages)
+{
+  mach_vm_address_t result = 0;
+  mach_port_t task;
+  gsize page_size, size;
+  kern_return_t kr;
+  gboolean wr;
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return NULL;
+
+  page_size = vm_kernel_page_size;
+  size = (n_pages + 1) * page_size;
+
+  kr = mach_vm_allocate (task, &result, size, VM_FLAGS_ANYWHERE);
+  g_assert_cmpint (kr, ==, KERN_SUCCESS);
+
+  wr = gum_darwin_write (task, result, (guint8*) &size, sizeof (gsize));
+  g_assert_cmpint (wr, ==, TRUE);
+
+  kr = vm_protect(task, result + page_size, size - page_size,
+      TRUE, VM_PROT_READ|VM_PROT_WRITE|VM_PROT_EXECUTE);
+  g_assert_cmpint (kr, ==, KERN_SUCCESS);
+
+  return GSIZE_TO_POINTER (result + page_size);
+}
+
+gboolean
+gum_kernel_try_mprotect (gpointer address,
+                         gsize size,
+                         GumPageProtection page_prot)
+{
+  gsize page_size;
+  gpointer aligned_address;
+  gsize aligned_size;
+  vm_prot_t mach_page_prot;
+  kern_return_t kr;
+  mach_port_t task;
+
+  g_assert (size != 0);
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return FALSE;
+
+  page_size = vm_kernel_page_size;
+  aligned_address = GSIZE_TO_POINTER (
+      GPOINTER_TO_SIZE (address) & ~(page_size - 1));
+  aligned_size =
+      (1 + ((address + size - 1 - aligned_address) / page_size)) * page_size;
+  mach_page_prot = gum_page_protection_to_mach (page_prot);
+
+  kr = mach_vm_protect (task, GPOINTER_TO_SIZE (aligned_address),
+      aligned_size, FALSE, mach_page_prot);
+
+  return kr == KERN_SUCCESS;
 }
 
 void

--- a/gum/gumkernel.c
+++ b/gum/gumkernel.c
@@ -14,6 +14,12 @@ gum_kernel_api_is_available (void)
   return FALSE;
 }
 
+guint
+gum_kernel_query_page_size (void)
+{
+  return 0;
+}
+
 guint8 *
 gum_kernel_read (GumAddress address,
                  gsize len,
@@ -34,6 +40,28 @@ gum_kernel_write (GumAddress address,
   (void) address;
   (void) bytes;
   (void) len;
+
+  return FALSE;
+}
+
+gpointer
+gum_kernel_alloc_n_pages (guint n_pages,
+                          GumPageProtection page_prot)
+{
+  (void) n_pages;
+  (void) page_prot;
+
+  return NULL;
+}
+
+gboolean
+gum_kernel_try_mprotect (gpointer address,
+                         gsize size,
+                         GumPageProtection page_prot)
+{
+  (void) address;
+  (void) size;
+  (void) page_prot;
 
   return FALSE;
 }

--- a/gum/gumkernel.c
+++ b/gum/gumkernel.c
@@ -20,6 +20,28 @@ gum_kernel_query_page_size (void)
   return 0;
 }
 
+gpointer
+gum_kernel_alloc_n_pages (guint n_pages,
+                          GumPageProtection page_prot)
+{
+  (void) n_pages;
+  (void) page_prot;
+
+  return NULL;
+}
+
+gboolean
+gum_kernel_try_mprotect (gpointer address,
+                         gsize size,
+                         GumPageProtection page_prot)
+{
+  (void) address;
+  (void) size;
+  (void) page_prot;
+
+  return FALSE;
+}
+
 guint8 *
 gum_kernel_read (GumAddress address,
                  gsize len,
@@ -40,28 +62,6 @@ gum_kernel_write (GumAddress address,
   (void) address;
   (void) bytes;
   (void) len;
-
-  return FALSE;
-}
-
-gpointer
-gum_kernel_alloc_n_pages (guint n_pages,
-                          GumPageProtection page_prot)
-{
-  (void) n_pages;
-  (void) page_prot;
-
-  return NULL;
-}
-
-gboolean
-gum_kernel_try_mprotect (gpointer address,
-                         gsize size,
-                         GumPageProtection page_prot)
-{
-  (void) address;
-  (void) size;
-  (void) page_prot;
 
   return FALSE;
 }

--- a/gum/gumkernel.h
+++ b/gum/gumkernel.h
@@ -13,13 +13,13 @@ G_BEGIN_DECLS
 
 GUM_API gboolean gum_kernel_api_is_available (void);
 GUM_API guint gum_kernel_query_page_size (void);
+GUM_API gpointer gum_kernel_alloc_n_pages (guint n_pages);
+GUM_API gboolean gum_kernel_try_mprotect (gpointer address, gsize size,
+    GumPageProtection page_prot);
 GUM_API guint8 * gum_kernel_read (GumAddress address, gsize len,
     gsize * n_bytes_read);
 GUM_API gboolean gum_kernel_write (GumAddress address, const guint8 * bytes,
     gsize len);
-GUM_API gpointer gum_kernel_alloc_n_pages (guint n_pages);
-GUM_API gboolean gum_kernel_try_mprotect (gpointer address, gsize size,
-    GumPageProtection page_prot);
 GUM_API void gum_kernel_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 

--- a/gum/gumkernel.h
+++ b/gum/gumkernel.h
@@ -12,10 +12,14 @@
 G_BEGIN_DECLS
 
 GUM_API gboolean gum_kernel_api_is_available (void);
+GUM_API guint gum_kernel_query_page_size (void);
 GUM_API guint8 * gum_kernel_read (GumAddress address, gsize len,
     gsize * n_bytes_read);
 GUM_API gboolean gum_kernel_write (GumAddress address, const guint8 * bytes,
     gsize len);
+GUM_API gpointer gum_kernel_alloc_n_pages (guint n_pages);
+GUM_API gboolean gum_kernel_try_mprotect (gpointer address, gsize size,
+    GumPageProtection page_prot);
 GUM_API void gum_kernel_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 


### PR DESCRIPTION
- make gum_kernel_read failsafe by reading in chunks smaller than page size
- add Kernel.alloc(), Kernel.protect(), and Kernel.pageSize

obviously Kernel.protect() is a bit crippled because to really change to any protection it's required to patch parent page table entries too, but getting there!