### PR TITLE
Fix Linux module enumeration assumption about executable ELF headers

### DIFF
--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -803,7 +803,7 @@ gum_process_enumerate_modules_by_parsing_proc_maps (GumFoundModuleFunc func,
     GumAddress end;
     gchar perms[5] = { 0, };
     gint n;
-    gboolean readable, executable, shared;
+    gboolean readable, shared;
     gchar * name;
 
     if (!got_line)
@@ -829,9 +829,8 @@ gum_process_enumerate_modules_by_parsing_proc_maps (GumFoundModuleFunc func,
     g_assert_cmpint (n, ==, 4);
 
     readable = perms[0] == 'r';
-    executable = perms[2] == 'x';
     shared = perms[3] == 's';
-    if (!readable || !executable || shared)
+    if (!readable || shared)
       continue;
     else if (path[0] != '/' || g_str_has_prefix (path, "/dev/"))
       continue;


### PR DESCRIPTION
Bugfix for the second issue already reported in https://github.com/frida/frida-core/pull/208.

We're just removing the check of the executable permission on the section.

Thanks for pointing me the code !