### PR TITLE
Free linux auxv struct

### DIFF
--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1573,6 +1573,7 @@ gum_linux_cpu_type_from_pid (pid_t pid,
   }
 
 beach:
+  g_free (auxv);
   g_free (auxv_path);
 
   return result;


### PR DESCRIPTION
g_file_get_contents allocates buffer for /proc/$pid/auxv file and it was not freed