### PR TITLE
Fix for duktape's Reflect.get() restriction

### DIFF
--- a/bindings/gumjs/runtime/error-handler-duktape.js
+++ b/bindings/gumjs/runtime/error-handler-duktape.js
@@ -122,3 +122,11 @@ function findSourceMap(source) {
   else
     return null;
 }
+
+// fixed for duktape's Reflect.get() restriction
+if (typeof Reflect !== "undefined" && Reflect.get) {
+  const original = Reflect.get;
+  Reflect.get = function (target, propertyKey, receiver) {
+    return original(target, propertyKey);
+  }
+}


### PR DESCRIPTION
Fix for duktape's Reflect.get() restriction, which will cause Java.choose throw unsupported error.