### PR TITLE
Improve Kernel APIs to support weird iOS kernels

### DIFF
--- a/bindings/gumjs/gumdukcore.h
+++ b/bindings/gumjs/gumdukcore.h
@@ -42,11 +42,13 @@ typedef struct _GumDukNativePointerImpl GumDukNativePointerImpl;
 typedef struct _GumDukCpuContext GumDukCpuContext;
 typedef guint GumDukCpuContextAccess;
 typedef struct _GumDukNativeResource GumDukNativeResource;
+typedef struct _GumDukKernelResource GumDukKernelResource;
 
 typedef void (* GumDukWeakNotify) (gpointer data);
 typedef void (* GumDukFlushNotify) (GumDukScript * script);
 typedef void (* GumDukMessageEmitter) (GumDukScript * script,
     const gchar * message, GBytes * data);
+typedef void (* GumDukKernelNotify) (guint64 data);
 
 struct _GumDukCore
 {
@@ -94,6 +96,8 @@ struct _GumDukCore
   GumDukHeapPtr native_resource;
   GumDukHeapPtr native_function;
   GumDukHeapPtr native_function_prototype;
+  GumDukHeapPtr kernel_pointer;
+  GumDukHeapPtr kernel_resource;
   GumDukHeapPtr system_function;
   GumDukHeapPtr system_function_prototype;
   GumDukHeapPtr cpu_context;
@@ -164,6 +168,13 @@ struct _GumDukNativeResource
   GumDukNativePointer parent;
 
   GDestroyNotify notify;
+};
+
+struct _GumDukKernelResource
+{
+  GumDukUInt64 parent;
+
+  GumDukKernelNotify notify;
 };
 
 G_GNUC_INTERNAL void _gum_duk_core_init (GumDukCore * self,

--- a/bindings/gumjs/gumdukkernel.c
+++ b/bindings/gumjs/gumdukkernel.c
@@ -436,8 +436,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
 
   address = gum_kernel_alloc_n_pages (n_pages);
 
-  _gum_duk_push_kernel_resource (ctx, address,
-      gum_kernel_free_pages, core);
+  _gum_duk_push_kernel_resource (ctx, address, gum_kernel_free_pages, core);
   return 1;
 }
 

--- a/bindings/gumjs/gumdukkernel.c
+++ b/bindings/gumjs/gumdukkernel.c
@@ -68,7 +68,6 @@ GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
 static gboolean gum_emit_module_range (
     const GumKernelModuleRangeDetails * details, GumDukMatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
-GUMJS_DECLARE_FUNCTION (gumjs_kernel_free)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 
 static int gum_duk_kernel_read (GumMemoryValueType type,
@@ -140,7 +139,6 @@ static const duk_function_list_entry gumjs_kernel_functions[] =
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges, 2 },
   { "_enumerateModuleRanges", gumjs_kernel_enumerate_module_ranges, 3 },
   { "alloc", gumjs_kernel_alloc, 2 },
-  { "free", gumjs_kernel_free, 1 },
   { "protect", gumjs_kernel_protect, 3 },
 
   GUMJS_EXPORT_MEMORY_READ_WRITE ("S8", S8),
@@ -437,23 +435,10 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
   n_pages = ((size + page_size - 1) & ~(page_size - 1)) / page_size;
 
   address = gum_kernel_alloc_n_pages (n_pages);
-  _gum_duk_push_uint64 (ctx, address, core);
 
+  _gum_duk_push_kernel_resource (ctx, address,
+      gum_kernel_free_pages, core);
   return 1;
-}
-
-GUMJS_DEFINE_FUNCTION (gumjs_kernel_free)
-{
-  GumAddress address;
-
-  gum_duk_kernel_check_api_available (ctx);
-
-  _gum_duk_args_parse (args, "Q", &address);
-
-  if (!gum_kernel_try_free_pages (address))
-    _gum_duk_throw (ctx, "cannot free that range");
-
-  return 0;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)

