### PR TITLE
Add GumJS locking API and rework locking

### DIFF
--- a/bindings/gumjs/gumdukcore.h
+++ b/bindings/gumjs/gumdukcore.h
@@ -61,7 +61,7 @@ struct _GumDukCore
   duk_context * heap_ctx;
   GumDukScope * current_scope;
 
-  GRecMutex mutex;
+  GRecMutex * mutex;
   volatile guint usage_count;
   volatile guint mutex_depth;
   volatile gboolean heap_thread_in_use;
@@ -167,7 +167,7 @@ struct _GumDukNativeResource
 };
 
 G_GNUC_INTERNAL void _gum_duk_core_init (GumDukCore * self,
-    GumDukScript * script, const gchar * runtime_source_map,
+    GumDukScript * script, GRecMutex * mutex, const gchar * runtime_source_map,
     GumDukInterceptor * interceptor, GumDukStalker * stalker,
     GumDukMessageEmitter message_emitter, GumScriptScheduler * scheduler,
     duk_context * ctx);

--- a/bindings/gumjs/gumdukscript.c
+++ b/bindings/gumjs/gumdukscript.c
@@ -448,9 +448,11 @@ gum_duk_script_create_context (GumDukScript * self,
 
   self->ctx = ctx;
 
-  _gum_duk_core_init (core, self, gumjs_frida_source_map, &self->interceptor,
-      &self->stalker, gum_duk_script_emit,
-      gum_duk_script_backend_get_scheduler (self->backend), self->ctx);
+  _gum_duk_core_init (core, self,
+      gum_duk_script_backend_get_scope_mutex (self->backend),
+      gumjs_frida_source_map, &self->interceptor, &self->stalker,
+      gum_duk_script_emit, gum_duk_script_backend_get_scheduler (self->backend),
+      self->ctx);
 
   scope.ctx = self->ctx;
   core->current_scope = &scope;

--- a/bindings/gumjs/gumdukscriptbackend.h
+++ b/bindings/gumjs/gumdukscriptbackend.h
@@ -21,6 +21,8 @@ G_GNUC_INTERNAL gpointer gum_duk_script_backend_create_heap (
 G_GNUC_INTERNAL gboolean gum_duk_script_backend_push_program (
     GumDukScriptBackend * self, gpointer ctx, const gchar * name,
     const gchar * source, GError ** error);
+G_GNUC_INTERNAL GRecMutex * gum_duk_script_backend_get_scope_mutex (
+    GumDukScriptBackend * self);
 G_GNUC_INTERNAL GumScriptScheduler * gum_duk_script_backend_get_scheduler (
     GumDukScriptBackend * self);
 

--- a/bindings/gumjs/gumscriptbackend.c
+++ b/bindings/gumjs/gumscriptbackend.c
@@ -224,6 +224,20 @@ gum_script_backend_post_debug_message (GumScriptBackend * self,
   GUM_SCRIPT_BACKEND_GET_IFACE (self)->post_debug_message (self, message);
 }
 
+void
+gum_script_backend_with_lock_held (GumScriptBackend * self,
+                                   GumScriptBackendLockedFunc func,
+                                   gpointer user_data)
+{
+  GUM_SCRIPT_BACKEND_GET_IFACE (self)->with_lock_held (self, func, user_data);
+}
+
+gboolean
+gum_script_backend_is_locked (GumScriptBackend * self)
+{
+  return GUM_SCRIPT_BACKEND_GET_IFACE (self)->is_locked (self);
+}
+
 GumScriptScheduler *
 gum_script_backend_get_scheduler (GumScriptBackend * self)
 {

--- a/bindings/gumjs/gumscriptbackend.h
+++ b/bindings/gumjs/gumscriptbackend.h
@@ -18,6 +18,7 @@ G_DECLARE_INTERFACE (GumScriptBackend, gum_script_backend, GUM, SCRIPT_BACKEND,
 
 typedef void (* GumScriptBackendDebugMessageHandler) (const gchar * message,
     gpointer user_data);
+typedef void (* GumScriptBackendLockedFunc) (gpointer user_data);
 
 struct _GumScriptBackendInterface
 {
@@ -51,6 +52,10 @@ struct _GumScriptBackendInterface
       GumScriptBackendDebugMessageHandler handler, gpointer data,
       GDestroyNotify data_destroy);
   void (* post_debug_message) (GumScriptBackend * self, const gchar * message);
+
+  void (* with_lock_held) (GumScriptBackend * self,
+      GumScriptBackendLockedFunc func, gpointer user_data);
+  gboolean (* is_locked) (GumScriptBackend * self);
 
   GumScriptScheduler * (* get_scheduler) (GumScriptBackend * self);
 };
@@ -90,6 +95,10 @@ GUM_API void gum_script_backend_set_debug_message_handler (
     gpointer data, GDestroyNotify data_destroy);
 GUM_API void gum_script_backend_post_debug_message (GumScriptBackend * self,
     const gchar * message);
+
+GUM_API void gum_script_backend_with_lock_held (GumScriptBackend * self,
+    GumScriptBackendLockedFunc func, gpointer user_data);
+GUM_API gboolean gum_script_backend_is_locked (GumScriptBackend * self);
 
 GUM_API GumScriptScheduler * gum_script_backend_get_scheduler (
     GumScriptBackend * self);

--- a/vapi/frida-gumjs-1.0.vapi
+++ b/vapi/frida-gumjs-1.0.vapi
@@ -9,6 +9,7 @@ namespace Gum {
 	[CCode (cheader_filename = "gumjs/gumscriptbackend.h", type_cname = "GumScriptBackendInterface")]
 	public interface ScriptBackend : GLib.Object {
 		public delegate void DebugMessageHandler (string message);
+		public delegate void LockedFunc ();
 
 		public static unowned ScriptBackend obtain ();
 		public static unowned ScriptBackend obtain_v8 ();
@@ -26,6 +27,9 @@ namespace Gum {
 		public void post_debug_message (string message);
 
 		public unowned ScriptScheduler get_scheduler ();
+
+		public void with_lock_held (Gum.ScriptBackend.LockedFunc func);
+		public bool is_locked ();
 	}
 
 	[CCode (cheader_filename = "gumjs/gumscript.h", type_cname = "GumScriptInterface")]


### PR DESCRIPTION
- Provide a way to run some code with a ScriptBackend's lock held,
  and a way to check if the lock is currently held.
- Consolidate Duktape locking to one lock like on V8.
- Fix V8 unlock logic when an exception occurs.