### PR TITLE
More kernel improvements

### DIFF
--- a/bindings/gumjs/gumdukcore.c
+++ b/bindings/gumjs/gumdukcore.c
@@ -183,6 +183,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_int64_or)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_xor)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_shr)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_shl)
+GUMJS_DECLARE_FUNCTION (gumjs_int64_not)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_compare)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_to_number)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_to_string)
@@ -198,6 +199,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_uint64_or)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_xor)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_shr)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_shl)
+GUMJS_DECLARE_FUNCTION (gumjs_uint64_not)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_compare)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_to_number)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_to_string)
@@ -348,6 +350,7 @@ static const duk_function_list_entry gumjs_int64_functions[] =
   { "xor", gumjs_int64_xor, 1 },
   { "shr", gumjs_int64_shr, 1 },
   { "shl", gumjs_int64_shl, 1 },
+  { "not", gumjs_int64_not, 1 },
   { "compare", gumjs_int64_compare, 1 },
   { "toNumber", gumjs_int64_to_number, 0 },
   { "toString", gumjs_int64_to_string, 1 },
@@ -366,6 +369,7 @@ static const duk_function_list_entry gumjs_uint64_functions[] =
   { "xor", gumjs_uint64_xor, 1 },
   { "shr", gumjs_uint64_shr, 1 },
   { "shl", gumjs_uint64_shl, 1 },
+  { "not", gumjs_uint64_not, 1 },
   { "compare", gumjs_uint64_compare, 1 },
   { "toNumber", gumjs_uint64_to_number, 0 },
   { "toString", gumjs_uint64_to_string, 1 },
@@ -1935,6 +1939,21 @@ GUM_DEFINE_INT64_OP_IMPL (xor, ^)
 GUM_DEFINE_INT64_OP_IMPL (shr, >>)
 GUM_DEFINE_INT64_OP_IMPL (shl, <<)
 
+#define GUM_DEFINE_INT64_UNARY_OP_IMPL(name, op) \
+  GUMJS_DEFINE_FUNCTION (gumjs_int64_##name) \
+  { \
+    gint64 value, result; \
+    \
+    value = gumjs_int64_from_args (args); \
+    \
+    result = op value; \
+    \
+    _gum_duk_push_int64 (ctx, result, args->core); \
+    return 1; \
+  }
+
+GUM_DEFINE_INT64_UNARY_OP_IMPL (not, ~)
+
 GUMJS_DEFINE_FUNCTION (gumjs_int64_compare)
 {
   gint64 lhs, rhs;
@@ -2067,6 +2086,21 @@ GUM_DEFINE_UINT64_OP_IMPL (or,  |)
 GUM_DEFINE_UINT64_OP_IMPL (xor, ^)
 GUM_DEFINE_UINT64_OP_IMPL (shr, >>)
 GUM_DEFINE_UINT64_OP_IMPL (shl, <<)
+
+#define GUM_DEFINE_UINT64_UNARY_OP_IMPL(name, op) \
+  GUMJS_DEFINE_FUNCTION (gumjs_uint64_##name) \
+  { \
+    guint64 value, result; \
+    \
+    value = gumjs_uint64_from_args (args); \
+    \
+    result = op value; \
+    \
+    _gum_duk_push_uint64 (ctx, result, args->core); \
+    return 1; \
+  }
+
+GUM_DEFINE_UINT64_UNARY_OP_IMPL (not, ~)
 
 GUMJS_DEFINE_FUNCTION (gumjs_uint64_compare)
 {

--- a/bindings/gumjs/gumdukkernel.c
+++ b/bindings/gumjs/gumdukkernel.c
@@ -9,6 +9,7 @@
 #include "gumdukmacros.h"
 
 typedef struct _GumDukMatchContext GumDukMatchContext;
+typedef struct _GumKernelScanContext GumKernelScanContext;
 
 struct _GumDukMatchContext
 {
@@ -18,32 +19,65 @@ struct _GumDukMatchContext
   GumDukScope * scope;
 };
 
+struct _GumKernelScanContext
+{
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  GumDukHeapPtr on_match;
+  GumDukHeapPtr on_error;
+  GumDukHeapPtr on_complete;
+
+  GumDukCore * core;
+};
+
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_kernel_construct)
 GUMJS_DECLARE_GETTER (gumjs_kernel_get_available)
+GUMJS_DECLARE_GETTER (gumjs_kernel_get_base)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_modules)
+static gboolean gum_emit_module (const GumModuleDetails * details,
+    GumDukMatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_ranges)
 static gboolean gum_emit_range (const GumRangeDetails * details,
     GumDukMatchContext * mc);
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
+static gboolean gum_emit_module_range (
+    const GumKernelModuleRangeDetails * details, GumDukMatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_read_byte_array)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_write_byte_array)
+
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_scan)
+static void gum_kernel_scan_context_free (GumKernelScanContext * ctx);
+static void gum_kernel_scan_context_run (GumKernelScanContext * self);
+static gboolean gum_kernel_scan_context_emit_match (GumAddress address,
+    gsize size, GumKernelScanContext * self);
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_scan_sync)
+static gboolean gum_append_match (GumAddress address, gsize size,
+    GumDukCore * core);
 
 static void gum_duk_kernel_check_api_available (duk_context * ctx);
 
 static const GumDukPropertyEntry gumjs_kernel_values[] =
 {
   { "available", gumjs_kernel_get_available, NULL },
+  { "base", gumjs_kernel_get_base, NULL },
 
   { NULL, NULL, NULL }
 };
 
 static const duk_function_list_entry gumjs_kernel_functions[] =
 {
+  { "enumerateModules", gumjs_kernel_enumerate_modules, 1 },
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges, 2 },
+  { "_enumerateModuleRanges", gumjs_kernel_enumerate_module_ranges, 3 },
   { "alloc", gumjs_kernel_alloc, 2 },
   { "protect", gumjs_kernel_protect, 3 },
   { "readByteArray", gumjs_kernel_read_byte_array, 2 },
   { "writeByteArray", gumjs_kernel_write_byte_array, 2 },
+
+  { "scan", gumjs_kernel_scan, 4 },
+  { "scanSync", gumjs_kernel_scan_sync, 3 },
 
   { NULL, NULL, 0 }
 };