--- a/bindings/gumjs/gumdukkernel.c
+++ b/bindings/gumjs/gumdukkernel.c
@@ -53,6 +53,7 @@ struct _GumKernelScanContext
 
 GUMJS_DECLARE_GETTER (gumjs_kernel_get_available)
 GUMJS_DECLARE_GETTER (gumjs_kernel_get_base)
+GUMJS_DECLARE_SETTER (gumjs_kernel_set_base)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_modules)
 static gboolean gum_emit_module (const GumModuleDetails * details,
     GumDukMatchContext * mc);
@@ -67,6 +68,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_kernel_enumerate_module_ranges)
 static gboolean gum_emit_module_range (
     const GumKernelModuleRangeDetails * details, GumDukMatchContext * mc);
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_alloc)
+GUMJS_DECLARE_FUNCTION (gumjs_kernel_free)
 GUMJS_DECLARE_FUNCTION (gumjs_kernel_protect)
 
 static int gum_duk_kernel_read (GumMemoryValueType type,
@@ -127,7 +129,7 @@ static void gum_duk_kernel_check_api_available (duk_context * ctx);
 static const GumDukPropertyEntry gumjs_kernel_values[] =
 {
   { "available", gumjs_kernel_get_available, NULL },
-  { "base", gumjs_kernel_get_base, NULL },
+  { "base", gumjs_kernel_get_base, gumjs_kernel_set_base },
 
   { NULL, NULL, NULL }
 };
@@ -138,6 +140,7 @@ static const duk_function_list_entry gumjs_kernel_functions[] =
   { "_enumerateRanges", gumjs_kernel_enumerate_ranges, 2 },
   { "_enumerateModuleRanges", gumjs_kernel_enumerate_module_ranges, 3 },
   { "alloc", gumjs_kernel_alloc, 2 },
+  { "free", gumjs_kernel_free, 1 },
   { "protect", gumjs_kernel_protect, 3 },
 
   GUMJS_EXPORT_MEMORY_READ_WRITE ("S8", S8),
@@ -212,6 +215,18 @@ GUMJS_DEFINE_GETTER (gumjs_kernel_get_base)
   _gum_duk_push_uint64 (ctx, address, core);
 
   return 1;
+}
+
+GUMJS_DEFINE_SETTER (gumjs_kernel_set_base)
+{
+  GumAddress address;
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "Q", &address);
+
+  gum_kernel_set_base_address (address);
+  return 0;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_enumerate_modules)
@@ -382,7 +397,7 @@ gum_emit_module_range (const GumKernelModuleRangeDetails * details,
   duk_put_prop_string (ctx, -2, "name");
 
   _gum_duk_push_uint64 (ctx, details->address, scope->core);
-  duk_put_prop_string (ctx, -2, "address");
+  duk_put_prop_string (ctx, -2, "base");
 
   duk_push_uint (ctx, details->size);
   duk_put_prop_string (ctx, -2, "size");
@@ -425,6 +440,20 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
   _gum_duk_push_uint64 (ctx, address, core);
 
   return 1;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_kernel_free)
+{
+  GumAddress address;
+
+  gum_duk_kernel_check_api_available (ctx);
+
+  _gum_duk_args_parse (args, "Q", &address);
+
+  if (!gum_kernel_try_free_pages (address))
+    _gum_duk_throw (ctx, "cannot free that range");
+
+  return 0;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_kernel_protect)

--- a/bindings/gumjs/gumdukvalue.c
+++ b/bindings/gumjs/gumdukvalue.c
@@ -1292,6 +1292,18 @@ _gum_duk_push_native_resource (duk_context * ctx,
   duk_new (ctx, 2);
 }
 
