### PR TITLE
Clone fix for arm64 android

### DIFF
--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -348,8 +348,10 @@ static GumVirtualizationRequirements gum_exec_block_virtualize_ret_insn (
     GumExecBlock * block, GumGeneratorContext * gc);
 static GumVirtualizationRequirements gum_exec_block_virtualize_sysenter_insn (
     GumExecBlock * block, GumGeneratorContext * gc);
+#ifdef HAVE_LINUX
 static GumVirtualizationRequirements gum_exec_block_virtualize_linux_sysenter (
-    GumExecBlock * block,  GumGeneratorContext * gc);
+    GumExecBlock * block, GumGeneratorContext * gc);
+#endif
 
 static void gum_exec_block_write_call_invoke_code (GumExecBlock * block,
     const GumBranchTarget * target, GumGeneratorContext * gc);
@@ -2627,14 +2629,16 @@ gum_exec_block_virtualize_sysenter_insn (GumExecBlock * block,
 #endif
 }
 
+#ifdef HAVE_LINUX
+
 static GumVirtualizationRequirements
 gum_exec_block_virtualize_linux_sysenter (GumExecBlock * block,
                                           GumGeneratorContext * gc)
 {
   GumArm64Writer * cw = gc->code_writer;
   const cs_insn * insn = gc->instruction->ci;
-  gconstpointer continue_normally = cw->code + 1;
-  gconstpointer end_payload = cw->code + 2;
+  gconstpointer perform_regular_syscall = cw->code + 1;
+  gconstpointer perform_next_instruction = cw->code + 2;
   const guint32 mrs_x15_nzcv = 0xd53b420f;
   const guint32 msr_nzcv_x15 = 0xd51b420f;
 
@@ -2649,30 +2653,39 @@ gum_exec_block_virtualize_linux_sysenter (GumExecBlock * block,
 
   gum_arm64_writer_put_sub_reg_reg_imm (cw, ARM64_REG_X17,
       ARM64_REG_X8, __NR_clone);
-  gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X17, continue_normally);
+  gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X17,
+      perform_regular_syscall);
 
   gum_arm64_writer_put_instruction (cw, msr_nzcv_x15);
   gum_arm64_writer_put_ldp_reg_reg_reg_offset (cw, ARM64_REG_X15,
       ARM64_REG_X17, ARM64_REG_SP, 16 + GUM_RED_ZONE_SIZE,
       GUM_INDEX_POST_ADJUST);
   gum_arm64_writer_put_bytes (cw, insn->bytes, 4);
-  gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X0, end_payload);
+  gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X0,
+      perform_next_instruction);
 
-  /* We are on the child return to the original next instruction */
+  /*
+   * We are on the child return to the original next instruction
+   *
+   * TODO: Is there any way we can avoid clobbering X17 here?
+   */
   gum_arm64_writer_put_ldr_reg_address (cw, ARM64_REG_X17,
       GUM_ADDRESS (gc->instruction->begin + 4));
   gum_arm64_writer_put_br_reg (cw, ARM64_REG_X17);
 
-  gum_arm64_writer_put_label (cw, continue_normally);
+  gum_arm64_writer_put_label (cw, perform_regular_syscall);
   gum_arm64_writer_put_instruction (cw, msr_nzcv_x15);
   gum_arm64_writer_put_ldp_reg_reg_reg_offset (cw, ARM64_REG_X15,
       ARM64_REG_X17, ARM64_REG_SP, 16 + GUM_RED_ZONE_SIZE,
       GUM_INDEX_POST_ADJUST);
   gum_arm64_writer_put_bytes (cw, insn->bytes, 4);
-  gum_arm64_writer_put_label (cw, end_payload);
+
+  gum_arm64_writer_put_label (cw, perform_next_instruction);
 
   return GUM_REQUIRE_NOTHING;
 }
