### PR TITLE
'hexdump()' has error when option's length bigger than ArrayBuffer.length

### DIFF
--- a/bindings/gumjs/runtime/hexdump.js
+++ b/bindings/gumjs/runtime/hexdump.js
@@ -13,6 +13,8 @@ function hexdump(target, options) {
   if (target instanceof ArrayBuffer) {
     if (length === undefined)
       length = target.byteLength;
+    else if (length > target.byteLength) 
+      length = target.byteLength
     buffer = target;
   } else {
     if (!(target instanceof NativePointer))

--- a/bindings/gumjs/runtime/hexdump.js
+++ b/bindings/gumjs/runtime/hexdump.js
@@ -13,8 +13,8 @@ function hexdump(target, options) {
   if (target instanceof ArrayBuffer) {
     if (length === undefined)
       length = target.byteLength;
-    else if (length > target.byteLength) 
-      length = target.byteLength
+    else
+      length = Math.min(length, target.byteLength);
     buffer = target;
   } else {
     if (!(target instanceof NativePointer))


### PR DESCRIPTION
'hexdump()' will throw an error when option's length bigger than ArrayBuffer.length.