### PR TITLE
add size field to Instruction.operands

### DIFF
--- a/bindings/gumjs/gumdukinstruction.c
+++ b/bindings/gumjs/gumdukinstruction.c
@@ -464,10 +464,10 @@ gum_push_operands (duk_context * ctx,
       default:
         g_assert_not_reached ();
     }
-    
+
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-    
+
     duk_push_uint (ctx, op->size);
     duk_put_prop_string (ctx, -2, "size");
 
@@ -568,10 +568,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-    
+
     duk_push_uint (ctx, op->size);
     duk_put_prop_string (ctx, -2, "size");
-    
+
     if (op->shift.type != ARM_SFT_INVALID)
     {
       gum_arm_push_shift_details (ctx, op, module);
@@ -727,10 +727,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-    
+
     duk_push_uint (ctx, op->size);
     duk_put_prop_string (ctx, -2, "size");
-    
+
     if (op->shift.type != ARM64_SFT_INVALID)
     {
       gum_arm64_push_shift_details (ctx, op, module);
@@ -917,10 +917,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-    
+
     duk_push_uint (ctx, op->size);
     duk_put_prop_string (ctx, -2, "size");
-    
+
     duk_put_prop_index (ctx, -2, op_index);
   }
 }

--- a/bindings/gumjs/gumdukinstruction.c
+++ b/bindings/gumjs/gumdukinstruction.c
@@ -464,8 +464,12 @@ gum_push_operands (duk_context * ctx,
       default:
         g_assert_not_reached ();
     }
+    
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
+    
+    duk_push_uint (ctx, op->size);
+    duk_put_prop_string (ctx, -2, "size");
 
     duk_put_prop_index (ctx, -2, op_index);
   }
@@ -564,7 +568,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-
+    
+    duk_push_uint (ctx, op->size);
+    duk_put_prop_string (ctx, -2, "size");
+    
     if (op->shift.type != ARM_SFT_INVALID)
     {
       gum_arm_push_shift_details (ctx, op, module);
@@ -720,7 +727,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-
+    
+    duk_push_uint (ctx, op->size);
+    duk_put_prop_string (ctx, -2, "size");
+    
     if (op->shift.type != ARM64_SFT_INVALID)
     {
       gum_arm64_push_shift_details (ctx, op, module);
@@ -907,7 +917,10 @@ gum_push_operands (duk_context * ctx,
     }
     duk_put_prop_string (ctx, -3, "type");
     duk_put_prop_string (ctx, -2, "value");
-
+    
+    duk_push_uint (ctx, op->size);
+    duk_put_prop_string (ctx, -2, "size");
+    
     duk_put_prop_index (ctx, -2, op_index);
   }
 }