@@ -89,6 +123,65 @@ GUMJS_DEFINE_GETTER (gumjs_kernel_get_available)
 {
   duk_push_boolean (ctx, gum_kernel_api_is_available ());
   return 1;
+}
+
+GUMJS_DEFINE_GETTER (gumjs_kernel_get_base)
+{
+  GumAddress address;
+  GumDukCore * core = args->core;
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  address = gum_kernel_find_base_address ();
+  _gum_duk_push_uint64 (ctx, address, core);
+
+  return 1;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_modules)
+{
+  GumDukMatchContext mc;
+  GumDukScope scope = GUM_DUK_SCOPE_INIT (args->core);
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "F{onMatch,onComplete}", &mc.on_match,
+      &mc.on_complete);
+  mc.scope = &scope;
+
+  gum_kernel_enumerate_modules ((GumFoundModuleFunc) gum_emit_module, &mc);
+  _gum_duk_scope_flush (&scope);
+
+  duk_push_heapptr (ctx, mc.on_complete);
+  duk_call (ctx, 0);
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static gboolean
+gum_emit_module (const GumModuleDetails * details,
+                 GumDukMatchContext * mc)
+{
+  GumDukScope * scope = mc->scope;
+  duk_context * ctx = scope->ctx;
+  gboolean proceed = TRUE;
+
+  duk_push_heapptr (ctx, mc->on_match);
+  _gum_duk_push_module (ctx, details, scope->core);
+
+  if (_gum_duk_scope_call_sync (scope, 1))
+  {
+    if (duk_is_string (ctx, -1))
+      proceed = strcmp (duk_require_string (ctx, -1), "stop") != 0;
+  }
+  else
+  {
+    proceed = FALSE;
+  }
+  duk_pop (ctx);
+
+  return proceed;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_ranges)
@@ -138,9 +231,72 @@ gum_emit_range (const GumRangeDetails * details,
   return proceed;
 }
 
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
+{
+  gchar * module_name;
+  GumDukMatchContext mc;
+  GumPageProtection prot;
+  GumDukScope scope = GUM_DUK_SCOPE_INIT (args->core);
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "s?mF{onMatch,onComplete}", &module_name, &prot,
+      &mc.on_match, &mc.on_complete);
+  mc.scope = &scope;
+
+  gum_kernel_enumerate_module_ranges (
+      (module_name == NULL) ? "Kernel" : module_name, prot,
+      (GumFoundKernelModuleRangeFunc) gum_emit_module_range, &mc);
+  _gum_duk_scope_flush (&scope);
+
+  duk_push_heapptr (ctx, mc.on_complete);
+  duk_call (ctx, 0);
+  duk_pop (ctx);
+
+  return 0;
+}
+
+static gboolean
+gum_emit_module_range (const GumKernelModuleRangeDetails * details,
+                       GumDukMatchContext * mc)
+{
+  GumDukScope * scope = mc->scope;
+  duk_context * ctx = scope->ctx;
+  gboolean proceed = TRUE;
+
+  duk_push_heapptr (ctx, mc->on_match);
+
+  duk_push_object (ctx);
+
+  duk_push_string (ctx, details->name);
+  duk_put_prop_string (ctx, -2, "name");
+
+  _gum_duk_push_uint64 (ctx, details->address, scope->core);
+  duk_put_prop_string (ctx, -2, "address");
+
+  duk_push_uint (ctx, details->size);
+  duk_put_prop_string (ctx, -2, "size");
+
+  _gum_duk_push_page_protection (ctx, details->protection);
+  duk_put_prop_string (ctx, -2, "protection");
+
+  if (_gum_duk_scope_call_sync (scope, 1))
+  {
+    if (duk_is_string (ctx, -1))
+      proceed = strcmp (duk_require_string (ctx, -1), "stop") != 0;
+  }
+  else
+  {
+    proceed = FALSE;
+  }
+  duk_pop (ctx);
+
+  return proceed;
+}
+
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
 {
-  gpointer address;
+  GumAddress address;
   gsize size, page_size;
   guint n_pages;
   GumDukCore * core = args->core;
@@ -156,21 +312,21 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
   n_pages = ((size + page_size - 1) & ~(page_size - 1)) / page_size;
 
   address = gum_kernel_alloc_n_pages (n_pages);
-  _gum_duk_push_native_pointer (ctx, address, core);
+  _gum_duk_push_uint64 (ctx, address, core);
 
   return 1;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
 {
-  gpointer address;
+  GumAddress address;
   gsize size;
   GumPageProtection prot;
   gboolean success;
 
   gum_duk_kernel_check_api_available (ctx);
 
-  _gum_duk_args_parse (args, "pZm", &address, &size, &prot);
+  _gum_duk_args_parse (args, "QZm", &address, &size, &prot);
 
   if (size > 0x7fffffff)
     _gum_duk_throw (ctx, "invalid size");
@@ -186,15 +342,15 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
 {
-  gpointer address;
+  GumAddress address;
   gssize length;
   gsize n_bytes_read;
 
   gum_duk_kernel_check_api_available (ctx);
 
-  _gum_duk_args_parse (args, "pZ", &address, &length);
+  _gum_duk_args_parse (args, "QZ", &address, &length);
 
-  if (address == NULL)
+  if (address == 0)
   {
     duk_push_null (ctx);
     return 1;
@@ -205,11 +361,11 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
     guint8 * data;
     gpointer buffer_data;
 
-    data = gum_kernel_read (GUM_ADDRESS (address), length, &n_bytes_read);
+    data = gum_kernel_read (address, length, &n_bytes_read);
     if (data == NULL)
     {
-      _gum_duk_throw (ctx, "access violation reading 0x%" G_GSIZE_MODIFIER "x",
-          GPOINTER_TO_SIZE (address));
+      _gum_duk_throw (ctx, "access violation reading 0x%" G_GINT64_MODIFIER "x",
+          address);
     }
 
     buffer_data = duk_push_fixed_buffer (ctx, n_bytes_read);
@@ -234,7 +390,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_write_byte_array)
 {
-  gpointer address;
+  GumAddress address;
   GBytes * bytes;
   const guint8 * data;
   gsize length;
@@ -242,20 +398,174 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_write_byte_array)
 
   gum_duk_kernel_check_api_available (ctx);
 
-  _gum_duk_args_parse (args, "pB", &address, &bytes);
+  _gum_duk_args_parse (args, "QB", &address, &bytes);
 
   data = g_bytes_get_data (bytes, &length);
-  success = gum_kernel_write (GUM_ADDRESS (address), data, length);
+  success = gum_kernel_write (address, data, length);
 
   g_bytes_unref (bytes);
 
   if (!success)
   {
-    _gum_duk_throw (ctx, "access violation writing to 0x%" G_GSIZE_MODIFIER "x",
-        GPOINTER_TO_SIZE (address));
+    _gum_duk_throw (ctx, "access violation writing to 0x%" G_GINT64_MODIFIER "x",
+        address);
   }
 
   return 0;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
+{
+  GumDukCore * core = args->core;
+  GumKernelScanContext sc;
+  GumAddress address;
+  gsize size;
+  const gchar * match_str;
+
+  _gum_duk_args_parse (args, "QZsF{onMatch,onError?,onComplete}",
+      &address, &size, &match_str, &sc.on_match, &sc.on_error, &sc.on_complete);
+
+  sc.range.base_address = address;
+  sc.range.size = size;
+  sc.pattern = gum_match_pattern_new_from_string (match_str);
+  sc.core = core;
+
+  if (sc.pattern == NULL)
+    _gum_duk_throw (ctx, "invalid match pattern");
+
+  _gum_duk_protect (ctx, sc.on_match);
+  if (sc.on_error != NULL)
+    _gum_duk_protect (ctx, sc.on_error);
+  _gum_duk_protect (ctx, sc.on_complete);
+
+  _gum_duk_core_pin (core);
+  _gum_duk_core_push_job (core,
+      (GumScriptJobFunc) gum_kernel_scan_context_run,
+      g_slice_dup (GumKernelScanContext, &sc),
+      (GDestroyNotify) gum_kernel_scan_context_free);
+
+  return 0;
+}
+
+static void
+gum_kernel_scan_context_free (GumKernelScanContext * self)
+{
+  GumDukCore * core = self->core;
+  GumDukScope scope;
+  duk_context * ctx;
+
+  ctx = _gum_duk_scope_enter (&scope, core);
+
+  _gum_duk_unprotect (ctx, self->on_match);
+  if (self->on_error != NULL)
+    _gum_duk_unprotect (ctx, self->on_error);
+  _gum_duk_unprotect (ctx, self->on_complete);
+
+  _gum_duk_core_unpin (core);
+  _gum_duk_scope_leave (&scope);
+
+  gum_match_pattern_free (self->pattern);
+
+  g_slice_free (GumKernelScanContext, self);
+}
+
+static void
+gum_kernel_scan_context_run (GumKernelScanContext * self)
+{
+  GumDukCore * core = self->core;
+  GumDukScope script_scope;
+  duk_context * ctx;
+
+  gum_kernel_scan (&self->range, self->pattern,
+      (GumMemoryScanMatchFunc) gum_kernel_scan_context_emit_match, self);
+
+  ctx = _gum_duk_scope_enter (&script_scope, core);
+
+  duk_push_heapptr (ctx, self->on_complete);
+  _gum_duk_scope_call (&script_scope, 0);
+  duk_pop (ctx);
+
+  _gum_duk_scope_leave (&script_scope);
+}
+
+static gboolean
+gum_kernel_scan_context_emit_match (GumAddress address,
+                                    gsize size,
+                                    GumKernelScanContext * self)
+{
+  GumDukCore * core = self->core;
+  GumDukScope scope;
+  duk_context * ctx;
+  gboolean proceed;
+
+  ctx = _gum_duk_scope_enter (&scope, core);
+
+  duk_push_heapptr (ctx, self->on_match);
+
+  _gum_duk_push_uint64 (ctx, address, core);
+  duk_push_number (ctx, size);
+
+  proceed = TRUE;
+
+  if (_gum_duk_scope_call (&scope, 2))
+  {
+    if (duk_is_string (ctx, -1))
+      proceed = strcmp (duk_require_string (ctx, -1), "stop") != 0;
+  }
+  duk_pop (ctx);
+
+  _gum_duk_scope_leave (&scope);
+
+  return proceed;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
+{
+  GumDukCore * core = args->core;
+  GumAddress address;
+  gsize size;
+  const gchar * match_str;
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+
+  _gum_duk_args_parse (args, "QZs", &address, &size, &match_str);
+
+  range.base_address = address;
+  range.size = size;
+
+  pattern = gum_match_pattern_new_from_string (match_str);
+  if (pattern == NULL)
+    _gum_duk_throw (ctx, "invalid match pattern");
+
+  duk_push_array (ctx);
+
+  gum_kernel_scan (&range, pattern, (GumMemoryScanMatchFunc) gum_append_match,
+      core);
+
+  gum_match_pattern_free (pattern);
+
+  return 1;
+}
+
+static gboolean
+gum_append_match (GumAddress address,
+                  gsize size,
+                  GumDukCore * core)
+{
+  GumDukScope scope = GUM_DUK_SCOPE_INIT (core);
+  duk_context * ctx = scope.ctx;
+
+  duk_push_object (ctx);
+
+  _gum_duk_push_uint64 (ctx, address, core);
+  duk_put_prop_string (ctx, -2, "address");
+
+  duk_push_uint (ctx, size);
+  duk_put_prop_string (ctx, -2, "size");
+
+  duk_put_prop_index (ctx, -2, (duk_uarridx_t) duk_get_length (ctx, -2));
+
+  return TRUE;
 }
 
 static void

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -198,6 +198,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_int64_or)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_xor)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_shr)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_shl)
+GUMJS_DECLARE_FUNCTION (gumjs_int64_not)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_compare)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_to_number)
 GUMJS_DECLARE_FUNCTION (gumjs_int64_to_string)
@@ -212,6 +213,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_uint64_or)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_xor)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_shr)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_shl)
+GUMJS_DECLARE_FUNCTION (gumjs_uint64_not)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_compare)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_to_number)
 GUMJS_DECLARE_FUNCTION (gumjs_uint64_to_string)
@@ -361,6 +363,7 @@ static const GumV8Function gumjs_int64_functions[] =
   { "xor", gumjs_int64_xor },
   { "shr", gumjs_int64_shr },
   { "shl", gumjs_int64_shl },
+  { "not", gumjs_int64_not },
   { "compare", gumjs_int64_compare },
   { "toNumber", gumjs_int64_to_number },
   { "toString", gumjs_int64_to_string },
@@ -379,6 +382,7 @@ static const GumV8Function gumjs_uint64_functions[] =
   { "xor", gumjs_uint64_xor },
   { "shr", gumjs_uint64_shr },
   { "shl", gumjs_uint64_shl },
+  { "not", gumjs_uint64_not },
   { "compare", gumjs_uint64_compare },
   { "toNumber", gumjs_uint64_to_number },
   { "toString", gumjs_uint64_to_string },
@@ -1577,6 +1581,18 @@ GUM_DEFINE_INT64_OP_IMPL (xor, ^)
 GUM_DEFINE_INT64_OP_IMPL (shr, >>)
 GUM_DEFINE_INT64_OP_IMPL (shl, <<)
 
