### PR TITLE
Fix have_v8 undefined

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -256,6 +256,8 @@ if get_option('enable_gumjs')
     gumjs_extra_deps += [v8_dep]
     gumjs_extra_requires += ['v8-7.0']
   endif
+else
+  have_v8 = false
 endif
 
 configure_file(input: 'config.h.in',


### PR DESCRIPTION
If the options enable_gumpp and enable_gumjs in meson_options.txt are set to false, it will fail to compile as have_v8 is undefined.