### PR TITLE
Add support for MemoryAccessMonitor to linux

### DIFF
--- a/gum/backend-linux/gumlinux.h
+++ b/gum/backend-linux/gumlinux.h
@@ -8,18 +8,27 @@
 #define __GUM_LINUX_H__
 
 #include "gumprocess.h"
+#include "gummemory.h"
 
 #include <ucontext.h>
 
 G_BEGIN_DECLS
 
 typedef struct _GumLinuxNamedRange GumLinuxNamedRange;
+typedef struct _GumLinuxRange GumLinuxRange;
 
 struct _GumLinuxNamedRange
 {
   const gchar * name;
   gpointer base;
   gsize size;
+};
+
+struct _GumLinuxRange
+{
+  GumAddress base;
+  gsize size;
+  GumPageProtection prot;
 };
 
 GUM_API GumCpuType gum_linux_cpu_type_from_file (const gchar * path,
@@ -29,6 +38,7 @@ GUM_API void gum_linux_enumerate_modules_using_proc_maps (
     GumFoundModuleFunc func, gpointer user_data);
 GUM_API void gum_linux_enumerate_ranges (pid_t pid, GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
+GUM_API GList * gum_linux_collect_ranges (void);
 GUM_API GHashTable * gum_linux_collect_named_ranges (void);
 
 GUM_API gboolean gum_linux_module_path_matches (const gchar * path,

--- a/gum/backend-linux/gumlinux.h
+++ b/gum/backend-linux/gumlinux.h
@@ -7,28 +7,28 @@
 #ifndef __GUM_LINUX_H__
 #define __GUM_LINUX_H__
 
-#include "gumprocess.h"
 #include "gummemory.h"
+#include "gumprocess.h"
 
 #include <ucontext.h>
 
 G_BEGIN_DECLS
 
-typedef struct _GumLinuxNamedRange GumLinuxNamedRange;
 typedef struct _GumLinuxRange GumLinuxRange;
-
-struct _GumLinuxNamedRange
-{
-  const gchar * name;
-  gpointer base;
-  gsize size;
-};
+typedef struct _GumLinuxNamedRange GumLinuxNamedRange;
 
 struct _GumLinuxRange
 {
   GumAddress base;
   gsize size;
   GumPageProtection prot;
+};
+
+struct _GumLinuxNamedRange
+{
+  const gchar * name;
+  gpointer base;
+  gsize size;
 };
 
 GUM_API GumCpuType gum_linux_cpu_type_from_file (const gchar * path,

--- a/gum/backend-linux/gummemoryaccessmonitor-linux.c
+++ b/gum/backend-linux/gummemoryaccessmonitor-linux.c
@@ -1,0 +1,464 @@
+/*
+ * Copyright (C) 2010-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2019 Álvaro Felipe Melchor <alvaro.felipe91@gmail.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gummemoryaccessmonitor.h"
+
+#include "gumexceptor.h"
+#include "gumlinux.h"
+
+#include <gio/gio.h>
+#include <sys/mman.h>
+
+typedef struct _GumRangeStats GumRangeStats;
+typedef struct _GumPageDetails GumPageDetails;
+
+typedef gboolean (* GumFoundLiveRangeFunc) (const GumPageDetails * details,
+    gpointer user_data);
+
+struct _GumMemoryAccessMonitor
+{
+  GObject parent;
+
+  guint page_size;
+
+  gboolean enabled;
+  GumExceptor * exceptor;
+
+  GumMemoryRange * ranges;
+  guint num_ranges;
+  volatile gint pages_remaining;
+  gint pages_total;
+
+  GumPageProtection access_mask;
+  GumPageDetails * pages_details;
+  guint num_pages;
+  gboolean auto_reset;
+
+  GumMemoryAccessNotify notify_func;
+  gpointer notify_data;
+  GDestroyNotify notify_data_destroy;
+};
+
+struct _GumPageDetails
+{
+  GumLinuxRange range;
+  guint range_index;
+  volatile guint completed;
+};
+
+struct _GumRangeStats
+{
+  guint live_size;
+  guint guarded_size;
+};
+
+static void gum_memory_access_monitor_dispose (GObject * object);
+static void gum_memory_access_monitor_finalize (GObject * object);
+
+static gboolean gum_collect_range_stats (const GumPageDetails * details,
+    gpointer user_data);
+static void gum_memory_access_monitor_enumerate_live_ranges (
+    GumMemoryAccessMonitor * self, GumFoundLiveRangeFunc func,
+    gpointer user_data);
+static void gum_linux_free_ranges (gpointer data);
+static gboolean gum_linux_set_flag (const GumPageDetails * details,
+    gpointer user_data);
+static gboolean gum_linux_clear_flag (const GumPageDetails * details,
+    gpointer user_data);
+static gboolean gum_memory_access_monitor_on_exception (
+    GumExceptionDetails * details, gpointer user_data);
+
+G_DEFINE_TYPE (GumMemoryAccessMonitor, gum_memory_access_monitor,
+    G_TYPE_OBJECT)
+
+static void
+gum_memory_access_monitor_class_init (GumMemoryAccessMonitorClass * klass)
+{
+  GObjectClass * object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = gum_memory_access_monitor_dispose;
+  object_class->finalize = gum_memory_access_monitor_finalize;
+}
+
+static void
+gum_memory_access_monitor_init (GumMemoryAccessMonitor * self)
+{
+  self->page_size = gum_query_page_size ();
+}
+
+static void
+gum_memory_access_monitor_dispose (GObject * object)
+{
+  GumMemoryAccessMonitor * self = GUM_MEMORY_ACCESS_MONITOR (object);
+
+  gum_memory_access_monitor_disable (self);
+
+  if (self->notify_data_destroy != NULL)
+  {
+    self->notify_data_destroy (self->notify_data);
+    self->notify_data_destroy = NULL;
+  }
+  self->notify_data = NULL;
+  self->notify_func = NULL;
+
+  G_OBJECT_CLASS (gum_memory_access_monitor_parent_class)->dispose (object);
+}
+
+static void
+gum_memory_access_monitor_finalize (GObject * object)
+{
+  GumMemoryAccessMonitor * self = GUM_MEMORY_ACCESS_MONITOR (object);
+
+  g_free (self->ranges);
+
+  G_OBJECT_CLASS (gum_memory_access_monitor_parent_class)->finalize (object);
+}
+
+GumMemoryAccessMonitor *
+gum_memory_access_monitor_new (const GumMemoryRange * ranges,
+                               guint num_ranges,
+                               GumPageProtection access_mask,
+                               gboolean auto_reset,
+                               GumMemoryAccessNotify func,
+                               gpointer data,
+                               GDestroyNotify data_destroy)
+{
+  GumMemoryAccessMonitor * monitor;
+  guint i;
+
+  monitor = g_object_new (GUM_TYPE_MEMORY_ACCESS_MONITOR, NULL);
+  monitor->ranges = g_memdup (ranges, num_ranges * sizeof (GumMemoryRange));
+  monitor->num_ranges = num_ranges;
+  monitor->access_mask = access_mask;
+  monitor->auto_reset = auto_reset;
+  monitor->pages_total = 0;
+
+  for (i = 0; i != num_ranges; i++)
+  {
+    GumMemoryRange * r = &monitor->ranges[i];
+    gsize aligned_start, aligned_end;
+    guint num_pages;
+
+    aligned_start = r->base_address & ~((gsize) monitor->page_size - 1);
+    aligned_end = (r->base_address + r->size + monitor->page_size - 1) &
+        ~((gsize) monitor->page_size - 1);
+    r->base_address = aligned_start;
+    r->size = aligned_end - aligned_start;
+
+    num_pages = r->size / monitor->page_size;
+    g_atomic_int_add (&monitor->pages_remaining, num_pages);
+    monitor->pages_total += num_pages;
+  }
+
+  monitor->notify_func = func;
+  monitor->notify_data = data;
+  monitor->notify_data_destroy = data_destroy;
+
+  return monitor;
+}
+
+gboolean
+gum_memory_access_monitor_enable (GumMemoryAccessMonitor * self,
+                                  GError ** error)
+{
+  GumRangeStats stats;
+
+  if (self->enabled)
+    return TRUE;
+
+  stats.live_size = 0;
+  stats.guarded_size = 0;
+
+  gum_memory_access_monitor_enumerate_live_ranges (self,
+      gum_collect_range_stats, &stats);
+
+  if (stats.live_size != self->pages_total * self->page_size)
+    goto error_invalid_pages;
+  else if (stats.guarded_size != 0)
+    goto error_guarded_pages;
+
+  self->exceptor = gum_exceptor_obtain ();
+  gum_exceptor_add (self->exceptor, gum_memory_access_monitor_on_exception,
+      self);
+
+  self->num_pages = 0;
+  self->pages_details = NULL;
+  gum_memory_access_monitor_enumerate_live_ranges (self, gum_linux_set_flag,
+      self);
+
+  self->enabled = TRUE;
+
+  return TRUE;
+
+error_invalid_pages:
+  {
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+        "one or more pages are unallocated");
+    return FALSE;
+  }
+error_guarded_pages:
+  {
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+        "one or more pages already have PROT_NONE set");
+    return FALSE;
+  }
+}
+
+static gboolean
+gum_collect_range_stats (const GumPageDetails * details,
+                         gpointer user_data)
+{
+  GumRangeStats * stats = (GumRangeStats *) user_data;
+  const GumLinuxRange * range = &details->range;
+
+  stats->live_size += range->size;
+  if (range->prot == GUM_PAGE_NO_ACCESS)
+    stats->guarded_size += range->size;
+
+  return TRUE;
+}
+
+void
+gum_memory_access_monitor_disable (GumMemoryAccessMonitor * self)
+{
+  if (!self->enabled)
+    return;
+
+  gum_memory_access_monitor_enumerate_live_ranges (self,
+      gum_linux_clear_flag, self);
+
+  gum_exceptor_remove (self->exceptor, gum_memory_access_monitor_on_exception,
+      self);
+  g_object_unref (self->exceptor);
+  self->exceptor = NULL;
+
+  g_free (self->pages_details);
+  self->num_pages = 0;
+  self->pages_details = NULL;
+  self->enabled = FALSE;
+}
+
+static void
+gum_memory_access_monitor_enumerate_live_ranges (GumMemoryAccessMonitor * self,
+                                                 GumFoundLiveRangeFunc func,
+                                                 gpointer user_data)
+{
+  GList * head;
+  guint i;
+  gboolean carry_on = TRUE;
+
+  head = gum_linux_collect_ranges ();
+
+  for (i = 0; i != self->num_ranges && carry_on; i++)
+  {
+    GList * range = head;
+    GumMemoryRange * r = &self->ranges[i];
+    GumAddress cur = r->base_address;
+    GumAddress end = cur + r->size;
+
+    while ((range = g_list_next (range)))
+    {
+      GumLinuxRange * lr = (GumLinuxRange *) range->data;
+      do
+      {
+        if (cur >= lr->base &&
+            cur + self->page_size - 1 < lr->base + lr->size)
+        {
+          GumPageDetails details;
+
+          details.range.base = cur;
+          details.range.size = self->page_size;
+          details.range.prot = lr->prot;
+          details.range_index = i;
+          carry_on = func (&details, user_data);
+          cur += self->page_size;
+        }
+        else
+        {
+          break;
+        }
+
+      }
+      while (cur < end && carry_on);
+    }
+  }
+
+  g_list_free_full (head, gum_linux_free_ranges);
+}
+
+static void
+gum_linux_free_ranges (gpointer data)
+{
+  g_slice_free (GumLinuxRange, data);
+}
+
+static gboolean
+gum_linux_set_flag (const GumPageDetails * details,
+                    gpointer user_data)
+{
+  GumMemoryAccessMonitor * self = GUM_MEMORY_ACCESS_MONITOR (user_data);
+  const GumLinuxRange * range = &details->range;
+  GumPageProtection access_mask = self->access_mask;
+  GumPageProtection new_prot = GUM_PAGE_NO_ACCESS;
+  guint num_pages;
+
+  switch (range->prot)
+  {
+    case GUM_PAGE_READ:
+      if ((access_mask & GUM_PAGE_READ) != 0)
+        new_prot = GUM_PAGE_WRITE;
+      else
+        return TRUE;
+      break;
+    case GUM_PAGE_WRITE:
+      if ((access_mask & GUM_PAGE_WRITE) != 0)
+        new_prot = GUM_PAGE_READ;
+      else
+        return TRUE;
+      break;
+    case GUM_PAGE_EXECUTE:
+      if ((access_mask & GUM_PAGE_EXECUTE) != 0)
+        new_prot = GUM_PAGE_WRITE;
+      else
+        return TRUE;
+      break;
+    case GUM_PAGE_RW:
+      if (access_mask == GUM_PAGE_WRITE)
+        new_prot = GUM_PAGE_READ;
+      else if (access_mask == GUM_PAGE_READ || access_mask == GUM_PAGE_EXECUTE)
+        new_prot = GUM_PAGE_WRITE;
+      else if (access_mask == (GUM_PAGE_EXECUTE | GUM_PAGE_WRITE))
+        new_prot = GUM_PAGE_NO_ACCESS;
+      break;
+    case GUM_PAGE_RX:
+      if (access_mask == GUM_PAGE_READ ||
+          access_mask == GUM_PAGE_EXECUTE ||
+          access_mask == GUM_PAGE_RX)
+        new_prot = GUM_PAGE_WRITE;
+      else
+        return TRUE;
+      break;
+    case GUM_PAGE_RWX:
+      new_prot = GUM_PAGE_NO_ACCESS;
+      break;
+    default:
+      g_assert_not_reached ();
+  }
+
+  num_pages = self->num_pages;
+
+  self->pages_details = g_realloc (self->pages_details,
+      (num_pages + 1) * sizeof (GumPageDetails));
+
+  memcpy ((void *) &self->pages_details[num_pages],
+      (void *) details, sizeof (GumPageDetails));
+
+  self->pages_details[num_pages].completed = 0;
+  self->num_pages++;
+
+  gum_mprotect (GSIZE_TO_POINTER (range->base), range->size, new_prot);
+
+  return TRUE;
+}
+
+static gboolean
+gum_linux_clear_flag (const GumPageDetails * details,
+                      gpointer user_data)
+{
+  guint i;
+  GumMemoryAccessMonitor * self = GUM_MEMORY_ACCESS_MONITOR (user_data);
+  const GumLinuxRange * range = &details->range;
+
+  for (i = 0; i != self->num_pages; i++)
+  {
+    const GumPageDetails * page = &self->pages_details[i];
+    const GumLinuxRange * r = &page->range;
+
+    if (range->base >= r->base &&
+        range->base + range->size - 1 < r->base + r->size)
+    {
+      gum_mprotect (GSIZE_TO_POINTER (r->base), r->size, r->prot);
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+static gboolean
+gum_memory_access_monitor_on_exception (GumExceptionDetails * details,
+                                        gpointer user_data)
+{
+  GumMemoryAccessMonitor * self = GUM_MEMORY_ACCESS_MONITOR (user_data);
+  GumMemoryAccessDetails d;
+  guint i;
+
+  if (details->type != GUM_EXCEPTION_ACCESS_VIOLATION)
+    return FALSE;
+
+  d.operation = details->memory.operation;
+  d.from = details->address;
+  d.address = details->memory.address;
+
+  for (i = 0; i != self->num_pages; i++)
+  {
+    GumPageDetails * page = &self->pages_details[i];
+    const GumLinuxRange * range = &page->range;
+    const GumMemoryRange * r = &self->ranges[page->range_index];
+    guint operation_mask;
+    guint operations_reported;
+    guint pages_remaining;
+
+    if ((GPOINTER_TO_SIZE (d.address) >= range->base) &&
+        GPOINTER_TO_SIZE (d.address) < (range->base + self->page_size))
+    {
+      GumPageProtection gum_orig_prot = range->prot;
+      switch (d.operation)
+      {
+        case GUM_MEMOP_READ:
+          if ((gum_orig_prot & GUM_PAGE_READ) == 0)
+            return FALSE;
+          break;
+        case GUM_MEMOP_WRITE:
+          if ((gum_orig_prot & GUM_PAGE_WRITE) == 0)
+            return FALSE;
+          break;
+        case GUM_MEMOP_EXECUTE:
+          if ((gum_orig_prot & GUM_PAGE_WRITE) == 0)
+            return FALSE;
+          break;
+        default:
+          g_assert_not_reached ();
+      }
+
+      /* Restore original flags */
+      if (self->auto_reset)
+        gum_mprotect (GSIZE_TO_POINTER (range->base), range->size, range->prot);
+
+      operation_mask = 1 << d.operation;
+      operations_reported = g_atomic_int_or (&page->completed, operation_mask);
+      if ((operations_reported != 0) && self->auto_reset)
+        return FALSE;
+      if (!operations_reported)
+        pages_remaining = g_atomic_int_add (&self->pages_remaining, -1) - 1;
+      else
+        pages_remaining = g_atomic_int_get (&self->pages_remaining);
+      d.pages_completed = self->pages_total - pages_remaining;
+
+      d.range_index = page->range_index;
+      d.page_index = (guint8 *) d.address - (guint8 *) r->base_address;
+      d.page_index = d.page_index / self->page_size;
+      d.pages_total = self->pages_total;
+
+      self->notify_func (self, &d, self->notify_data);
+
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}

--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -17,12 +17,15 @@
 # include "backend-qnx/gumqnx.h"
 #endif
 
+#include <capstone.h>
 #include <signal.h>
 #include <stdlib.h>
 #ifdef HAVE_QNX
 # include <sys/debug.h>
 # include <unix.h>
 #endif
+
+#define X86OP(n) insn->detail->x86.operands[n]
 
 struct _GumExceptorBackend
 {
@@ -50,6 +53,21 @@ static int gum_exceptor_backend_replacement_sigaction (int sig,
     const struct sigaction * act, struct sigaction * oact);
 static void gum_exceptor_backend_on_signal (int sig, siginfo_t * siginfo,
     void * context);
+
+static GumMemoryOperation gum_exceptor_check_mem_access (gpointer address,
+    GumCpuContext * cpu);
+static cs_insn * disassemble_instruction_at (gconstpointer address,
+    GumCpuContext * cpu);
+
+#if defined (HAVE_I386)
+static GumMemoryOperation gum_exceptor_x86_check_mem_operation (cs_insn * insn);
+#elif defined (HAVE_ARM64)
+static GumMemoryOperation gum_exceptor_arm64_check_mem_operation (
+    cs_insn * insn);
+#elif defined (HAVE_ARM)
+static GumMemoryOperation gum_exceptor_arm_check_mem_operation (cs_insn * insn);
+#endif
+
 static void gum_exceptor_backend_abort (GumExceptorBackend * self,
     GumExceptionDetails * details);
 
@@ -335,7 +353,7 @@ gum_exceptor_backend_on_signal (int sig,
       if (siginfo->si_addr == ed.address)
         md->operation = GUM_MEMOP_EXECUTE;
       else
-        md->operation = GUM_MEMOP_READ; /* FIXME */
+        md->operation = gum_exceptor_check_mem_access (ed.address, cpu_context);
       md->address = siginfo->si_addr;
       break;
     default:
@@ -377,6 +395,236 @@ gum_exceptor_backend_on_signal (int sig,
 panic:
   gum_exceptor_backend_detach_handler (self, sig);
 }
+
+static GumMemoryOperation
+gum_exceptor_check_mem_access (gpointer address, 
+                               GumCpuContext * cpu)
+{
+  cs_insn * insn;
+  GumMemoryOperation op;
+
+  insn = disassemble_instruction_at (address, cpu);
+  if (insn == NULL)
+    return GUM_MEMOP_READ;
+
+#if defined (HAVE_I386)
+  op = gum_exceptor_x86_check_mem_operation (insn);
+#elif defined (HAVE_ARM64)
+  op = gum_exceptor_arm64_check_mem_operation (insn);
+#elif defined (HAVE_ARM)
+  op = gum_exceptor_arm_check_mem_operation (insn);
+#else
+  return GUM_MEMOP_READ;
+#endif
+
+  cs_free (insn, 1);
+  return op;
+}
+
+static cs_insn *
+disassemble_instruction_at (gconstpointer address, 
+                            GumCpuContext * cpu)
+{
+  cs_err err;
+  csh capstone;
+  cs_insn * insn = NULL;
+
+#if defined (HAVE_ARM64)
+  err = cs_open (CS_ARCH_ARM64, GUM_DEFAULT_CS_ENDIAN, &capstone);
+#elif defined (HAVE_I386)
+  err = cs_open (CS_ARCH_X86, GUM_CPU_MODE, &capstone);
+#elif defined (HAVE_ARM)
+  if (cpu->cpsr & ARM_GRP_THUMB)
+    err = cs_open (CS_ARCH_ARM, CS_MODE_THUMB, &capstone);
+  else
+    err = cs_open (CS_ARCH_ARM, CS_MODE_ARM, &capstone);
+#else
+  return NULL;
+#endif
+
+  if (err != CS_ERR_OK)
+    return NULL;
+
+  cs_option (capstone, CS_OPT_DETAIL, CS_OPT_ON);
+  cs_disasm (capstone, address, 16, GPOINTER_TO_SIZE (address), 1, &insn);
+  cs_close (&capstone);
+
+  return insn;
+}
+
+#if defined (HAVE_I386)
+
+static GumMemoryOperation
+gum_exceptor_x86_check_mem_operation (cs_insn * insn)
+{
+  switch (insn->id)
+  {
+    case X86_INS_CLI:
+    case X86_INS_STI:
+    case X86_INS_CLC:
+    case X86_INS_STC:
+    case X86_INS_CLAC:
+    case X86_INS_CLGI:
+    case X86_INS_CLTS:
+#if CS_API_MAJOR >= 4
+    case X86_INS_CLWB:
+#endif
+    case X86_INS_STAC:
+    case X86_INS_STGI:
+    case X86_INS_CPUID:
+    case X86_INS_MOVNTQ:
+    case X86_INS_MOVNTDQA:
+    case X86_INS_MOVNTDQ:
+    case X86_INS_MOVNTI:
+    case X86_INS_MOVNTPD:
+    case X86_INS_MOVNTPS:
+    case X86_INS_MOVNTSD:
+    case X86_INS_MOVNTSS:
+    case X86_INS_VMOVNTDQA:
+    case X86_INS_VMOVNTDQ:
+    case X86_INS_VMOVNTPD:
+    case X86_INS_VMOVNTPS:
+    case X86_INS_MOVSS:
+    case X86_INS_MOV:
+    case X86_INS_MOVAPS:
+    case X86_INS_MOVAPD:
+    case X86_INS_MOVZX:
+    case X86_INS_MOVUPS:
+    case X86_INS_MOVABS:
+    case X86_INS_MOVHPD:
+    case X86_INS_MOVHPS:
+    case X86_INS_MOVLPD:
+    case X86_INS_MOVLPS:
+    case X86_INS_MOVBE:
+    case X86_INS_MOVSB:
+    case X86_INS_MOVSD:
+    case X86_INS_MOVSQ:
+    case X86_INS_MOVSX:
+    case X86_INS_MOVSXD:
+    case X86_INS_MOVSW:
+    case X86_INS_MOVD:
+    case X86_INS_MOVQ:
+    case X86_INS_MOVDQ2Q:
+    case X86_INS_RDRAND:
+    case X86_INS_RDSEED:
+    case X86_INS_RDMSR:
+    case X86_INS_RDPMC:
+    case X86_INS_RDTSC:
+    case X86_INS_RDTSCP:
+    case X86_INS_CRC32:
+    case X86_INS_SHA1MSG1:
+    case X86_INS_SHA1MSG2:
+    case X86_INS_SHA1NEXTE:
+    case X86_INS_SHA1RNDS4:
+    case X86_INS_SHA256MSG1:
+    case X86_INS_SHA256MSG2:
+    case X86_INS_SHA256RNDS2:
+    case X86_INS_AESDECLAST:
+    case X86_INS_AESDEC:
+    case X86_INS_AESENCLAST:
+    case X86_INS_AESENC:
+    case X86_INS_AESIMC:
+    case X86_INS_AESKEYGENASSIST:
+    case X86_INS_PACKSSDW:
+    case X86_INS_PACKSSWB:
+    case X86_INS_PACKUSWB:
+    case X86_INS_XCHG:
+    case X86_INS_CLD:
+    case X86_INS_STD:
+      switch (X86OP (0).type)
+      {
+        case X86_OP_MEM:
+          return GUM_MEMOP_WRITE;
+        case X86_OP_REG:
+          if (X86OP (1).type == X86_OP_MEM)
+            return GUM_MEMOP_READ;
+        default:
+          return GUM_MEMOP_READ;
+      }
+    default:
+      return GUM_MEMOP_READ;
+  }
+}
+
+#elif defined (HAVE_ARM64)
+
+static GumMemoryOperation
+gum_exceptor_arm64_check_mem_operation (cs_insn * insn)
+{
+  switch (insn->id)
+  {
+    case ARM64_INS_LDUR:
+    case ARM64_INS_LDURB:
+    case ARM64_INS_LDRSW:
+    case ARM64_INS_LDRSB:
+    case ARM64_INS_LDRSH:
+    case ARM64_INS_LDR:
+    case ARM64_INS_LDURSW:
+    case ARM64_INS_LDP:
+    case ARM64_INS_LDNP:
+    case ARM64_INS_LDPSW:
+    case ARM64_INS_LDRH:
+    case ARM64_INS_LDRB:
+    case ARM64_INS_LDRAA:
+    case ARM64_INS_LDRAB:
+      return GUM_MEMOP_READ;
+    case ARM64_INS_STRB:
+    case ARM64_INS_STURB:
+    case ARM64_INS_STUR:
+    case ARM64_INS_STR:
+    case ARM64_INS_STP:
+    case ARM64_INS_STNP:
+    case ARM64_INS_STXR:
+    case ARM64_INS_STXRH:
+    case ARM64_INS_STLXRH:
+    case ARM64_INS_STXRB:
+      return GUM_MEMOP_WRITE;
+    default:
+      return GUM_MEMOP_READ;
+  }
+}
+
+#elif defined (HAVE_ARM)
+
+static GumMemoryOperation
+gum_exceptor_arm_check_mem_operation (cs_insn * insn)
+{
+  switch (insn->id)
+  {
+    case ARM_INS_LDREX:
+    case ARM_INS_LDREXB:
+    case ARM_INS_LDREXD:
+    case ARM_INS_LDREXH:
+    case ARM_INS_LDR:
+    case ARM_INS_LDRD:
+    case ARM_INS_LDRB:
+    case ARM_INS_LDRBT:
+    case ARM_INS_LDRH:
+    case ARM_INS_LDRHT:
+    case ARM_INS_LDRSB:
+    case ARM_INS_LDRSBT:
+    case ARM_INS_LDRSH:
+    case ARM_INS_LDRSHT:
+    case ARM_INS_LDRT:
+      return GUM_MEMOP_READ;
+    case ARM_INS_STREX:
+    case ARM_INS_STREXB:
+    case ARM_INS_STREXD:
+    case ARM_INS_STREXH:
+    case ARM_INS_STR:
+    case ARM_INS_STRB:
+    case ARM_INS_STRD:
+    case ARM_INS_STRBT:
+    case ARM_INS_STRH:
+    case ARM_INS_STRHT:
+    case ARM_INS_STRT:
+      return GUM_MEMOP_WRITE;
+    default:
+      return GUM_MEMOP_READ;
+  }
+}
+
+#endif
 
 static void
 gum_exceptor_backend_abort (GumExceptorBackend * self,

--- a/gum/meson.build
+++ b/gum/meson.build
@@ -125,6 +125,7 @@ if host_os_family == 'linux'
     'backend-linux/gummemory-linux.c',
     'backend-posix/gummemory-posix.c',
     'backend-linux/gumprocess-linux.c',
+    'backend-linux/gummemoryaccessmonitor-linux.c',
     'backend-posix/gumtls-posix.c',
     'backend-posix/gumexceptor-posix.c',
   ]

--- a/tests/core/memoryaccessmonitor-fixture.c
+++ b/tests/core/memoryaccessmonitor-fixture.c
@@ -36,8 +36,15 @@ test_memory_access_monitor_fixture_setup (TestMAMonitorFixture * fixture,
   fixture->range.size = 2 * gum_query_page_size ();
   fixture->offset_in_first_page = gum_query_page_size () / 2;
   fixture->offset_in_second_page =
-      fixture->offset_in_first_page + gum_query_page_size ();
-  *((guint8 *) fixture->range.base_address) = 0xc3; /* ret instruction */
+    fixture->offset_in_first_page + gum_query_page_size ();
+  /* ret instruction */
+#if defined (HAVE_ARM64)
+  *((guint32 *) fixture->range.base_address) = 0xd65f03c0;
+#elif defined (HAVE_ARM)
+  *((guint32 *) fixture->range.base_address) = 0xe1a0f00e;
+#else
+  *((guint8 *) fixture->range.base_address) = 0xc3;
+#endif
   fixture->nop_function_in_first_page =
       GUM_POINTER_TO_FUNCPTR (GCallback, fixture->range.base_address);
 

--- a/tests/core/memoryaccessmonitor-fixture.c
+++ b/tests/core/memoryaccessmonitor-fixture.c
@@ -38,12 +38,12 @@ test_memory_access_monitor_fixture_setup (TestMAMonitorFixture * fixture,
   fixture->offset_in_second_page =
     fixture->offset_in_first_page + gum_query_page_size ();
   /* ret instruction */
-#if defined (HAVE_ARM64)
-  *((guint32 *) fixture->range.base_address) = 0xd65f03c0;
+#if defined (HAVE_I386)
+  *((guint8 *) fixture->range.base_address) = 0xc3;
 #elif defined (HAVE_ARM)
   *((guint32 *) fixture->range.base_address) = 0xe1a0f00e;
-#else
-  *((guint8 *) fixture->range.base_address) = 0xc3;
+#elif defined (HAVE_ARM64)
+  *((guint32 *) fixture->range.base_address) = 0xd65f03c0;
 #endif
   fixture->nop_function_in_first_page =
       GUM_POINTER_TO_FUNCPTR (GCallback, fixture->range.base_address);

--- a/tests/core/meson.build
+++ b/tests/core/meson.build
@@ -29,7 +29,14 @@ endif
 if host_os == 'android'
   core_sources += [
     'interceptor-android.c',
+    'memoryaccessmonitor.c',
   ]
+endif
+
+if host_os == 'linux'
+core_sources += [
+  'memoryaccessmonitor.c',
+]
 endif
 
 if host_arch == 'x86' or host_arch == 'x86_64'

--- a/tests/core/meson.build
+++ b/tests/core/meson.build
@@ -26,17 +26,17 @@ if host_os_family == 'darwin'
   ]
 endif
 
+if host_os == 'linux'
+  core_sources += [
+    'memoryaccessmonitor.c',
+  ]
+endif
+
 if host_os == 'android'
   core_sources += [
     'interceptor-android.c',
     'memoryaccessmonitor.c',
   ]
-endif
-
-if host_os == 'linux'
-core_sources += [
-  'memoryaccessmonitor.c',
-]
 endif
 
 if host_arch == 'x86' or host_arch == 'x86_64'

--- a/tests/gumtest.c
+++ b/tests/gumtest.c
@@ -205,10 +205,7 @@ main (gint argc, gchar * argv[])
 #ifdef HAVE_DARWIN
   TESTLIST_REGISTER (exceptor_darwin);
 #endif
-#if defined (HAVE_I386) && defined (G_OS_WIN32)
-  TESTLIST_REGISTER (memoryaccessmonitor);
-#endif
-#if defined (HAVE_LINUX)
+#if (defined (HAVE_I386) && defined (G_OS_WIN32)) || defined (HAVE_LINUX)
   TESTLIST_REGISTER (memoryaccessmonitor);
 #endif
 

--- a/tests/gumtest.c
+++ b/tests/gumtest.c
@@ -208,6 +208,9 @@ main (gint argc, gchar * argv[])
 #if defined (HAVE_I386) && defined (G_OS_WIN32)
   TESTLIST_REGISTER (memoryaccessmonitor);
 #endif
+#if defined (HAVE_LINUX)
+  TESTLIST_REGISTER (memoryaccessmonitor);
+#endif
 
   if (gum_stalker_is_supported ())
   {


### PR DESCRIPTION
Besides adding MemoryAccessMonitor to Linux I also fixed a `FIXME` in the signal handler when reporting memory operation - it was needed for MemoryAccessMonitor to function correctly. Now, it is possible to check if the signal was due to a read or write - using capstone to disassemble the instruction.

Likewise, `gum_linux_unparse_ucontext` was using pc to set THUMB bit. However, on the signal context CPSR already contains that information plus PC will always be even. Therefore, with the previous logic when resuming after handling the exception it will always return to ARM mode instead of the one that correspond - let me know if that breaks something I am not aware. This should also be added to darwin and other ARM backends. Unfortunately, I don't have devices to test but let me know if you want me to send the same fix for darwin.