### PR TITLE
Let the js lock go before calling gum_module_ensure_initialized

### DIFF
--- a/bindings/gumjs/gumdukmodule.c
+++ b/bindings/gumjs/gumdukmodule.c
@@ -125,11 +125,15 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_module_construct)
 GUMJS_DEFINE_FUNCTION (gumjs_module_ensure_initialized)
 {
   const gchar * name;
+  GumDukScope scope = GUM_DUK_SCOPE_INIT (args->core);
   gboolean success;
 
   _gum_duk_args_parse (args, "s", &name);
 
+  _gum_duk_scope_suspend (&scope);
   success = gum_module_ensure_initialized (name);
+  _gum_duk_scope_resume (&scope);
+
   if (!success)
   {
     _gum_duk_throw (ctx, "unable to find module '%s'", name);

--- a/bindings/gumjs/gumv8module.cpp
+++ b/bindings/gumjs/gumv8module.cpp
@@ -235,7 +235,13 @@ GUMJS_DEFINE_FUNCTION (gumjs_module_ensure_initialized)
   if (!_gum_v8_args_parse (args, "s", &name))
     return;
 
-  auto success = gum_module_ensure_initialized (name);
+  gboolean success;
+  {
+    ScriptUnlocker unlocker (core);
+
+    success = gum_module_ensure_initialized (name);
+  }
+
   if (!success)
   {
     _gum_v8_throw (isolate, "unable to find module '%s'", name);


### PR DESCRIPTION
Because internally it’s calling dlopen which in turn can lock on dyld lock, causing a deadlock.

Example deadlock stack trace excerpt:

```
Thread 6
0   libsystem_pthread.dylib         _pthread_mutex_lock_wait
1   libsystem_pthread.dylib         _pthread_mutex_lock_slow$VARIANT$mp
2   frida-agent.dylib               _gum_duk_scope_enter (gumdukcore.c:1138)
3   frida-agent.dylib               gum_duk_invocation_listener_on_leave (gumdukinterceptor.c:697)
4   frida-agent.dylib               _gum_function_context_end_invocation (guminterceptor.c:1360)
5   libsystem_kernel.dylib          write
6   MyApp                           0x429e68
...

Thread 7
0   libsystem_pthread.dylib         _pthread_mutex_lock_wait
1   libsystem_pthread.dylib         _pthread_mutex_lock_slow$VARIANT$mp
2   libdyld.dylib                   LockHelper::LockHelper()
3   libdyld.dylib                   dladdr
4   MyApp                           0x45336c

Thread 8
0   libsystem_pthread.dylib         _pthread_mutex_lock_wait
1   libsystem_pthread.dylib         _pthread_mutex_lock_slow$VARIANT$mp
2   libdyld.dylib                   dyldGlobalLockAcquire()
3   dyld                            dlopen
4   libdyld.dylib                   dlopen
5   frida-agent.dylib               gum_module_ensure_initialized (gumprocess-darwin.c:596)
6   frida-agent.dylib               gumjs_module_ensure_initialized (gumdukmodule.c:125)
7   frida-agent.dylib               duk__handle_call_raw (duk_js_call.c:0)
...

Thread 10
0   libsystem_pthread.dylib         _pthread_mutex_lock_wait
1   libsystem_pthread.dylib         _pthread_mutex_lock_slow$VARIANT$mp
2   frida-agent.dylib               _gum_duk_scope_enter (gumdukcore.c:1138)
3   frida-agent.dylib               gum_duk_invocation_listener_on_leave (gumdukinterceptor.c:697)
4   frida-agent.dylib               _gum_function_context_end_invocation (guminterceptor.c:1360)
5   libsystem_kernel.dylib          write
6   MyApp                            0x411178
7   dyld                            dyld::registerAddCallback(void (*)(mach_header const*, long))
8   libdyld.dylib                   _dyld_register_func_for_add_image
9   ???                             0x10836cb0c

```