+void
+_gum_duk_push_kernel_resource (duk_context * ctx,
+                               guint64 data,
+                               GumDukKernelNotify notify,
+                               GumDukCore * core)
+{
+  duk_push_heapptr (ctx, core->kernel_resource);
+  _gum_duk_push_uint64 (ctx, data, core);
+  duk_push_pointer (ctx, GUM_FUNCPTR_TO_POINTER (notify));
+  duk_new (ctx, 2);
+}
+
 GumDukCpuContext *
 _gum_duk_push_cpu_context (duk_context * ctx,
                            GumCpuContext * handle,

--- a/bindings/gumjs/gumdukvalue.h
+++ b/bindings/gumjs/gumdukvalue.h
@@ -98,6 +98,8 @@ G_GNUC_INTERNAL GumDukNativePointer * _gum_duk_require_native_pointer (
 
 G_GNUC_INTERNAL void _gum_duk_push_native_resource (duk_context * ctx,
     gpointer data, GDestroyNotify notify, GumDukCore * core);
+G_GNUC_INTERNAL void _gum_duk_push_kernel_resource (duk_context * ctx,
+    guint64 data, GumDukKernelNotify notify, GumDukCore * core);
 
 G_GNUC_INTERNAL GumDukCpuContext * _gum_duk_push_cpu_context (duk_context * ctx,
     GumCpuContext * handle, GumDukCpuContextAccess access,

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -708,6 +708,8 @@ _gum_v8_core_realize (GumV8Core * self)
 
   self->native_resources = g_hash_table_new_full (NULL, NULL, NULL,
       (GDestroyNotify) _gum_v8_native_resource_free);
+  self->kernel_resources = g_hash_table_new_full (NULL, NULL, NULL,
+      (GDestroyNotify) _gum_v8_kernel_resource_free);
 
   self->source_maps = g_hash_table_new_full (NULL, NULL, NULL,
       (GDestroyNotify) gum_v8_source_map_free);
@@ -857,6 +859,8 @@ _gum_v8_core_dispose (GumV8Core * self)
   g_hash_table_unref (self->source_maps);
   self->source_maps = NULL;
 
+  g_hash_table_unref (self->kernel_resources);
+  self->kernel_resources = NULL;
   g_hash_table_unref (self->native_resources);
   self->native_resources = NULL;
 

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -39,6 +39,7 @@ struct GumPersistent
 typedef void (* GumV8FlushNotify) (GumV8Script * script);
 typedef void (* GumV8MessageEmitter) (GumV8Script * script,
     const gchar * message, GBytes * data);
+typedef void (* GumV8KernelNotify) (guint64 data);
 
 struct GumV8Core
 {
@@ -81,6 +82,7 @@ struct GumV8Core
   GHashTable * native_callbacks;
 
   GHashTable * native_resources;
+  GHashTable * kernel_resources;
 
   GHashTable * source_maps;
 
@@ -114,6 +116,15 @@ struct GumV8NativeResource
   gpointer data;
   gsize size;
   GDestroyNotify notify;
+  GumV8Core * core;
+};
+
+struct GumV8KernelResource
+{
+  GumPersistent<v8::Object>::type * instance;
+  guint64 data;
+  gsize size;
+  GumV8KernelNotify notify;
   GumV8Core * core;
 };
 

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -421,8 +421,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_alloc)
 
   GumAddress address = gum_kernel_alloc_n_pages (n_pages);
 
-  GumV8KernelResource * res = _gum_v8_kernel_resource_new (address, n_pages * page_size,
-      gum_kernel_free_pages, core);
+  GumV8KernelResource * res = _gum_v8_kernel_resource_new (address,
+      n_pages * page_size, gum_kernel_free_pages, core);
 
   info.GetReturnValue ().Set (Local<Object>::New (isolate, *res->instance));
 }

--- a/bindings/gumjs/gumv8value.h
+++ b/bindings/gumjs/gumv8value.h
@@ -45,6 +45,10 @@ G_GNUC_INTERNAL GumV8NativeResource * _gum_v8_native_resource_new (
     gpointer data, gsize size, GDestroyNotify notify, GumV8Core * core);
 G_GNUC_INTERNAL void _gum_v8_native_resource_free (GumV8NativeResource * block);
 
+G_GNUC_INTERNAL GumV8KernelResource * _gum_v8_kernel_resource_new (
+    guint64 data, gsize size, GumV8KernelNotify notify, GumV8Core * core);
+G_GNUC_INTERNAL void _gum_v8_kernel_resource_free (GumV8KernelResource * block);
+
 G_GNUC_INTERNAL gboolean _gum_v8_int_get (v8::Handle<v8::Value> value, gint * i,
     GumV8Core * core);
 

--- a/bindings/gumjs/types/frida-gum/frida-gum.d.ts
+++ b/bindings/gumjs/types/frida-gum/frida-gum.d.ts
@@ -1027,9 +1027,19 @@ declare class Int64 {
     shl(v: Int64 | number | string): Int64;
 
     /**
+     * Makes a new Int64 whose value is ~`this`.
+     */
+    not(): Int64;
+
+    /**
      * Returns an integer comparison result just like String#localeCompare().
      */
     compare(v: Int64 | number | string): number;
+
+    /**
+     * Returns a boolean indicating whether `v` is equal to `this`.
+     */
+    equals(v: Int64 | number | string): boolean;
 
     /**
      * Converts to a number.
@@ -1103,9 +1113,19 @@ declare class UInt64 {
     shl(v: UInt64 | number | string): UInt64;
 
     /**
+     * Makes a new UInt64 whose value is ~`this`.
+     */
+    not(): UInt64;
+
+    /**
      * Returns an integer comparison result just like String#localeCompare().
      */
     compare(v: UInt64 | number | string): number;
+
+    /**
+     * Returns a boolean indicating whether `v` is equal to `this`.
+     */
+    equals(v: UInt64 | number | string): boolean;
 
     /**
      * Converts to a number.
@@ -1899,22 +1919,6 @@ declare namespace Kernel {
      * @param protection Desired page protection.
      */
     function protect(address: UInt64, size: number | UInt64, protection: PageProtection): boolean;
-
-    /**
-     * Reads kernel memory into an ArrayBuffer.
-     *
-     * @param address The kernel memory address to read from.
-     * @param size The number of bytes to read.
-     */
-    function readByteArray(address: UInt64, size: number): ArrayBuffer | null;
-
-    /**
-     * Writes the contents of an ArrayBuffer or array to kernel memory.
-     *
-     * @param address The kernel memory address to read from.
-     * @param value The data to write.
-     */
-    function writeByteArray(address: UInt64, value: ArrayBuffer | number[]): void;
 
     /**
      * Scans kernel memory for occurences of `pattern` in the memory range given by `address` and `size`.

--- a/bindings/gumjs/types/frida-gum/frida-gum.d.ts
+++ b/bindings/gumjs/types/frida-gum/frida-gum.d.ts
@@ -1875,9 +1875,9 @@ declare namespace Kernel {
     const available: boolean;
 
     /**
-     * Base address of the kernel.
+     * Base address of the kernel. Can be overridden with any non-zero UInt64.
      */
-    const base: UInt64;
+    let base: UInt64;
 
     /**
      * Size of kernel page in bytes.

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -167,8 +167,8 @@ gum_kernel_alloc_n_pages (guint n_pages)
   return result + page_size;
 }
 
-gboolean
-gum_kernel_try_free_pages (GumAddress mem)
+void
+gum_kernel_free_pages (GumAddress mem)
 {
   mach_port_t task;
   gsize page_size;
@@ -179,7 +179,7 @@ gum_kernel_try_free_pages (GumAddress mem)
 
   task = gum_kernel_get_task ();
   if (task == MACH_PORT_NULL)
-    return FALSE;
+    return;
 
   page_size = vm_kernel_page_size;
 
@@ -187,17 +187,16 @@ gum_kernel_try_free_pages (GumAddress mem)
   size = (mach_vm_size_t *) gum_kernel_read (address, sizeof (mach_vm_size_t),
       &bytes_read);
   if (size == NULL)
-    return FALSE;
+    return;
   if (bytes_read < sizeof (mach_vm_size_t))
   {
     g_free (size);
-    return FALSE;
+    return;
   }
 
   kr = mach_vm_deallocate (task, address, *size);
   g_free (size);
-
-  return kr == KERN_SUCCESS;
+  g_assert_cmpint (kr, ==, KERN_SUCCESS);
 }
 
 gboolean

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -173,7 +173,7 @@ gum_kernel_try_free_pages (GumAddress mem)
   mach_port_t task;
   gsize page_size;
   mach_vm_address_t address;
-  mach_vm_size_t *size;
+  mach_vm_size_t * size;
   gsize bytes_read;
   kern_return_t kr;
 
@@ -184,7 +184,7 @@ gum_kernel_try_free_pages (GumAddress mem)
   page_size = vm_kernel_page_size;
 
   address = mem - page_size;
-  size = (mach_vm_size_t*) gum_kernel_read (address, sizeof (mach_vm_size_t),
+  size = (mach_vm_size_t *) gum_kernel_read (address, sizeof (mach_vm_size_t),
       &bytes_read);
   if (size == NULL)
     return FALSE;
@@ -731,7 +731,7 @@ gum_kernel_get_version (void)
 
 #ifdef HAVE_ARM64
 
-static bool
+static gboolean
 gum_kernel_is_debug (void)
 {
   char buf[256];
@@ -761,7 +761,7 @@ gum_kernel_bruteforce_base (GumAddress unslid_base)
    */
 
   gint slide_byte;
-  bool is_debug;
+  gboolean is_debug;
 
   is_debug = gum_kernel_is_debug ();
 

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -123,6 +123,7 @@ static mach_port_t gum_kernel_do_init (void);
 static void gum_kernel_do_deinit (void);
 
 static GumDarwinModule * gum_kernel_cached_module = NULL;
+static GumAddress gum_kernel_external_base = 0;
 
 gboolean
 gum_kernel_api_is_available (void)
@@ -164,6 +165,39 @@ gum_kernel_alloc_n_pages (guint n_pages)
   g_assert_cmpint (kr, ==, KERN_SUCCESS);
 
   return result + page_size;
+}
+
+gboolean
+gum_kernel_try_free_pages (GumAddress mem)
+{
+  mach_port_t task;
+  gsize page_size;
+  mach_vm_address_t address;
+  mach_vm_size_t *size;
+  gsize bytes_read;
+  kern_return_t kr;
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return FALSE;
+
+  page_size = vm_kernel_page_size;
+
+  address = mem - page_size;
+  size = (mach_vm_size_t*) gum_kernel_read (address, sizeof (mach_vm_size_t),
+      &bytes_read);
+  if (size == NULL)
+    return FALSE;
+  if (bytes_read < sizeof (mach_vm_size_t))
+  {
+    g_free (size);
+    return FALSE;
+  }
+
+  kr = mach_vm_deallocate (task, address, *size);
+  g_free (size);
+
+  return kr == KERN_SUCCESS;
 }
 
 gboolean
@@ -646,9 +680,18 @@ gum_kernel_find_base_address (void)
 {
   static GOnce get_base_once = G_ONCE_INIT;
 
+  if (gum_kernel_external_base != 0)
+    return gum_kernel_external_base;
+
   g_once (&get_base_once, (GThreadFunc) gum_kernel_do_find_base_address, NULL);
 
   return *((GumAddress *) get_base_once.retval);
+}
+
+void
+gum_kernel_set_base_address (GumAddress base)
+{
+  gum_kernel_external_base = base;
 }
 
 static GumAddress *
@@ -688,6 +731,20 @@ gum_kernel_get_version (void)
 
 #ifdef HAVE_ARM64
 
+static bool
+gum_kernel_is_debug (void)
+{
+  char buf[256];
+  size_t size;
+  int res;
+
+  size = sizeof (buf);
+  res = sysctlbyname ("kern.bootargs", buf, &size, NULL, 0);
+  g_assert_cmpint (res, ==, 0);
+
+  return strstr (buf, "debug") != NULL;
+}
+
 static GumAddress
 gum_kernel_bruteforce_base (GumAddress unslid_base)
 {
@@ -704,6 +761,12 @@ gum_kernel_bruteforce_base (GumAddress unslid_base)
    */
 
   gint slide_byte;
+  bool is_debug;
+
+  is_debug = gum_kernel_is_debug ();
+
+  if (is_debug && gum_kernel_is_header (unslid_base))
+    return unslid_base;
 
   if (gum_kernel_is_header (unslid_base + 0x21000000))
     return unslid_base + 0x21000000;

--- a/gum/gumkernel.c
+++ b/gum/gumkernel.c
@@ -26,10 +26,9 @@ gum_kernel_alloc_n_pages (guint n_pages)
   return 0;
 }
 
-gboolean
-gum_kernel_try_free_pages (GumAddress mem)
+void
+gum_kernel_free_pages (GumAddress mem)
 {
-  return FALSE;
 }
 
 gboolean

--- a/gum/gumkernel.c
+++ b/gum/gumkernel.c
@@ -27,6 +27,12 @@ gum_kernel_alloc_n_pages (guint n_pages)
 }
 
 gboolean