--- a/bindings/gumjs/gumv8instruction.cpp
+++ b/bindings/gumjs/gumv8instruction.cpp
@@ -467,7 +467,7 @@ gum_parse_operands (const cs_insn * insn,
     auto type_key = "type";
     auto value_key = "value";
     auto size_key = "size";
-    
+
     switch (op->type)
     {
       case X86_OP_REG:
@@ -495,9 +495,9 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-    
+
     _gum_v8_object_set_uint (element, size_key, op->size, core);
-    
+
     elements->Set (op_index, element);
   }
 
@@ -562,7 +562,7 @@ gum_parse_operands (const cs_insn * insn,
     auto type_key = "type";
     auto value_key = "value";
     auto size_key = "size";
-    
+
     switch (op->type)
     {
       case ARM_OP_REG:
@@ -605,7 +605,7 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-    
+
     _gum_v8_object_set_uint (element, size_key, op->size, core);
 
     if (op->shift.type != ARM_SFT_INVALID)
@@ -718,7 +718,7 @@ gum_parse_operands (const cs_insn * insn,
     auto type_key = "type";
     auto value_key = "value";
     auto size_key = "size";
-    
+
     switch (op->type)
     {
       case ARM64_OP_REG:
@@ -775,7 +775,7 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-    
+
     _gum_v8_object_set_uint (element, size_key, op->size, core);
 
     if (op->shift.type != ARM64_SFT_INVALID)
@@ -953,7 +953,7 @@ gum_parse_operands (const cs_insn * insn,
     auto type_key = "type";
     auto value_key = "value";
     auto size_key = "size";
-    
+
     switch (op->type)
     {
       case MIPS_OP_REG:
@@ -973,9 +973,9 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-    
+
     _gum_v8_object_set_uint (element, size_key, op->size, core);
-    
+
     elements->Set (op_index, element);
   }
 

--- a/bindings/gumjs/gumv8instruction.cpp
+++ b/bindings/gumjs/gumv8instruction.cpp
@@ -466,7 +466,8 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-
+    auto size_key = "size";
+    
     switch (op->type)
     {
       case X86_OP_REG:
@@ -494,7 +495,9 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-
+    
+    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    
     elements->Set (op_index, element);
   }
 
@@ -558,7 +561,8 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-
+    auto size_key = "size";
+    
     switch (op->type)
     {
       case ARM_OP_REG:
@@ -601,6 +605,8 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
+    
+    _gum_v8_object_set_uint (element, size_key, op->size, core);
 
     if (op->shift.type != ARM_SFT_INVALID)
     {
@@ -711,7 +717,8 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-
+    auto size_key = "size";
+    
     switch (op->type)
     {
       case ARM64_OP_REG:
@@ -768,6 +775,8 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
+    
+    _gum_v8_object_set_uint (element, size_key, op->size, core);
 
     if (op->shift.type != ARM64_SFT_INVALID)
     {
@@ -943,7 +952,8 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-
+    auto size_key = "size";
+    
     switch (op->type)
     {
       case MIPS_OP_REG:
@@ -963,7 +973,9 @@ gum_parse_operands (const cs_insn * insn,
       default:
         g_assert_not_reached ();
     }
-
+    
+    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    
     elements->Set (op_index, element);
   }
 

--- a/bindings/gumjs/gumv8instruction.cpp
+++ b/bindings/gumjs/gumv8instruction.cpp
@@ -466,7 +466,6 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-    auto size_key = "size";
 
     switch (op->type)
     {
@@ -496,7 +495,7 @@ gum_parse_operands (const cs_insn * insn,
         g_assert_not_reached ();
     }
 
-    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    _gum_v8_object_set_uint (element, "size", op->size, core);
 
     elements->Set (op_index, element);
   }
@@ -561,7 +560,6 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-    auto size_key = "size";
 
     switch (op->type)
     {
@@ -606,7 +604,7 @@ gum_parse_operands (const cs_insn * insn,
         g_assert_not_reached ();
     }
 
-    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    _gum_v8_object_set_uint (element, "size", op->size, core);
 
     if (op->shift.type != ARM_SFT_INVALID)
     {
@@ -717,7 +715,6 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-    auto size_key = "size";
 
     switch (op->type)
     {
@@ -776,7 +773,7 @@ gum_parse_operands (const cs_insn * insn,
         g_assert_not_reached ();
     }
 
-    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    _gum_v8_object_set_uint (element, "size", op->size, core);
 
     if (op->shift.type != ARM64_SFT_INVALID)
     {
@@ -952,7 +949,6 @@ gum_parse_operands (const cs_insn * insn,
 
     auto type_key = "type";
     auto value_key = "value";
-    auto size_key = "size";
 
     switch (op->type)
     {
@@ -974,7 +970,7 @@ gum_parse_operands (const cs_insn * insn,
         g_assert_not_reached ();
     }
 
-    _gum_v8_object_set_uint (element, size_key, op->size, core);
+    _gum_v8_object_set_uint (element, "size", op->size, core);
 
     elements->Set (op_index, element);
   }

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -339,8 +339,10 @@ SCRIPT_TESTCASE (instruction_can_be_parsed)
       "send(operands.length);"
       "send(operands[0].type);"
       "send(operands[0].value);"
+      "send(operands[0].size);"
       "send(operands[1].type);"
       "send(operands[1].value);"
+      "send(operands[1].size);"
       "send(mov.regsRead);"
       "send(mov.regsWritten);"
       "send(mov.groups);"
@@ -371,8 +373,10 @@ SCRIPT_TESTCASE (instruction_can_be_parsed)
   EXPECT_SEND_MESSAGE_WITH ("2");
   EXPECT_SEND_MESSAGE_WITH ("\"reg\"");
   EXPECT_SEND_MESSAGE_WITH ("\"eax\"");
+  EXPECT_SEND_MESSAGE_WITH ("4");
   EXPECT_SEND_MESSAGE_WITH ("\"imm\"");
   EXPECT_SEND_MESSAGE_WITH ("42");
+  EXPECT_SEND_MESSAGE_WITH ("4");
   EXPECT_SEND_MESSAGE_WITH ("[]");
   EXPECT_SEND_MESSAGE_WITH ("[]");
   EXPECT_SEND_MESSAGE_WITH ("[]");


### PR DESCRIPTION
Look here: https://github.com/frida/frida-gum/issues/293

I tested the patch using ducktape on a x86 binary and it's ok.
My test build is python-64.
You should test all the other architectures and also the v8 patch, I didn't find how to select v8 in the compilation process.

Here an example:
```python
>>> import frida
>>> 
>>> code = """
... i = Instruction.parse(ptr("0x4005C7")) //movzx   eax, byte ptr [rax]
... console.log(JSON.stringify(i.operands))
... """
>>> pid = frida.spawn(["./foo", "A"*30])
>>> session = frida.attach(pid)
>>> script = session.create_script(code)
>>> script.load()
[{"type":"reg","value":"eax","size":4},{"type":"mem","value":{"base":"rax","scale":1,"disp":0},"size":1}]
>>> 
```