### PR TITLE
Tweak darwinmodule for quick app check

### DIFF
--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -321,7 +321,8 @@ gum_darwin_mapper_new_take_blob (const gchar * name,
   GumDarwinMapper * mapper;
 
   module = gum_darwin_module_new_from_blob (blob, resolver->task,
-      resolver->cpu_type, resolver->page_size, NULL);
+      resolver->cpu_type, resolver->page_size, GUM_DARWIN_MODULE_FLAGS_NONE,
+      NULL);
 
   mapper = g_object_new (GUM_DARWIN_TYPE_MAPPER,
       "name", name,

--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -364,7 +364,7 @@ gum_darwin_mapper_new_from_file_with_parent (GumDarwinMapper * parent,
   }
 
   module = gum_darwin_module_new_from_file (path, resolver->task,
-      resolver->cpu_type, resolver->page_size, cache_file, NULL);
+      resolver->cpu_type, resolver->page_size, cache_file, FALSE, NULL);
 
   mapper = g_object_new (GUM_DARWIN_TYPE_MAPPER,
       "name", path,

--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -365,7 +365,8 @@ gum_darwin_mapper_new_from_file_with_parent (GumDarwinMapper * parent,
   }
 
   module = gum_darwin_module_new_from_file (path, resolver->task,
-      resolver->cpu_type, resolver->page_size, cache_file, FALSE, NULL);
+      resolver->cpu_type, resolver->page_size, cache_file,
+      GUM_DARWIN_MODULE_FLAGS_NONE, NULL);
 
   mapper = g_object_new (GUM_DARWIN_TYPE_MAPPER,
       "name", path,

--- a/gum/backend-darwin/gumdarwinmodule.c
+++ b/gum/backend-darwin/gumdarwinmodule.c
@@ -2338,8 +2338,8 @@ gum_darwin_module_flags_get_type (void)
   {
     static const GFlagsValue values[] =
     {
-      { GUM_DARWIN_MODULE_FLAGS_NONE, "GUM_DARWIN_MODULE_FLAGS_NONE", "default" },
-      { GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY, "GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY", "optional" },
+      { GUM_DARWIN_MODULE_FLAGS_NONE, "GUM_DARWIN_MODULE_FLAGS_NONE", "none" },
+      { GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY, "GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY", "header-only" },
       { 0, NULL, NULL }
     };
     GType ftype;

--- a/gum/backend-darwin/gumdarwinmodule.c
+++ b/gum/backend-darwin/gumdarwinmodule.c
@@ -241,8 +241,8 @@ gum_darwin_module_class_init (GumDarwinModuleClass * klass)
       G_TYPE_MAPPED_FILE,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class, PROP_FLAGS,
-      g_param_spec_uint ("flags", "Flags", "Optional flags", 0, G_MAXUINT,
-      GUM_DARWIN_MODULE_FLAGS_NONE,
+      g_param_spec_flags ("flags", "Flags", "Optional flags",
+      GUM_DARWIN_TYPE_MODULE_FLAGS, GUM_DARWIN_MODULE_FLAGS_NONE,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 }
 
@@ -432,7 +432,7 @@ gum_darwin_module_get_property (GObject * object,
       g_value_set_boxed (value, self->cache_file);
       break;
     case PROP_FLAGS:
-      g_value_set_uint (value, self->flags);
+      g_value_set_flags (value, self->flags);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -478,7 +478,7 @@ gum_darwin_module_set_property (GObject * object,
       self->cache_file = g_value_dup_boxed (value);
       break;
     case PROP_FLAGS:
-      self->flags = g_value_get_uint (value);
+      self->flags = g_value_get_flags (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -2327,4 +2327,27 @@ gum_dyld_cache_offset_from_address (GumAddress address,
   }
 
   return 0;
+}
+
+GType
+gum_darwin_module_flags_get_type (void)
+{
+  static volatile gsize gonce_value;
+
+  if (g_once_init_enter (&gonce_value))
+  {
+    static const GFlagsValue values[] =
+    {
+      { GUM_DARWIN_MODULE_FLAGS_NONE, "GUM_DARWIN_MODULE_FLAGS_NONE", "default" },
+      { GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY, "GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY", "optional" },
+      { 0, NULL, NULL }
+    };
+    GType ftype;
+
+    ftype = g_flags_register_static ("GumDarwinModuleFlags", values);
+
+    g_once_init_leave (&gonce_value, ftype);
+  }
+
+  return (GType) gonce_value;
 }

--- a/gum/backend-darwin/gumdarwinmodule.h
+++ b/gum/backend-darwin/gumdarwinmodule.h
@@ -45,6 +45,8 @@ typedef gboolean (* GumDarwinFoundInitPointersFunc) (
     const GumDarwinInitPointersDetails * details, gpointer user_data);
 typedef gboolean (* GumDarwinFoundTermPointersFunc) (
     const GumDarwinTermPointersDetails * details, gpointer user_data);
+typedef gboolean (* GumDarwinFoundDependencyFunc) (const gchar * dependency,
+    gpointer user_data);
 typedef gpointer (* GumDarwinModuleResolverFunc) (void);
 
 struct _GumDarwinModule
@@ -94,6 +96,8 @@ struct _GumDarwinModule
 
   GPtrArray * dependencies;
   GPtrArray * reexports;
+
+  gboolean header_only;
 };
 
 struct _GumDarwinModuleImage
@@ -205,7 +209,7 @@ struct _GumDarwinSymbolDetails
 
 GUM_API GumDarwinModule * gum_darwin_module_new_from_file (const gchar * path,
     mach_port_t task, GumCpuType cpu_type, guint page_size,
-    GMappedFile * cache_file, GError ** error);
+    GMappedFile * cache_file, gboolean header_only, GError ** error);
 GUM_API GumDarwinModule * gum_darwin_module_new_from_blob (GBytes * blob,
     mach_port_t task, GumCpuType cpu_type, guint page_size, GError ** error);
 GUM_API GumDarwinModule * gum_darwin_module_new_from_memory (const gchar * name,
@@ -241,6 +245,8 @@ GUM_API void gum_darwin_module_enumerate_init_pointers (GumDarwinModule * self,
     GumDarwinFoundInitPointersFunc func, gpointer user_data);
 GUM_API void gum_darwin_module_enumerate_term_pointers (GumDarwinModule * self,
     GumDarwinFoundTermPointersFunc func, gpointer user_data);
+GUM_API void gum_darwin_module_enumerate_dependencies (GumDarwinModule * self,
+    GumDarwinFoundDependencyFunc func, gpointer user_data);
 GUM_API const gchar * gum_darwin_module_get_dependency_by_ordinal (
     GumDarwinModule * self, gint ordinal);
 

--- a/gum/backend-darwin/gumdarwinmodule.h
+++ b/gum/backend-darwin/gumdarwinmodule.h
@@ -19,6 +19,8 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (GumDarwinModule, gum_darwin_module, GUM_DARWIN, MODULE,
     GObject)
 
+#define GUM_DARWIN_TYPE_MODULE_FLAGS (gum_darwin_module_flags_get_type ())
+
 typedef enum {
   GUM_DARWIN_MODULE_FLAGS_NONE = 0,
   GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY = (1<<0),
@@ -71,6 +73,7 @@ struct _GumDarwinModule
   gchar * source_path;
   GBytes * source_blob;
   GMappedFile * cache_file;
+  GumDarwinModuleFlags flags;
 
   GumDarwinModuleImage * image;
 
@@ -101,8 +104,6 @@ struct _GumDarwinModule
 
   GPtrArray * dependencies;
   GPtrArray * reexports;
-
-  GumDarwinModuleFlags flags;
 };
 
 struct _GumDarwinModuleImage
@@ -260,6 +261,8 @@ GUM_API GumDarwinModuleImage * gum_darwin_module_image_new (void);
 GUM_API GumDarwinModuleImage * gum_darwin_module_image_dup (
     const GumDarwinModuleImage * other);
 GUM_API void gum_darwin_module_image_free (GumDarwinModuleImage * image);
+
+GUM_API GType gum_darwin_module_flags_get_type (void) G_GNUC_CONST;
 
 G_END_DECLS
 

--- a/gum/backend-darwin/gumdarwinmodule.h
+++ b/gum/backend-darwin/gumdarwinmodule.h
@@ -19,6 +19,11 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (GumDarwinModule, gum_darwin_module, GUM_DARWIN, MODULE,
     GObject)
 
+typedef enum {
+  GUM_DARWIN_MODULE_FLAGS_NONE = 0,
+  GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY = (1<<0),
+} GumDarwinModuleFlags;
+
 typedef struct _GumDarwinModuleImage GumDarwinModuleImage;
 
 typedef struct _GumDarwinModuleImageSegment GumDarwinModuleImageSegment;
@@ -45,7 +50,7 @@ typedef gboolean (* GumDarwinFoundInitPointersFunc) (
     const GumDarwinInitPointersDetails * details, gpointer user_data);
 typedef gboolean (* GumDarwinFoundTermPointersFunc) (
     const GumDarwinTermPointersDetails * details, gpointer user_data);
-typedef gboolean (* GumDarwinFoundDependencyFunc) (const gchar * dependency,
+typedef gboolean (* GumDarwinFoundDependencyFunc) (const gchar * path,
     gpointer user_data);
 typedef gpointer (* GumDarwinModuleResolverFunc) (void);
 
@@ -97,7 +102,7 @@ struct _GumDarwinModule
   GPtrArray * dependencies;
   GPtrArray * reexports;
 
-  gboolean header_only;
+  GumDarwinModuleFlags flags;
 };
 
 struct _GumDarwinModuleImage
@@ -209,12 +214,13 @@ struct _GumDarwinSymbolDetails
 
 GUM_API GumDarwinModule * gum_darwin_module_new_from_file (const gchar * path,
     mach_port_t task, GumCpuType cpu_type, guint page_size,
-    GMappedFile * cache_file, gboolean header_only, GError ** error);
+    GMappedFile * cache_file, GumDarwinModuleFlags flags, GError ** error);
 GUM_API GumDarwinModule * gum_darwin_module_new_from_blob (GBytes * blob,
-    mach_port_t task, GumCpuType cpu_type, guint page_size, GError ** error);
+    mach_port_t task, GumCpuType cpu_type, guint page_size,
+    GumDarwinModuleFlags flags, GError ** error);
 GUM_API GumDarwinModule * gum_darwin_module_new_from_memory (const gchar * name,
     mach_port_t task, GumCpuType cpu_type, guint page_size,
-    GumAddress base_address, GError ** error);
+    GumAddress base_address, GumDarwinModuleFlags flags, GError ** error);
 
 GUM_API gboolean gum_darwin_module_resolve_export (GumDarwinModule * self,
     const gchar * symbol, GumDarwinExportDetails * details);

--- a/gum/backend-darwin/gumdarwinmoduleresolver.c
+++ b/gum/backend-darwin/gumdarwinmoduleresolver.c
@@ -317,7 +317,8 @@ gum_store_module (const GumModuleDetails * details,
   }
 
   module = gum_darwin_module_new_from_memory (details->path, self->task,
-      self->cpu_type, self->page_size, details->range->base_address, NULL);
+      self->cpu_type, self->page_size, details->range->base_address,
+      GUM_DARWIN_MODULE_FLAGS_NONE, NULL);
   g_hash_table_insert (self->modules, g_strdup (details->name),
       module);
   g_hash_table_insert (self->modules, g_strdup (details->path),

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -451,7 +451,7 @@ gum_kernel_enumerate_kexts (GumFoundKextFunc func,
       continue;
 
     module = gum_darwin_module_new_from_memory (kext->name, task, GUM_CPU_ARM64,
-        vm_kernel_page_size, kext->address, NULL);
+        vm_kernel_page_size, kext->address, GUM_DARWIN_MODULE_FLAGS_NONE, NULL);
 
     if (module == NULL)
       continue;
@@ -669,7 +669,8 @@ gum_kernel_get_module (void)
   base = gum_kernel_find_base_address ();
 
   gum_kernel_cached_module = gum_darwin_module_new_from_memory ("Kernel", task,
-      GUM_CPU_ARM64, vm_kernel_page_size, base, NULL);
+      GUM_CPU_ARM64, vm_kernel_page_size, base, GUM_DARWIN_MODULE_FLAGS_NONE,
+      NULL);
 
   return gum_kernel_cached_module;
 }