+gum_kernel_try_free_pages (GumAddress mem)
+{
+  return FALSE;
+}
+
+gboolean
 gum_kernel_try_mprotect (GumAddress address,
                          gsize size,
                          GumPageProtection page_prot)
@@ -83,6 +89,11 @@ GumAddress
 gum_kernel_find_base_address (void)
 {
   return 0;
+}
+
+void
+gum_kernel_set_base_address (GumAddress base)
+{
 }
 
 #endif

--- a/gum/gumkernel.h
+++ b/gum/gumkernel.h
@@ -27,6 +27,7 @@ typedef gboolean (* GumFoundKernelModuleRangeFunc) (
 GUM_API gboolean gum_kernel_api_is_available (void);
 GUM_API guint gum_kernel_query_page_size (void);
 GUM_API GumAddress gum_kernel_alloc_n_pages (guint n_pages);
+GUM_API gboolean gum_kernel_try_free_pages (GumAddress mem);
 GUM_API gboolean gum_kernel_try_mprotect (GumAddress address, gsize size,
     GumPageProtection page_prot);
 GUM_API guint8 * gum_kernel_read (GumAddress address, gsize len,
@@ -44,6 +45,7 @@ GUM_API void gum_kernel_enumerate_module_ranges (const gchar * module_name,
 GUM_API void gum_kernel_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
 GUM_API GumAddress gum_kernel_find_base_address (void);
+GUM_API void gum_kernel_set_base_address (GumAddress base);
 
 G_END_DECLS
 

--- a/gum/gumkernel.h
+++ b/gum/gumkernel.h
@@ -27,7 +27,7 @@ typedef gboolean (* GumFoundKernelModuleRangeFunc) (
 GUM_API gboolean gum_kernel_api_is_available (void);
 GUM_API guint gum_kernel_query_page_size (void);
 GUM_API GumAddress gum_kernel_alloc_n_pages (guint n_pages);
-GUM_API gboolean gum_kernel_try_free_pages (GumAddress mem);
+GUM_API void gum_kernel_free_pages (GumAddress mem);
 GUM_API gboolean gum_kernel_try_mprotect (GumAddress address, gsize size,
     GumPageProtection page_prot);
 GUM_API guint8 * gum_kernel_read (GumAddress address, gsize len,


### PR DESCRIPTION
- try the unslid base first if kernel seems being debugged
- make `Kernel.base` writable to override the internal base-finding algorithm

Plus:
- add `Kernel.free` to deallocate memory allocated with `Kernel.alloc`
- tweak the `Int64` / `UInt64` typescript type definitions to expose `.not()` and `.equals()`
- remove dupe type definitions for `Kernel.readByteArray()` / `Kernel.writeByteArray()`