+#define GUM_DEFINE_INT64_UNARY_OP_IMPL(name, op) \
+  GUMJS_DEFINE_FUNCTION (gumjs_int64_##name) \
+  { \
+    gint64 value = _gum_v8_int64_get_value (info.Holder ()); \
+    \
+    gint64 result = op value; \
+    \
+    info.GetReturnValue ().Set (_gum_v8_int64_new (result, core)); \
+  }
+
+GUM_DEFINE_INT64_UNARY_OP_IMPL (not, ~)
+
 GUMJS_DEFINE_FUNCTION (gumjs_int64_compare)
 {
   gint64 lhs = _gum_v8_int64_get_value (info.Holder ());
@@ -1671,6 +1687,18 @@ GUM_DEFINE_UINT64_OP_IMPL (or,  |)
 GUM_DEFINE_UINT64_OP_IMPL (xor, ^)
 GUM_DEFINE_UINT64_OP_IMPL (shr, >>)
 GUM_DEFINE_UINT64_OP_IMPL (shl, <<)
+
+#define GUM_DEFINE_UINT64_UNARY_OP_IMPL(name, op) \
+  GUMJS_DEFINE_FUNCTION (gumjs_uint64_##name) \
+  { \
+    guint64 value = _gum_v8_uint64_get_value (info.Holder ()); \
+    \
+    guint64 result = op value; \
+    \
+    info.GetReturnValue ().Set (_gum_v8_uint64_new (result, core)); \
+  }
+
+GUM_DEFINE_UINT64_UNARY_OP_IMPL (not, ~)
 
 GUMJS_DEFINE_FUNCTION (gumjs_uint64_compare)
 {

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -25,31 +25,71 @@ struct GumV8MatchContext
   gboolean has_pending_exception;
 };
 
+struct GumKernelScanContext
+{
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  GumPersistent<Function>::type * on_match;
+  GumPersistent<Function>::type * on_error;
+  GumPersistent<Function>::type * on_complete;
+
+  GumV8Core * core;
+};
+
+struct GumKernelScanSyncContext
+{
+  Local<Array> matches;
+
+  GumV8Core * core;
+};
+
 GUMJS_DECLARE_GETTER (gumjs_kernel_get_available)
+GUMJS_DECLARE_GETTER (gumjs_kernel_get_base)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_modules)
+static gboolean gum_emit_module (const GumModuleDetails * details,
+    GumV8MatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_ranges)
 static gboolean gum_emit_range (const GumRangeDetails * details,
     GumV8MatchContext * mc);
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
+static gboolean gum_emit_module_range (
+    const GumKernelModuleRangeDetails * details, GumV8MatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_read_byte_array)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_write_byte_array)
+
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_scan)
+static void gum_kernel_scan_context_free (GumKernelScanContext * self);
+static void gum_kernel_scan_context_run (GumKernelScanContext * self);
+static gboolean gum_kernel_scan_context_emit_match (GumAddress address,
+    gsize size, GumKernelScanContext * self);
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_scan_sync)
+static gboolean gum_append_match (GumAddress address, gsize size,
+    GumKernelScanSyncContext * ctx);
 
 static gboolean gum_v8_kernel_check_api_available (Isolate * isolate);
 
 static const GumV8Property gumjs_kernel_values[] =
 {
   { "available", gumjs_kernel_get_available, NULL },
+  { "base", gumjs_kernel_get_base, NULL },
 
   { NULL, NULL, NULL }
 };
 
 static const GumV8Function gumjs_kernel_functions[] =
 {
+  { "enumerateModules", gumjs_kernel_enumerate_modules },
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges },
+  { "_enumerateModuleRanges", gumjs_kernel_enumerate_module_ranges },
   { "alloc", gumjs_kernel_alloc },
   { "protect", gumjs_kernel_protect },
   { "readByteArray", gumjs_kernel_read_byte_array },
   { "writeByteArray", gumjs_kernel_write_byte_array },
+
+  { "scan", gumjs_kernel_scan },
+  { "scanSync", gumjs_kernel_scan_sync },
 
   { NULL, NULL }
 };
@@ -92,6 +132,61 @@ GUMJS_DEFINE_GETTER (gumjs_kernel_get_available)
   info.GetReturnValue ().Set (!!gum_kernel_api_is_available ());
 }
 
