### PR TITLE
Show the actual start address when viewing a pointer.

### DIFF
--- a/bindings/gumjs/runtime/hexdump.js
+++ b/bindings/gumjs/runtime/hexdump.js
@@ -11,6 +11,7 @@ function hexdump(target, options) {
   const useAnsi = options.hasOwnProperty('ansi') ? options.ansi : false;
 
   let buffer;
+  let startAddress = NULL;
   if (target instanceof ArrayBuffer) {
     if (length === undefined)
       length = target.byteLength;
@@ -19,6 +20,7 @@ function hexdump(target, options) {
     if (length === undefined)
       length = 256;
     buffer = Memory.readByteArray(target, length);
+    startAddress = target;
   }
 
   const bytes = new Uint8Array(buffer);
@@ -60,7 +62,7 @@ function hexdump(target, options) {
       result.push('\n');
 
     result.push(
-      offsetColor, pad(offset.toString(16), leftColumnWidth, '0'), resetColor,
+      offsetColor, pad(startAddress.add(offset).toString(16), leftColumnWidth, '0'), resetColor,
       columnPadding
     );
 


### PR DESCRIPTION
I have only tested this on 32bits. So using the `NativePointer.toInt32()` works. Not sure how this should work on 64-bits adressing. I'm also not sure why NativePointer will only return signed integers. Isn't it more logical to return an unsigned int?