--- a/vapi/frida-gum-darwin-1.0.vapi
+++ b/vapi/frida-gum-darwin-1.0.vapi
@@ -53,10 +53,9 @@ namespace Gum.Darwin {
 		}
 
 		[Flags]
-		[CCode (cprefix = "GUM_DARWIN_MODULE_FLAGS_")]
 		public enum Flags {
-			NONE = 0,
-			HEADER_ONLY	  = (1 << 0),
+			NONE,
+			HEADER_ONLY,
 		}
 
 		public Module.from_file (string path, Port task, Gum.CpuType cpu_type, uint page_size, GLib.MappedFile? cache_file = null, Gum.Darwin.Module.Flags flags = NONE) throws GLib.Error;

--- a/vapi/frida-gum-darwin-1.0.vapi
+++ b/vapi/frida-gum-darwin-1.0.vapi
@@ -52,9 +52,16 @@ namespace Gum.Darwin {
 			get;
 		}
 
-		public Module.from_file (string path, Port task, Gum.CpuType cpu_type, uint page_size, GLib.MappedFile? cache_file = null) throws GLib.Error;
-		public Module.from_blob (GLib.Bytes blob, Port task, Gum.CpuType cpu_type, uint page_size) throws GLib.Error;
-		public Module.from_memory (string? name, Port task, Gum.CpuType cpu_type, uint page_size, Gum.Address base_address) throws GLib.Error;
+		[Flags]
+		[CCode (cprefix = "GUM_DARWIN_MODULE_FLAGS_")]
+		public enum Flags {
+			NONE = 0,
+			HEADER_ONLY	  = (1 << 0),
+		}
+
+		public Module.from_file (string path, Port task, Gum.CpuType cpu_type, uint page_size, GLib.MappedFile? cache_file = null, Gum.Darwin.Module.Flags flags = NONE) throws GLib.Error;
+		public Module.from_blob (GLib.Bytes blob, Port task, Gum.CpuType cpu_type, uint page_size, Gum.Darwin.Module.Flags flags = NONE) throws GLib.Error;
+		public Module.from_memory (string? name, Port task, Gum.CpuType cpu_type, uint page_size, Gum.Address base_address, Gum.Darwin.Module.Flags flags = NONE) throws GLib.Error;
 
 		public bool resolve_export (string symbol, out ExportDetails details);
 		public Gum.Address resolve_symbol_address (string symbol);
@@ -68,6 +75,7 @@ namespace Gum.Darwin {
 		public void enumerate_lazy_binds (FoundBindFunc func);
 		public void enumerate_init_pointers (FoundInitPointersFunc func);
 		public void enumerate_term_pointers (FoundTermPointersFunc func);
+		public void enumerate_dependencies (FoundDependenciesFunc func);
 		public unowned string? get_dependency_by_ordinal (int ordinal);
 
 		public delegate bool FoundExportFunc (ExportDetails details);
@@ -77,6 +85,7 @@ namespace Gum.Darwin {
 		public delegate bool FoundBindFunc (BindDetails details);
 		public delegate bool FoundInitPointersFunc (InitPointersDetails details);
 		public delegate bool FoundTermPointersFunc (TermPointersDetails details);
+		public delegate bool FoundDependenciesFunc (string path);
 	}
 
 	[Compact]


### PR DESCRIPTION
- add _enumerate_dependencies api call
- add the “header-only” property, to load only the header and the commands instead of the whole binary, applies to file system loading
- enable gumdarwinmodule to load executables too, not only libs