+GUMJS_DEFINE_GETTER (gumjs_kernel_get_base)
+{
+  if (!gum_v8_kernel_check_api_available (isolate))
+    return;
+
+  GumAddress address = gum_kernel_find_base_address ();
+  info.GetReturnValue ().Set (_gum_v8_uint64_new (address, core));
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_modules)
+{
+  if (!gum_v8_kernel_check_api_available (isolate))
+    return;
+
+  GumV8MatchContext mc;
+  if (!_gum_v8_args_parse (args, "F{onMatch,onComplete}", &mc.on_match,
+      &mc.on_complete))
+    return;
+  mc.core = core;
+
+  mc.has_pending_exception = FALSE;
+
+  gum_kernel_enumerate_modules ((GumFoundModuleFunc) gum_emit_module, &mc);
+
+  if (!mc.has_pending_exception)
+  {
+    mc.on_complete->Call (Undefined (isolate), 0, nullptr);
+  }
+}
+
+static gboolean
+gum_emit_module (const GumModuleDetails * details,
+                 GumV8MatchContext * mc)
+{
+  auto core = mc->core;
+  auto isolate = core->isolate;
+
+  auto module = _gum_v8_parse_module_details (details, core);
+
+  Handle<Value> argv[] = { module };
+  auto result =
+      mc->on_match->Call (Undefined (isolate), G_N_ELEMENTS (argv), argv);
+
+  mc->has_pending_exception = result.IsEmpty ();
+
+  gboolean proceed = !mc->has_pending_exception;
+  if (proceed && result->IsString ())
+  {
+    String::Utf8Value str (result);
+    proceed = strcmp (*str, "stop") != 0;
+  }
+
+  return proceed;
+}
+
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_ranges)
 {
   if (!gum_v8_kernel_check_api_available (isolate))
@@ -122,7 +217,7 @@ gum_emit_range (const GumRangeDetails * details,
   auto isolate = core->isolate;
 
   auto range = Object::New (isolate);
-  _gum_v8_object_set_pointer (range, "base", details->range->base_address,
+  _gum_v8_object_set_uint64 (range, "base", details->range->base_address,
       core);
   _gum_v8_object_set_uint (range, "size", details->range->size, core);
   _gum_v8_object_set_page_protection (range, "protection", details->prot, core);
@@ -135,6 +230,61 @@ gum_emit_range (const GumRangeDetails * details,
     _gum_v8_object_set_uint (range, "offset", f->offset, core);
     _gum_v8_object_set (range, "file", file, core);
   }
+
+  Handle<Value> argv[] = { range };
+  auto result =
+      mc->on_match->Call (Undefined (isolate), G_N_ELEMENTS (argv), argv);
+
+  mc->has_pending_exception = result.IsEmpty ();
+
+  gboolean proceed = !mc->has_pending_exception;
+  if (proceed && result->IsString ())
+  {
+    String::Utf8Value str (result);
+    proceed = strcmp (*str, "stop") != 0;
+  }
+
+  return proceed;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
+{
+  if (!gum_v8_kernel_check_api_available (isolate))
+    return;
+
+  GumV8MatchContext mc;
+  gchar * module_name;
+  GumPageProtection prot;
+  if (!_gum_v8_args_parse (args, "s?mF{onMatch,onComplete}", &module_name,
+      &prot, &mc.on_match, &mc.on_complete))
+    return;
+  mc.core = core;
+
+  mc.has_pending_exception = FALSE;
+
+  gum_kernel_enumerate_module_ranges (
+    (module_name == NULL) ? "Kernel" : module_name, prot,
+    (GumFoundKernelModuleRangeFunc) gum_emit_module_range, &mc);
+
+  if (!mc.has_pending_exception)
+  {
+    mc.on_complete->Call (Undefined (isolate), 0, nullptr);
+  }
+}
+
+static gboolean
+gum_emit_module_range (const GumKernelModuleRangeDetails * details,
+                       GumV8MatchContext * mc)
+{
+  auto core = mc->core;
+  auto isolate = core->isolate;
+
+  auto range = Object::New (isolate);
+  _gum_v8_object_set_utf8 (range, "name", details->name, core);
+  _gum_v8_object_set_uint64 (range, "address", details->address, core);
+  _gum_v8_object_set_uint (range, "size", details->size, core);
+  _gum_v8_object_set_page_protection (range, "protection",
+    details->protection, core);
 
   Handle<Value> argv[] = { range };
   auto result =
@@ -170,8 +320,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
   gsize page_size = gum_kernel_query_page_size ();
   guint n_pages = ((size + page_size - 1) & ~(page_size - 1)) / page_size;
 
-  gpointer address = gum_kernel_alloc_n_pages (n_pages);
-  info.GetReturnValue ().Set (_gum_v8_native_pointer_new (address, core));
+  GumAddress address = gum_kernel_alloc_n_pages (n_pages);
+  info.GetReturnValue ().Set (_gum_v8_uint64_new (address, core));
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
@@ -179,10 +329,10 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)
   if (!gum_v8_kernel_check_api_available (isolate))
     return;
 
-  gpointer address;
+  GumAddress address;
   gsize size;
   GumPageProtection prot;
-  if (!_gum_v8_args_parse (args, "pZm", &address, &size, &prot))
+  if (!_gum_v8_args_parse (args, "QZm", &address, &size, &prot))
     return;
 
   if (size > 0x7fffffff)
@@ -205,12 +355,12 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
   if (!gum_v8_kernel_check_api_available (isolate))
     return;
 
-  gpointer address;
+  GumAddress address;
   gssize length;
-  if (!_gum_v8_args_parse (args, "pZ", &address, &length))
+  if (!_gum_v8_args_parse (args, "QZ", &address, &length))
     return;
 
-  if (address == NULL)
+  if (address == 0)
   {
     info.GetReturnValue ().Set (Null (isolate));
     return;
@@ -220,7 +370,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
   if (length > 0)
   {
     gsize n_bytes_read;
-    auto data = gum_kernel_read (GUM_ADDRESS (address), length, &n_bytes_read);
+    auto data = gum_kernel_read (address, length, &n_bytes_read);
     if (data != NULL)
     {
       result = ArrayBuffer::New (isolate, data, n_bytes_read,
@@ -229,8 +379,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_read_byte_array)
     else
     {
       _gum_v8_throw_ascii (isolate,
-          "access violation reading 0x%" G_GSIZE_MODIFIER "x",
-          GPOINTER_TO_SIZE (address));
+          "access violation reading 0x%" G_GINT64_MODIFIER "x",
+          address);
       return;
     }
   }
@@ -247,23 +397,223 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_write_byte_array)
   if (!gum_v8_kernel_check_api_available (isolate))
     return;
 
-  gpointer address;
+  GumAddress address;
   GBytes * bytes;
-  if (!_gum_v8_args_parse (args, "pB", &address, &bytes))
+  if (!_gum_v8_args_parse (args, "QB", &address, &bytes))
     return;
 
   gsize length;
   auto data = (const guint8 *) g_bytes_get_data (bytes, &length);
 
-  if (!gum_kernel_write (GUM_ADDRESS (address), data, length))
+  if (!gum_kernel_write (address, data, length))
   {
     _gum_v8_throw_ascii (isolate,
-        "access violation writing to 0x%" G_GSIZE_MODIFIER "x",
-        GPOINTER_TO_SIZE (address));
+        "access violation writing to 0x%" G_GINT64_MODIFIER "x",
+        address);
   }
 
   g_bytes_unref (bytes);
 }
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
+{
+  GumAddress address;
+  gsize size;
+  gchar * match_str;
+  Local<Function> on_match, on_error, on_complete;
+  if (!_gum_v8_args_parse (args, "QZsF{onMatch,onError?,onComplete}",
+      &address, &size, &match_str, &on_match, &on_error, &on_complete))
+    return;
+
+  GumMemoryRange range;
+  range.base_address = address;
+  range.size = size;
+
+  auto pattern = gum_match_pattern_new_from_string (match_str);
+
+  g_free (match_str);
+
+  if (pattern != NULL)
+  {
+    auto ctx = g_slice_new0 (GumKernelScanContext);
+    ctx->range = range;
+    ctx->pattern = pattern;
+    ctx->on_match = new GumPersistent<Function>::type (isolate, on_match);
+    if (!on_error.IsEmpty ())
+      ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
+    ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
+    ctx->core = core;
+
+    _gum_v8_core_pin (core);
+    _gum_v8_core_push_job (core, (GumScriptJobFunc) gum_kernel_scan_context_run,
+        ctx, (GDestroyNotify) gum_kernel_scan_context_free);
+  }
+  else
+  {
+    _gum_v8_throw_ascii_literal (isolate, "invalid match pattern");
+  }
+}
+
+static void
+gum_kernel_scan_context_free (GumKernelScanContext * self)
+{
+  auto core = self->core;
+
+  gum_match_pattern_free (self->pattern);
+
+  {
+    ScriptScope script_scope (core->script);
+
+    delete self->on_match;
+    delete self->on_error;
+    delete self->on_complete;
+
+    _gum_v8_core_unpin (core);
+  }
+
+  g_slice_free (GumKernelScanContext, self);
+}
+
+#ifdef _MSC_VER
+# pragma warning (push)
+# pragma warning (disable: 4611)
+#endif
+
+static void
+gum_kernel_scan_context_run (GumKernelScanContext * self)
+{
+  auto core = self->core;
+  auto exceptor = core->exceptor;
+  auto isolate = core->isolate;
+  GumExceptorScope scope;
+
+  if (gum_exceptor_try (exceptor, &scope))
+  {
+    gum_kernel_scan (&self->range, self->pattern,
+        (GumMemoryScanMatchFunc) gum_kernel_scan_context_emit_match, self);
+  }
+
+  if (gum_exceptor_catch (exceptor, &scope) && self->on_error != nullptr)
+  {
+    ScriptScope script_scope (core->script);
+
+    auto message = gum_exception_details_to_string (&scope.exception);
+
+    auto on_error = Local<Function>::New (isolate, *self->on_error);
+    Handle<Value> argv[] = { String::NewFromUtf8 (isolate, message) };
+    on_error->Call (Undefined (isolate), G_N_ELEMENTS (argv), argv);
+
+    g_free (message);
+  }
+
+  {
+    ScriptScope script_scope (core->script);
+
+    auto on_complete (Local<Function>::New (isolate, *self->on_complete));
+    on_complete->Call (Undefined (isolate), 0, nullptr);
+  }
+}
+
+static gboolean
+gum_kernel_scan_context_emit_match (GumAddress address,
+                                    gsize size,
+                                    GumKernelScanContext * self)
+{
+  ScriptScope scope (self->core->script);
+  auto isolate = self->core->isolate;
+
+  auto on_match = Local<Function>::New (isolate, *self->on_match);
+  Handle<Value> argv[] = {
+    _gum_v8_uint64_new (address, self->core),
+    Integer::NewFromUnsigned (isolate, size)
+  };
+  auto result = on_match->Call (Undefined (isolate), G_N_ELEMENTS (argv), argv);
+
+  gboolean proceed = TRUE;
+  if (!result.IsEmpty () && result->IsString ())
+  {
+    String::Utf8Value str (result);
+    proceed = strcmp (*str, "stop") != 0;
+  }
+
+  return proceed;
+}
+
+/*
+ * Prototype:
+ * Kernel.scanSync(address, size, match_str)
+ *
+ * Docs:
+ * Scans a kernel memory region for a specific string
+ *
+ * Example:
+ * TBW
+ */
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
+{
+  GumAddress address;
+  gsize size;
+  gchar * match_str;
+  if (!_gum_v8_args_parse (args, "QZs", &address, &size, &match_str))
+    return;
+
+  GumMemoryRange range;
+  range.base_address = address;
+  range.size = size;
+
+  auto pattern = gum_match_pattern_new_from_string (match_str);
+
+  g_free (match_str);
+
+  if (pattern == NULL)
+  {
+    _gum_v8_throw_ascii_literal (isolate, "invalid match pattern");
+    return;
+  }
+
+  GumKernelScanSyncContext ctx;
+  ctx.matches = Array::New (isolate);
+  ctx.core = core;
+
+  GumExceptorScope scope;
+
+  if (gum_exceptor_try (core->exceptor, &scope))
+  {
+    gum_kernel_scan (&range, pattern, (GumMemoryScanMatchFunc) gum_append_match,
+        &ctx);
+  }
+
+  gum_match_pattern_free (pattern);
+
+  if (gum_exceptor_catch (core->exceptor, &scope))
+  {
+    _gum_v8_throw_native (&scope.exception, core);
+  }
+  else
+  {
+    info.GetReturnValue ().Set (ctx.matches);
+  }
+}
+
+static gboolean
+gum_append_match (GumAddress address,
+                  gsize size,
+                  GumKernelScanSyncContext * ctx)
+{
+  GumV8Core * core = ctx->core;
+
+  auto match = Object::New (core->isolate);
+  _gum_v8_object_set_uint64 (match, "address", address, core);
+  _gum_v8_object_set_uint (match, "size", size, core);
+  ctx->matches->Set (core->isolate->GetCurrentContext (),
+      ctx->matches->Length (), match).ToChecked ();
+
+  return TRUE;
+}
+
+#ifdef _MSC_VER
+# pragma warning (pop)
+#endif
 
 static gboolean
 gum_v8_kernel_check_api_available (Isolate * isolate)

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -1504,6 +1504,18 @@ _gum_v8_object_set_pointer (Handle<Object> object,
 }
 
 gboolean
+_gum_v8_object_set_uint64 (Handle<Object> object,
+                            const gchar * key,
+                            GumAddress value,
+                            GumV8Core * core)
+{
+  return _gum_v8_object_set (object,
+      key,
+      _gum_v8_uint64_new (value, core),
+      core);
+}
+
+gboolean
 _gum_v8_object_set_ascii (Handle<Object> object,
                           const gchar * key,
                           const gchar * value,

--- a/bindings/gumjs/gumv8value.h
+++ b/bindings/gumjs/gumv8value.h
@@ -127,6 +127,9 @@ G_GNUC_INTERNAL gboolean _gum_v8_object_set_pointer (
 G_GNUC_INTERNAL gboolean _gum_v8_object_set_pointer (
     v8::Handle<v8::Object> object, const gchar * key, GumAddress value,
     GumV8Core * core);
+G_GNUC_INTERNAL gboolean _gum_v8_object_set_uint64 (
+    v8::Handle<v8::Object> object, const gchar * key, GumAddress value,
+    GumV8Core * core);
 G_GNUC_INTERNAL gboolean _gum_v8_object_set_ascii (
     v8::Handle<v8::Object> object, const gchar * key, const gchar * value,
     GumV8Core * core);

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -130,12 +130,15 @@ Object.defineProperties(engine, {
   },
 });
 
-NativePointer.prototype.equals = function (ptr) {
-  if (!(ptr instanceof NativePointer)) {
-    throw new Error('not a pointer');
-  }
-  return this.compare(ptr) === 0;
-};
+[
+  Int64,
+  UInt64,
+  NativePointer
+].forEach(klass => {
+  klass.prototype.equals = function (rhs) {
+    return this.compare(rhs) === 0;
+  };
+});
 
 const _nextTick = Script._nextTick;
 Script.nextTick = function (callback, ...args) {

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -247,7 +247,7 @@ Object.defineProperty(Kernel, 'enumerateModuleRangesSync', {
   enumerable: true,
   value: function (moduleName, specifier) {
     const ranges = [];
-    Kernel._enumerateModuleRanges(moduleName, specifier, {
+    Kernel.enumerateModuleRanges(moduleName, specifier, {
       onMatch: function (r) {
         ranges.push(r);
       },

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -152,7 +152,6 @@ if (Script.runtime === 'DUK') {
   };
 }
 
-makeEnumerateThreads(Kernel);
 makeEnumerateRanges(Kernel);
 
 makeEnumerateThreads(Process);
@@ -240,6 +239,36 @@ function makeEnumerateRanges(mod) {
     },
   });
 }
+
+Object.defineProperty(Kernel, 'enumerateModuleRangesSync', {
+  enumerable: true,
+  value: function (moduleName, specifier) {
+    const ranges = [];
+    Kernel._enumerateModuleRanges(moduleName, specifier, {
+      onMatch: function (r) {
+        ranges.push(r);
+      },
+      onComplete: function () {
+      }
+    });
+    return ranges;
+  }
+});
+
+Object.defineProperty(Kernel, 'enumerateModulesSync', {
+  enumerable: true,
+  value: function () {
+    const modules = [];
+    Kernel.enumerateModules({
+      onMatch: function (m) {
+        modules.push(m);
+      },
+      onComplete: function () {
+      }
+    });
+    return modules;
+  }
+});
 
 Object.defineProperties(Memory, {
   dup: {

--- a/bindings/gumjs/types/frida-gum/frida-gum.d.ts
+++ b/bindings/gumjs/types/frida-gum/frida-gum.d.ts
@@ -635,6 +635,127 @@ declare namespace Memory {
     function writeAnsiString(address: NativePointerValue, value: string): void;
 }
 
+declare namespace Kernel {
+    /**
+     * Whether the Kernel API is available.
+     */
+    const available: boolean;
+
+    /**
+     * Base address of the kernel.
+     */
+    const base: UInt64;
+
+    /**
+     * Size of kernel page in bytes.
+     */
+    const pageSize: UInt64;
+
+    /**
+     * Enumerate all kernel modules.
+     *
+     * @param callbacks Object with callbacks.
+     */
+    function enumerateModules(callbacks: EnumerateCallbacks<KernelModuleDetails>): void;
+
+    /**
+     * Synchronous version of `enumerateModules()`.
+     *
+     * @param callbacks Object with callbacks.
+     */
+    function enumerateModulesSync(): KernelModuleDetails[];
+
+    /**
+      * Enumerates all kernel memory ranges matching `specifier`.
+      *
+      * @param specifier The kind of ranges to include.
+      * @param callbacks Object with callbacks.
+      */
+    function enumerateRanges(specifier: PageProtection | EnumerateRangesSpecifier, callbacks: EnumerateCallbacks<KernelRangeDetails>): void;
+
+    /**
+     * Synchronous version of `enumerateRanges()`.
+     *
+     * @param specifier The kind of ranges to include.
+     */
+    function enumerateRangesSync(specifier: PageProtection | EnumerateRangesSpecifier): KernelRangeDetails[];
+
+    /**
+     * Enumerates all ranges of a kernel module.
+     *
+     * @param name Name of the module, or `null` for the main kernel.
+     * @param protection Include ranges with at least this protection.
+     * @param callbacks Object with callbacks.
+     */
+    function enumerateModuleRanges(name: string | null,  protection: PageProtection, callbacks: EnumerateCallbacks<KernelModuleRangeDetails>): void;
+
+    /**
+     * Synchronous version of `enumerateModuleRanges()`.
+     *
+     * @param name Name of the module, or `null` for the main kernel.
+     * @param protection Include ranges with at least this protection.
+     */
+    function enumerateModuleRangesSync(name: string | null,  protection: PageProtection): KernelModuleRangeDetails[];
+
+    /**
+     * Allocate kernel memory.
+     *
+     * @param size Size of the allocation in bytes (will be page aligned).
+     */
+    function alloc(size: number | UInt64): UInt64;
+
+    /**
+     * Changes the page protection on a region of kernel memory.
+     *
+     * @param address Starting address.
+     * @param size Number of bytes. Must be a multiple of Process#pageSize.
+     * @param protection Desired page protection.
+     */
+    function protect(address: UInt64, size: number | UInt64, protection: PageProtection): boolean;
+
+    /**
+     * Read kernel memory into an ArrayBuffer.
+     *
+     * @param address The kernel memory address to read from.
+     * @param size The number of bytes to read.
+     */
+    function readByteArray(address: UInt64, size: number): ArrayBuffer | null;
+
+    /**
+     * Write the contents of an ArrayBuffer or array to kernel memory.
+     *
+     * @param address The kernel memory address to read from.
+     * @param value The data to write.
+     */
+    function writeByteArray(address: UInt64, value: ArrayBuffer | number[]): void;
+
+    /**
+     * Scans kernel memory for occurences of `pattern` in the memory range given by `address` and `size`.
+     *
+     * @param address Starting address to scan from.
+     * @param size Number of bytes to scan.
+     * @param pattern Match pattern of the form “13 37 ?? ff” to match 0x13 followed by 0x37 followed by any byte
+     *                followed by 0xff. For more advanced matching it is also possible to specify an r2-style mask.
+     *                The mask is bitwise AND-ed against both the needle and the haystack. To specify the mask append
+     *                a `:` character after the needle, followed by the mask using the same syntax.
+     *                For example: “13 37 13 37 : 1f ff ff f1”.
+     *                For convenience it is also possible to specify nibble-level wildcards, like “?3 37 13 ?7”,
+     *                which gets translated into masks behind the scenes.
+     * @param callbacks Object with callbacks.
+     */
+    function scan(address: UInt64, size: number | UInt64, pattern: string, callbacks: KernelMemoryScanCallbacks): void;
+
+    /**
+     * Synchronous version of `scan()`.
+     *
+     * @param address Starting address to scan from.
+     * @param size Number of bytes to scan.
+     * @param pattern Match pattern, see `Memory.scan()` for details.
+     * @param callbacks Object with callbacks.
+     */
+    function scanSync(address: UInt64, size: number | UInt64, pattern: string): KernelMemoryScanMatch[];
+}
+
 declare enum Architecture {
     Ia32 = "ia32",
     X64 = "x64",
@@ -707,6 +828,23 @@ declare interface ModuleDetails {
      * Full filesystem path.
      */
     path: string;
+}
+
+declare interface KernelModuleDetails {
+    /**
+     * Canonical module name.
+     */
+    name: string;
+
+    /**
+     * Base address.
+     */
+    base: UInt64;
+
+    /**
+     * Size in bytes.
+     */
+    size: number;
 }
 
 declare interface ModuleImportDetails {
@@ -843,6 +981,45 @@ declare interface RangeDetails {
     file?: FileMapping;
 }
 
+declare interface KernelRangeDetails {
+    /**
+     * Base address.
+     */
+    base: UInt64;
+
+    /**
+     * Size in bytes.
+     */
+    size: number;
+
+    /**
+     * Protection.
+     */
+    protection: PageProtection;
+}
+
+declare interface KernelModuleRangeDetails {
+    /**
+     * Name.
+     */
+    name: string;
+
+    /**
+     * Base address.
+     */
+    base: UInt64;
+
+    /**
+     * Size in bytes.
+     */
+    size: number;
+
+    /**
+     * Protection.
+     */
+    protection: PageProtection;
+}
+
 declare interface FileMapping {
     /**
      * Full filesystem path.
@@ -971,6 +1148,40 @@ declare interface MemoryScanMatch {
      * Memory address where a match was found.
      */
     address: NativePointer;
+
+    /**
+     * Size of this match.
+     */
+    size: number;
+}
+
+declare interface KernelMemoryScanCallbacks {
+    /**
+     * Called with each occurence that was found.
+     *
+     * @param address Memory address where a match was found.
+     * @param size Size of this match.
+     */
+    onMatch: (address: UInt64, size: number) => void | EnumerateAction;
+
+    /**
+     * Called when there was a memory access error while scanning.
+     *
+     * @param reason Why the memory access failed.
+     */
+    onError?: (reason: string) => void;
+
+    /**
+     * Called when the memory range has been fully scanned.
+     */
+    onComplete: () => void;
+}
+
+declare interface KernelMemoryScanMatch {
+    /**
+     * Memory address where a match was found.
+     */
+    address: UInt64;
 
     /**
      * Size of this match.
@@ -1828,14 +2039,6 @@ declare namespace Java {
     function performNow(fn: any): void;
     function scheduleOnMainThread(fn: any): void;
     function use(className: any): any;
-}
-declare namespace Kernel {
-    const available: boolean;
-    function enumerateRanges(specifier: any, callbacks: any): void;
-    function enumerateRangesSync(specifier: any): any;
-    function enumerateThreadsSync(): any;
-    function readByteArray(pointer: any, size: number): any;
-    function writeByteArray(): any;
 }
 declare namespace MemoryAccessMonitor {
     function disable(): any;

--- a/gum/backend-darwin/gumdarwin.h
+++ b/gum/backend-darwin/gumdarwin.h
@@ -106,6 +106,8 @@ GUM_API vm_prot_t gum_page_protection_to_mach (GumPageProtection page_prot);
 
 GUM_API const char * gum_symbol_name_from_darwin (const char * s);
 
+GUM_API mach_port_t gum_kernel_get_task (void);
+
 G_END_DECLS
 
 #endif

--- a/gum/backend-darwin/gumdarwinmodule.h
+++ b/gum/backend-darwin/gumdarwinmodule.h
@@ -55,6 +55,7 @@ struct _GumDarwinModule
 
   mach_port_t task;
   gboolean is_local;
+  gboolean is_kernel;
   GumCpuType cpu_type;
   gsize pointer_size;
   gsize page_size;
@@ -116,8 +117,8 @@ struct _GumDarwinModuleImageSegment
 
 struct _GumDarwinSectionDetails
 {
-  const gchar * segment_name;
-  const gchar * section_name;
+  gchar segment_name[17];
+  gchar section_name[17];
   GumAddress vm_address;
   guint64 size;
   vm_prot_t protection;
@@ -158,7 +159,7 @@ struct _GumDarwinTermPointersDetails
 
 struct _GumDarwinSegment
 {
-  gchar name[16];
+  gchar name[17];
   GumAddress vm_address;
   guint64 vm_size;
   guint64 file_offset;

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -8,12 +8,121 @@
 
 #include "gum-init.h"
 #include "gumdarwin.h"
+#include "gummemory-priv.h"
 
 #include <mach/mach.h>
+#include <mach-o/loader.h>
+#include <sys/sysctl.h>
 
-static mach_port_t gum_kernel_get_task (void);
+#define GUM_KERNEL_SLIDE_OFFSET 0x1000000
+#define GUM_KERNEL_SLIDE_SIZE 0x200000
+
+typedef struct _GumKernelScanContext GumKernelScanContext;
+typedef struct _GumKernelEnumerateModuleRangesContext
+    GumKernelEnumerateModuleRangesContext;
+typedef struct _GumKernelSearchKextContext GumKernelSearchKextContext;
+typedef struct _GumKernelKextInfo GumKernelKextInfo;
+typedef struct _GumKernelFindRangeByNameContext GumKernelFindRangeByNameContext;
+typedef struct _GumEmitModuleContext GumEmitModuleContext;
+typedef struct _GumKernelKextByNameContext GumKernelKextByNameContext;
+
+struct _GumKernelScanContext
+{
+  GumMemoryScanMatchFunc func;
+  gpointer user_data;
+
+  GumAddress cursor_userland;
+  GumAddress cursor_kernel;
+
+  gboolean carry_on;
+};
+
+struct _GumKernelEnumerateModuleRangesContext
+{
+  GumPageProtection protection;
+  GumFoundKernelModuleRangeFunc func;
+  gpointer user_data;
+};
+
+struct _GumKernelSearchKextContext
+{
+  GHashTable * kexts;
+};
+
+struct _GumKernelKextInfo
+{
+  gchar name[0x41];
+  GumAddress address;
+};
+
+struct _GumKernelFindRangeByNameContext
+{
+  const gchar * name;
+  gboolean found;
+  GumMemoryRange range;
+};
+
+struct _GumEmitModuleContext
+{
+  GumFoundModuleFunc func;
+  gpointer user_data;
+};
+
+struct _GumKernelKextByNameContext
+{
+  const gchar * module_name;
+  gboolean found;
+  GumDarwinModule * module;
+};
+
+typedef gboolean (* GumFoundKextFunc) (GumDarwinModule * module,
+    gpointer user_data);
+
+static gboolean gum_kernel_emit_match (GumAddress address, gsize size,
+    GumKernelScanContext * ctx);
+static void gum_kernel_enumerate_kexts (GumFoundKextFunc func,
+    gpointer user_data);
+static gboolean gum_kernel_scan_section (const gchar * section_name,
+    const gchar * pattern_string, GumMemoryScanMatchFunc func,
+    gpointer user_data);
+static gboolean gum_kernel_emit_module_range (
+    const GumDarwinSectionDetails * section, gpointer user_data);
+static gboolean gum_kernel_emit_module (GumDarwinModule * module,
+    gpointer user_data);
+static gsize gum_darwin_module_estimate_size (
+    GumDarwinModule * module);
+static gboolean gum_kernel_range_by_name (GumMemoryRange * out_range,
+    const gchar * name);
+static gboolean gum_kernel_find_range_by_name (
+    GumKernelModuleRangeDetails * details,
+    GumKernelFindRangeByNameContext * ctx);
+static gboolean gum_kernel_store_kext_addr (GumAddress address,
+    gsize size, GumKernelSearchKextContext * ctx);
+static gboolean gum_kernel_store_kext_name (GumAddress address,
+    gsize size, GumKernelSearchKextContext * ctx);
+static GumDarwinModule * gum_kernel_find_module_by_name (
+    const gchar * module_name);
+static gboolean gum_kernel_kext_by_name (GumDarwinModule * module,
+    GumKernelKextByNameContext * ctx);
+static GumDarwinModule * gum_kernel_get_module (void);
+static GumAddress gum_kernel_do_find_base_address (void);
+static float gum_kernel_get_version (void);
+
+#ifdef HAVE_ARM64
+
+static GumAddress gum_kernel_bruteforece_base (GumAddress unslid_base);
+static gboolean gum_kernel_is_header (GumAddress address);
+static gboolean gum_kernel_has_kld (GumAddress address);
+static gboolean gum_kernel_find_first_hit (GumAddress address, gsize size,
+    gboolean * found);
+
+#endif
+
+mach_port_t gum_kernel_get_task (void);
 static mach_port_t gum_kernel_do_init (void);
 static void gum_kernel_do_deinit (void);
+
+static GumDarwinModule * gum_kernel_cached_module = NULL;
 
 gboolean
 gum_kernel_api_is_available (void)
@@ -27,7 +136,7 @@ gum_kernel_query_page_size (void)
   return vm_kernel_page_size;
 }
 
-gpointer
+GumAddress
 gum_kernel_alloc_n_pages (guint n_pages)
 {
   mach_vm_address_t result;
@@ -38,7 +147,7 @@ gum_kernel_alloc_n_pages (guint n_pages)
 
   task = gum_kernel_get_task ();
   if (task == MACH_PORT_NULL)
-    return NULL;
+    return 0;
 
   page_size = vm_kernel_page_size;
   size = (n_pages + 1) * page_size;
@@ -54,17 +163,17 @@ gum_kernel_alloc_n_pages (guint n_pages)
       TRUE, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE);
   g_assert_cmpint (kr, ==, KERN_SUCCESS);
 
-  return GSIZE_TO_POINTER (result + page_size);
+  return result + page_size;
 }
 
 gboolean
-gum_kernel_try_mprotect (gpointer address,
+gum_kernel_try_mprotect (GumAddress address,
                          gsize size,
                          GumPageProtection page_prot)
 {
   mach_port_t task;
   gsize page_size;
-  gpointer aligned_address;
+  GumAddress aligned_address;
   gsize aligned_size;
   vm_prot_t mach_page_prot;
   kern_return_t kr;
@@ -76,14 +185,13 @@ gum_kernel_try_mprotect (gpointer address,
     return FALSE;
 
   page_size = vm_kernel_page_size;
-  aligned_address = GSIZE_TO_POINTER (
-      GPOINTER_TO_SIZE (address) & ~(page_size - 1));
+  aligned_address = address & ~(page_size - 1);
   aligned_size =
       (1 + ((address + size - 1 - aligned_address) / page_size)) * page_size;
   mach_page_prot = gum_page_protection_to_mach (page_prot);
 
-  kr = mach_vm_protect (task, GPOINTER_TO_SIZE (aligned_address),
-      aligned_size, FALSE, mach_page_prot);
+  kr = mach_vm_protect (task, aligned_address, aligned_size,
+      FALSE, mach_page_prot);
 
   return kr == KERN_SUCCESS;
 }
@@ -114,7 +222,7 @@ gum_kernel_read (GumAddress address,
     gsize chunk_size, page_offset;
 
     chunk_address = address + offset;
-    page_address = chunk_address & ~(GumAddress) (page_size - 1);
+    page_address = chunk_address & ~GUM_ADDRESS (page_size - 1);
     page_offset = chunk_address - page_address;
     chunk_size = MIN (len - offset, page_size - page_offset);
 
@@ -170,7 +278,521 @@ gum_kernel_enumerate_ranges (GumPageProtection prot,
   gum_darwin_enumerate_ranges (task, prot, func, user_data);
 }
 
-static mach_port_t
+void
+gum_kernel_scan (const GumMemoryRange * range,
+                 const GumMatchPattern * pattern,
+                 GumMemoryScanMatchFunc func,
+                 gpointer user_data)
+{
+  GumKernelScanContext ctx;
+  GumAddress cursor, end;
+  gsize size, max_chunk_size;
+
+  ctx.func = func;
+  ctx.user_data = user_data;
+
+  cursor = range->base_address;
+  size = range->size;
+  max_chunk_size = MAX (pattern->size * 2, 2048 * 512);
+  end = cursor + size - pattern->size;
+
+  while (cursor <= end)
+  {
+    gsize chunk_size;
+    guint8 * haystack;
+    GumMemoryRange subrange;
+
+    chunk_size = MIN (size, max_chunk_size);
+    haystack = gum_kernel_read (cursor, chunk_size, NULL);
+    if (haystack == NULL)
+      return;
+
+    subrange.base_address = GUM_ADDRESS (haystack);
+    subrange.size = chunk_size;
+
+    ctx.cursor_userland = GUM_ADDRESS (haystack);
+    ctx.cursor_kernel = GUM_ADDRESS (cursor);
+
+    gum_memory_scan (&subrange, pattern,
+        (GumMemoryScanMatchFunc) gum_kernel_emit_match, &ctx);
+
+    g_free (haystack);
+
+    if (!ctx.carry_on)
+      return;
+
+    cursor += chunk_size - pattern->size + 1;
+    size -= chunk_size - pattern->size + 1;
+  }
+}
+
+static gboolean
+gum_kernel_emit_match (GumAddress address,
+                       gsize size,
+                       GumKernelScanContext * ctx)
+{
+  GumAddress address_kernel = address - ctx->cursor_userland +
+      ctx->cursor_kernel;
+
+  ctx->carry_on = ctx->func (address_kernel, size, ctx->user_data);
+
+  return ctx->carry_on;
+}
+
+void
+gum_kernel_enumerate_modules (GumFoundModuleFunc func,
+                              gpointer user_data)
+{
+  GumEmitModuleContext ctx;
+
+  ctx.func = func;
+  ctx.user_data = user_data;
+
+  if (!gum_kernel_emit_module (gum_kernel_get_module (), &ctx))
+    return;
+
+  gum_kernel_enumerate_kexts (gum_kernel_emit_module, &ctx);
+}
+
+static gboolean
+gum_kernel_emit_module (GumDarwinModule * module,
+                        gpointer user_data)
+{
+  GumEmitModuleContext * ctx = user_data;
+  GumModuleDetails details;
+  GumMemoryRange range;
+
+  range.base_address = module->base_address;
+  range.size = gum_darwin_module_estimate_size (module);
+
+  details.name = module->name;
+  details.range = &range;
+  details.path = NULL;
+
+  return ctx->func (&details, ctx->user_data);
+}
+
+static void
+gum_kernel_enumerate_kexts (GumFoundKextFunc func,
+                            gpointer user_data)
+{
+  mach_port_t task;
+  GHashTable * kexts;
+  GumKernelSearchKextContext kext_ctx;
+  GHashTableIter iter;
+  gpointer item;
+  gpointer header_addr;
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return;
+
+  kexts = g_hash_table_new (NULL, NULL);
+  kext_ctx.kexts = kexts;
+
+  /* Search the first 8 bytes of mach0 header. */
+  if (!gum_kernel_scan_section ("__PRELINK_TEXT.__text", "cffaedfe0c00000100",
+        (GumMemoryScanMatchFunc) gum_kernel_store_kext_addr, &kext_ctx))
+  {
+    return;
+  }
+
+  /* Search for "com.apple" string. */
+  if (!gum_kernel_scan_section ("__PRELINK_DATA.__data", "636f6d2e6170706c65",
+        (GumMemoryScanMatchFunc) gum_kernel_store_kext_name, &kext_ctx))
+  {
+    if (!gum_kernel_scan_section ("__PRELINK_TEXT.__text", "636f6d2e6170706c65",
+          (GumMemoryScanMatchFunc) gum_kernel_store_kext_name, &kext_ctx))
+    {
+      return;
+    }
+  }
+
+  g_hash_table_iter_init (&iter, kexts);
+  while (g_hash_table_iter_next (&iter, &header_addr, &item))
+  {
+    GumKernelKextInfo * kext = item;
+    GumDarwinModule * module;
+
+    if (*kext->name == '\0')
+      continue;
+
+    module = gum_darwin_module_new_from_memory (kext->name, task, GUM_CPU_ARM64,
+        vm_kernel_page_size, kext->address);
+
+    if (module == NULL)
+      continue;
+
+    if (!func (module, user_data))
+      break;
+  }
+
+  g_hash_table_unref (kexts);
+}
+
+static gboolean
+gum_kernel_scan_section (const gchar * section_name,
+                         const gchar * pattern_string,
+                         GumMemoryScanMatchFunc func,
+                         gpointer user_data)
+{
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+
+  if (!gum_kernel_range_by_name (&range, section_name))
+    return FALSE;
+
+  pattern = gum_match_pattern_new_from_string (pattern_string);
+  if (pattern == NULL)
+    return FALSE;
+
+  gum_kernel_scan (&range, pattern, func, user_data);
+
+  gum_match_pattern_free (pattern);
+
+  return TRUE;
+}
+
+static gsize
+gum_darwin_module_estimate_size (GumDarwinModule * module)
+{
+  gsize index = 0, size = 0;
+
+  do
+  {
+    const GumDarwinSegment * segment;
+
+    segment = gum_darwin_module_segment (module, index++);
+    size += segment->vm_size;
+  }
+  while (index < module->segments->len);
+
+  return size;
+}
+
+static gboolean
+gum_kernel_range_by_name (GumMemoryRange * out_range,
+                          const gchar * name)
+{
+  GumKernelFindRangeByNameContext ctx;
+
+  ctx.name = name;
+  ctx.found = FALSE;
+
+  gum_kernel_enumerate_module_ranges ("Kernel", GUM_PAGE_NO_ACCESS,
+      (GumFoundKernelModuleRangeFunc) gum_kernel_find_range_by_name, &ctx);
+
+  if (ctx.found)
+  {
+    out_range->base_address = ctx.range.base_address;
+    out_range->size = ctx.range.size;
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+static gboolean
+gum_kernel_find_range_by_name (GumKernelModuleRangeDetails * details,
+                               GumKernelFindRangeByNameContext * ctx)
+{
+  if (strncmp (details->name, ctx->name, sizeof (details->name)) == 0)
+  {
+    ctx->range.base_address = details->address;
+    ctx->range.size = details->size;
+    ctx->found = TRUE;
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static gboolean
+gum_kernel_store_kext_addr (GumAddress address,
+                            gsize size,
+                            GumKernelSearchKextContext * ctx)
+{
+  GumKernelKextInfo * kext;
+
+  kext = g_slice_new0 (GumKernelKextInfo);
+  kext->address = address;
+
+  g_hash_table_insert (ctx->kexts, GSIZE_TO_POINTER (address), kext);
+
+  return TRUE;
+}
+
+static gboolean
+gum_kernel_store_kext_name (GumAddress address,
+                            gsize size,
+                            GumKernelSearchKextContext * ctx)
+{
+  GumKernelKextInfo * kext;
+  guint8 * buf;
+
+  /* Reference: osfmk/mach/kmod.h */
+  buf = gum_kernel_read (address + 0x8c, 8, NULL);
+  kext = g_hash_table_lookup (ctx->kexts, *((GumAddress**)buf));
+  g_free (buf);
+
+  if (kext == NULL)
+    return TRUE;
+
+  buf = gum_kernel_read (address, 0x40, NULL);
+  strncpy (kext->name, (gchar*) buf, 0x40);
+  kext->name[0x40] = 0;
+  g_free (buf);
+
+  return TRUE;
+}
+
+void
+gum_kernel_enumerate_module_ranges (const gchar * module_name,
+                                    GumPageProtection prot,
+                                    GumFoundKernelModuleRangeFunc func,
+                                    gpointer user_data)
+{
+  GumDarwinModule * module;
+  GumKernelEnumerateModuleRangesContext ctx;
+
+  module = gum_kernel_find_module_by_name (module_name);
+  if (module == NULL)
+    return;
+
+  ctx.protection = prot;
+  ctx.func = func;
+  ctx.user_data = user_data;
+
+  gum_darwin_module_enumerate_sections (module, gum_kernel_emit_module_range,
+      &ctx);
+}
+
+static GumDarwinModule *
+gum_kernel_find_module_by_name (const gchar * module_name)
+{
+  GumKernelKextByNameContext ctx;
+
+  if (strcmp (module_name, "Kernel") == 0)
+    return gum_kernel_get_module ();
+
+  ctx.module_name = module_name;
+  ctx.found = FALSE;
+
+  gum_kernel_enumerate_kexts ((GumFoundKextFunc) gum_kernel_kext_by_name, &ctx);
+
+  if (!ctx.found)
+    return NULL;
+
+  return ctx.module;
+}
+
+static gboolean
+gum_kernel_kext_by_name (GumDarwinModule * module,
+                         GumKernelKextByNameContext * ctx)
+{
+  ctx->found = strcmp (module->name, ctx->module_name) == 0;
+
+  if (ctx->found)
+    ctx->module = module;
+
+  return !ctx->found;
+}
+
+
+static gboolean
+gum_kernel_emit_module_range (const GumDarwinSectionDetails * section,
+                              gpointer user_data)
+{
+  GumKernelEnumerateModuleRangesContext * ctx = user_data;
+  GumPageProtection prot;
+  GumKernelModuleRangeDetails details;
+
+  prot = gum_page_protection_from_mach (section->protection);
+  if ((prot & ctx->protection) != ctx->protection)
+    return TRUE;
+
+  g_snprintf (details.name, sizeof (details.name), "%s.%s",
+      section->segment_name, section->section_name);
+  details.address = section->vm_address;
+  details.size = section->size;
+  details.protection = prot;
+
+  return ctx->func (&details, ctx->user_data);
+}
+
+static GumDarwinModule *
+gum_kernel_get_module (void)
+{
+  mach_port_t task;
+  GumAddress base;
+
+  if (gum_kernel_cached_module != NULL)
+    return gum_kernel_cached_module;
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return NULL;
+
+  base = gum_kernel_find_base_address ();
+
+  gum_kernel_cached_module = gum_darwin_module_new_from_memory ("Kernel", task,
+      GUM_CPU_ARM64, vm_kernel_page_size, base);
+
+  return gum_kernel_cached_module;
+}
+
+GumAddress
+gum_kernel_find_base_address (void)
+{
+  static GOnce get_base_once = G_ONCE_INIT;
+
+  g_once (&get_base_once, (GThreadFunc) gum_kernel_do_find_base_address, NULL);
+
+  return (GumAddress) get_base_once.retval;
+}
+
+static GumAddress
+gum_kernel_do_find_base_address (void)
+{
+  GumAddress base = 0;
+  float version;
+
+  version = gum_kernel_get_version ();
+
+#ifdef HAVE_ARM64
+  if (version >= 16.0) /* iOS 10.0+ */
+    base = gum_kernel_bruteforece_base (0xfffffff007004000LL);
+  else if (version >= 15.0) /* iOS 9.0+ */
+    base = gum_kernel_bruteforece_base (0xffffff8004004000LL);
+#endif
+
+  return base;
+}
+
+static float
+gum_kernel_get_version (void)
+{
+  char buf[256];
+  size_t size;
+  int res;
+  float version;
+
+  size = sizeof (buf);
+  res = sysctlbyname ("kern.osrelease", buf, &size, NULL, 0);
+  g_assert_cmpint (res, ==, 0);
+
+  version = atof (buf);
+
+  return version;
+}
+
+#ifdef HAVE_ARM64
+
+static GumAddress
+gum_kernel_bruteforece_base (GumAddress unslid_base)
+{
+  /*
+   * References & credits:
+   * http://conference.hackinthebox.org/hitbsecconf2012kul/materials
+   *    /D1T2%20-%20Mark%20Dowd%20&%20Tarjei%20Mandt%20-%20iOS6%20Security.pdf
+   * https://www.theiphonewiki.com/wiki/Kernel_ASLR
+   * https://www.wikiwand.com/en/Address_space_layout_randomization
+   * https://www.slideshare.net/i0n1c
+   *    /csw2013-stefan-esserios6exploitation280dayslater
+   *    /19-KASLR_iOS_6_introduces_KASLR
+   * http://people.oregonstate.edu/~jangye/assets/papers/2016/jang:drk-bh.pdf
+   */
+
+  gint slide_byte;
+
+  if (gum_kernel_is_header (unslid_base + 0x21000000))
+    return unslid_base + 0x21000000;
+
+  for (slide_byte = 255; slide_byte > 0; slide_byte--)
+  {
+    GumAddress base = unslid_base;
+
+    base += GUM_KERNEL_SLIDE_OFFSET +
+        ((1 + slide_byte) * GUM_KERNEL_SLIDE_SIZE);
+
+    if (gum_kernel_is_header (base))
+      return base;
+  }
+
+  return 0;
+}
+
+static gboolean
+gum_kernel_is_header (GumAddress address)
+{
+  gboolean result = FALSE;
+  guint8 * header = NULL;
+  gsize n_bytes_read;
+
+  header = gum_kernel_read (address, 28, &n_bytes_read);
+  if (n_bytes_read != 28 || header == NULL)
+    goto bail_out;
+
+  /* Magic */
+  if (*((guint32*) (header + 0)) != MH_MAGIC_64)
+    goto bail_out;
+
+  /* Cpu type */
+  if (*((guint32*) (header + 4)) != CPU_TYPE_ARM64)
+    goto bail_out;
+
+  /* File type */
+  if (*((guint32*) (header + 12)) != MH_EXECUTE)
+    goto bail_out;
+
+  if (!gum_kernel_has_kld (address))
+    goto bail_out;
+
+  result = TRUE;
+
+bail_out:
+  if (header != NULL)
+    g_free (header);
+
+  return result;
+}
+
+static gboolean
+gum_kernel_has_kld (GumAddress address)
+{
+  gboolean found = FALSE;
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+
+  range.base_address = address;
+  range.size = 2048;
+
+  /* __KLD */
+  pattern = gum_match_pattern_new_from_string ("5f 5f 4b 4c 44");
+  if (pattern == NULL)
+    return FALSE;
+
+  gum_kernel_scan (&range, pattern,
+      (GumMemoryScanMatchFunc) gum_kernel_find_first_hit, &found);
+
+  gum_match_pattern_free (pattern);
+
+  return found;
+}
+
+static gboolean
+gum_kernel_find_first_hit (GumAddress address,
+                           gsize size,
+                           gboolean * found)
+{
+  *found = TRUE;
+
+  return FALSE;
+}
+
+#endif
+
+mach_port_t
 gum_kernel_get_task (void)
 {
   static GOnce init_once = G_ONCE_INIT;

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1856,7 +1856,7 @@ gum_darwin_find_linkedit (const guint8 * module,
     {
       struct segment_command * sc = (struct segment_command *) lc;
       struct segment_command_64 * sc64 = (struct segment_command_64 *) lc;
-      if (strcmp (sc->segname, "__LINKEDIT") == 0)
+      if (strncmp (sc->segname, "__LINKEDIT", 10) == 0)
       {
         if (header->magic == MH_MAGIC)
           *linkedit = sc->vmaddr - sc->fileoff;

--- a/gum/gumkernel.c
+++ b/gum/gumkernel.c
@@ -20,14 +20,14 @@ gum_kernel_query_page_size (void)
   return 0;
 }
 
-gpointer
+GumAddress
 gum_kernel_alloc_n_pages (guint n_pages)
 {
-  return NULL;
+  return 0;
 }
 
 gboolean
-gum_kernel_try_mprotect (gpointer address,
+gum_kernel_try_mprotect (GumAddress address,
                          gsize size,
                          GumPageProtection page_prot)
 {
@@ -51,10 +51,38 @@ gum_kernel_write (GumAddress address,
 }
 
 void
+gum_kernel_scan (const GumMemoryRange * range,
+                 const GumMatchPattern * pattern,
+                 GumMemoryScanMatchFunc func,
+                 gpointer user_data)
+{
+}
+
+void
 gum_kernel_enumerate_ranges (GumPageProtection prot,
                              GumFoundRangeFunc func,
                              gpointer user_data)
 {
+}
+
+void
+gum_kernel_enumerate_module_ranges (const gchar * module_name,
+                                    GumPageProtection prot,
+                                    GumFoundKernelModuleRangeFunc func,
+                                    gpointer user_data)
+{
+}
+
+void
+gum_kernel_enumerate_modules (GumFoundModuleFunc func,
+                              gpointer user_data)
+{
+}
+
+GumAddress
+gum_kernel_find_base_address (void)
+{
+  return 0;
 }
 
 #endif

--- a/gum/gumkernel.h
+++ b/gum/gumkernel.h
@@ -11,17 +11,39 @@
 
 G_BEGIN_DECLS
 
+typedef struct _GumKernelModuleRangeDetails GumKernelModuleRangeDetails;
+
+struct _GumKernelModuleRangeDetails
+{
+  gchar name[48];
+  GumAddress address;
+  guint64 size;
+  GumPageProtection protection;
+};
+
+typedef gboolean (* GumFoundKernelModuleRangeFunc) (
+    const GumKernelModuleRangeDetails * details, gpointer user_data);
+
 GUM_API gboolean gum_kernel_api_is_available (void);
 GUM_API guint gum_kernel_query_page_size (void);
-GUM_API gpointer gum_kernel_alloc_n_pages (guint n_pages);
-GUM_API gboolean gum_kernel_try_mprotect (gpointer address, gsize size,
+GUM_API GumAddress gum_kernel_alloc_n_pages (guint n_pages);
+GUM_API gboolean gum_kernel_try_mprotect (GumAddress address, gsize size,
     GumPageProtection page_prot);
 GUM_API guint8 * gum_kernel_read (GumAddress address, gsize len,
     gsize * n_bytes_read);
 GUM_API gboolean gum_kernel_write (GumAddress address, const guint8 * bytes,
     gsize len);
+GUM_API void gum_kernel_scan (const GumMemoryRange * range,
+    const GumMatchPattern * pattern, GumMemoryScanMatchFunc func,
+    gpointer user_data);
 GUM_API void gum_kernel_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
+GUM_API void gum_kernel_enumerate_module_ranges (const gchar * module_name,
+    GumPageProtection prot, GumFoundKernelModuleRangeFunc func,
+    gpointer user_data);
+GUM_API void gum_kernel_enumerate_modules (GumFoundModuleFunc func,
+    gpointer user_data);
+GUM_API GumAddress gum_kernel_find_base_address (void);
 
 G_END_DECLS
 

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -180,6 +180,8 @@ TEST_LIST_BEGIN (script)
   SCRIPT_TESTENTRY (native_pointer_provides_arithmetic_operations)
   SCRIPT_TESTENTRY (native_pointer_to_match_pattern)
   SCRIPT_TESTENTRY (native_pointer_can_be_constructed_from_64bit_value)
+  SCRIPT_TESTENTRY (uint64_provides_arithmetic_operations)
+  SCRIPT_TESTENTRY (int64_provides_arithmetic_operations)
   SCRIPT_TESTENTRY (native_function_can_be_invoked)
   SCRIPT_TESTENTRY (native_function_can_be_intercepted_when_thread_is_ignored)
   SCRIPT_TESTENTRY (native_function_should_implement_call_and_apply)
@@ -1443,6 +1445,48 @@ SCRIPT_TESTCASE (native_pointer_can_be_constructed_from_64bit_value)
       "send(ptr(int64(-1)).equals(ptr('0xffffffffffffffff')));");
   EXPECT_SEND_MESSAGE_WITH ("true");
 #endif
+}
+
+SCRIPT_TESTCASE (uint64_provides_arithmetic_operations)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "send(uint64(3).add(4).toNumber());"
+      "send(uint64(7).sub(4).toNumber());"
+      "send(uint64(6).and(3).toNumber());"
+      "send(uint64(6).or(3).toNumber());"
+      "send(uint64(6).xor(3).toNumber());"
+      "send(uint64(63).shr(4).toNumber());"
+      "send(uint64(1).shl(3).toNumber());"
+      "send(uint64(0).not().toString());");
+  EXPECT_SEND_MESSAGE_WITH ("7");
+  EXPECT_SEND_MESSAGE_WITH ("3");
+  EXPECT_SEND_MESSAGE_WITH ("2");
+  EXPECT_SEND_MESSAGE_WITH ("7");
+  EXPECT_SEND_MESSAGE_WITH ("5");
+  EXPECT_SEND_MESSAGE_WITH ("3");
+  EXPECT_SEND_MESSAGE_WITH ("8");
+  EXPECT_SEND_MESSAGE_WITH ("\"18446744073709551615\"");
+}
+
+SCRIPT_TESTCASE (int64_provides_arithmetic_operations)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "send(int64(3).add(4).toNumber());"
+      "send(int64(7).sub(4).toNumber());"
+      "send(int64(6).and(3).toNumber());"
+      "send(int64(6).or(3).toNumber());"
+      "send(int64(6).xor(3).toNumber());"
+      "send(int64(63).shr(4).toNumber());"
+      "send(int64(1).shl(3).toNumber());"
+      "send(int64(0).not().toNumber());");
+  EXPECT_SEND_MESSAGE_WITH ("7");
+  EXPECT_SEND_MESSAGE_WITH ("3");
+  EXPECT_SEND_MESSAGE_WITH ("2");
+  EXPECT_SEND_MESSAGE_WITH ("7");
+  EXPECT_SEND_MESSAGE_WITH ("5");
+  EXPECT_SEND_MESSAGE_WITH ("3");
+  EXPECT_SEND_MESSAGE_WITH ("8");
+  EXPECT_SEND_MESSAGE_WITH ("-1");
 }
 
 static gint


### PR DESCRIPTION
- add scan, enumerateModules, enumerateModuleRanges
- add kernel base getter
- fix overflow on section / segment names

this works on 64-bit devices, tested on versions from iOS 9.0 to iOS 11.3.

## Added interfaces

`Kernel.scan()` / `Kernel.scanSync()` work exactly like their `Memory` counterparts, supporting bit masks too.

`Kernel.enumerateModules()` / `Kernel.enumerateModulesSync()` lists all the KEXTs, and the main kernel module (called `"Kernel"`), example:

```
[iPhone::SystemSession]-> Kernel.enumerateModulesSync()
[
    {
        "base": "0xfffffff016604000",
        "name": "Kernel",
        "path": null,
        "size": 31886248
    },
    {
        "base": "0xfffffff0152bc940",
        "name": "com.apple.driver.AppleEffaceableStorage",
        "path": null,
        "size": 28550
    },
    {
        "base": "0xfffffff015272dc0",
        "name": "com.apple.driver.AppleMultitouchSPI",
        "path": null,
        "size": 111560
    },
...
```

`Kernel.enumerateModuleRanges()` / `Kernel.enumerateModuleRangesSync()` list sections of a module by name (taken by the previous call). The semantic is the same of `Module.enumerateRanges()` Example:

```
[iPhone::SystemSession]-> Kernel.enumerateModuleRangesSync('com.apple.driver.AppleMultitouchSPI', '---')
[
    {
        "address": "0xfffffff0152733c8",
        "name": "__TEXT.__const",
        "protection": "r--",
        "size": 288
    },
    {
        "address": "0xfffffff0152734e8",
        "name": "__TEXT.__cstring",
        "protection": "r--",
        "size": 14675
    },
    {
        "address": "0xfffffff015276e3b",
        "name": "__TEXT.__os_log",
        "protection": "r--",
        "size": 1577
    },
    {
        "address": "0xfffffff015a44000",
        "name": "__TEXT_EXEC.__text",
        "protection": "r-x",
        "size": 78788
    },
...
```

the `Kernel.base` property returns a pointer to the base of the kernel in memory (intended as the address of its `__TEXT` segment).