+
+#endif
 
 static void
 gum_exec_block_write_call_invoke_code (GumExecBlock * block,

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -2643,7 +2643,8 @@ gum_exec_block_virtualize_linux_sysenter (GumExecBlock * block,
   if (gc->opened_prolog != GUM_PROLOG_NONE)
     gum_exec_block_close_prolog (block, gc);
 
-  gum_arm64_writer_put_push_reg_reg (cw, ARM64_REG_X15, ARM64_REG_X17);
+  gum_arm64_writer_put_stp_reg_reg_reg_offset (cw, ARM64_REG_X15, ARM64_REG_X17,
+      ARM64_REG_SP, -(16 + GUM_RED_ZONE_SIZE), GUM_INDEX_PRE_ADJUST);
   gum_arm64_writer_put_instruction (cw, mrs_x15_nzcv);
 
   gum_arm64_writer_put_sub_reg_reg_imm (cw, ARM64_REG_X17,
@@ -2651,7 +2652,9 @@ gum_exec_block_virtualize_linux_sysenter (GumExecBlock * block,
   gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X17, continue_normally);
 
   gum_arm64_writer_put_instruction (cw, msr_nzcv_x15);
-  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X15, ARM64_REG_X17);
+  gum_arm64_writer_put_ldp_reg_reg_reg_offset (cw, ARM64_REG_X15,
+      ARM64_REG_X17, ARM64_REG_SP, 16 + GUM_RED_ZONE_SIZE,
+      GUM_INDEX_POST_ADJUST);
   gum_arm64_writer_put_bytes (cw, insn->bytes, 4);
   gum_arm64_writer_put_cbnz_reg_label (cw, ARM64_REG_X0, end_payload);
 
@@ -2662,7 +2665,9 @@ gum_exec_block_virtualize_linux_sysenter (GumExecBlock * block,
 
   gum_arm64_writer_put_label (cw, continue_normally);
   gum_arm64_writer_put_instruction (cw, msr_nzcv_x15);
-  gum_arm64_writer_put_pop_reg_reg (cw, ARM64_REG_X15, ARM64_REG_X17);
+  gum_arm64_writer_put_ldp_reg_reg_reg_offset (cw, ARM64_REG_X15,
+      ARM64_REG_X17, ARM64_REG_SP, 16 + GUM_RED_ZONE_SIZE,
+      GUM_INDEX_POST_ADJUST);
   gum_arm64_writer_put_bytes (cw, insn->bytes, 4);
   gum_arm64_writer_put_label (cw, end_payload);
 

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -53,6 +53,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (follow_thread)
 
   /* EXTRA */
+  TESTENTRY (pthread_create)
   TESTENTRY (heap_api)
   TESTENTRY (no_register_clobber)
   TESTENTRY (performance)
@@ -64,6 +65,7 @@ static void insert_extra_add_after_sub (GumStalkerIterator * iterator,
 static void store_x0 (GumCpuContext * cpu_context, gpointer user_data);
 static void unfollow_during_transform (GumStalkerIterator * iterator,
     GumStalkerWriter * output, gpointer user_data);
+static gpointer increment_integer (gpointer data);
 static gboolean store_range_of_test_runner (const GumModuleDetails * details,
     gpointer user_data);
 static void pretend_workload (GumMemoryRange * runner_range);
@@ -1238,6 +1240,34 @@ TESTCASE (follow_thread)
 #ifdef HAVE_LINUX
   prctl (PR_SET_DUMPABLE, prev_dumpable);
 #endif
+}
+
+TESTCASE (pthread_create)
+{
+  int ret;
+  pthread_t thread;
+  int number = 0;
+  fixture->sink->mask = (GumEventType) (GUM_COMPILE);
+
+  gum_stalker_follow_me (fixture->stalker, fixture->transformer,
+      GUM_EVENT_SINK (fixture->sink));
+
+  ret = pthread_create (&thread, NULL, increment_integer, (gpointer) &number);
+  g_assert_cmpuint (ret, ==, 0);
+
+  ret = pthread_join (thread, NULL);
+  g_assert_cmpuint (ret, ==, 0);
+
+  g_assert_cmpuint (number, ==, 1);
+  gum_stalker_unfollow_me (fixture->stalker);
+}
+
+static gpointer
+increment_integer (gpointer data)
+{
+  int * number = (int *) data;
+  *number += 1;
+  return NULL;
 }
 
 TESTCASE (heap_api)

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -1247,18 +1247,20 @@ TESTCASE (pthread_create)
   int ret;
   pthread_t thread;
   int number = 0;
-  fixture->sink->mask = (GumEventType) (GUM_COMPILE);
+
+  fixture->sink->mask = (GumEventType) GUM_COMPILE;
 
   gum_stalker_follow_me (fixture->stalker, fixture->transformer,
       GUM_EVENT_SINK (fixture->sink));
 
   ret = pthread_create (&thread, NULL, increment_integer, (gpointer) &number);
-  g_assert_cmpuint (ret, ==, 0);
+  g_assert_cmpint (ret, ==, 0);
 
   ret = pthread_join (thread, NULL);
-  g_assert_cmpuint (ret, ==, 0);
+  g_assert_cmpint (ret, ==, 0);
 
-  g_assert_cmpuint (number, ==, 1);
+  g_assert_cmpint (number, ==, 1);
+
   gum_stalker_unfollow_me (fixture->stalker);
 }
 


### PR DESCRIPTION
This still does not work but the idea is as follows, let me know how it looks like to you or if you think otherwise.

`gum_stalker_iterator_keep` it emits new code when SVC calls are found to check for clone calls. When this happen, `ctx->thread_clone` is set with `GUM_NEW_THREAD_WHILE_STALKING`. Likewise, after encountering a SVC call afterwards is inserted more code to check if the SVC call was clone to get the new thread id of the child - `gum_stalker_thread_creation` is where child and parent is distinguished. Is here where I would like to return to normal life for the child and within the parent notify with a new event so the user can decide whether or not wants to stalk the new thread. However, I am failing to do so - I dunno how to 'disinfect' the child and leave untouched the parent. 

To work around that, I added a few lines within `gum_exec_ctx_replace_current_block_with` to detect when we are running on the child to return to `start_address` but does not seem to work either.

The normal disinfect routine and unfollow would not work as long as the child and parent share the ctx and I thought setting cpu_context->pc to the real address would be enough but either that is not enough or I don't know how to do it correctly.