### PR TITLE
Enable AccessMonitor V8 for Linux and implement support for duktape runtime

### DIFF
--- a/bindings/gumjs/gumdukmemory.h
+++ b/bindings/gumjs/gumdukmemory.h
@@ -9,6 +9,8 @@
 
 #include "gumdukcore.h"
 
+#include <gum/gummemoryaccessmonitor.h>
+
 G_BEGIN_DECLS
 
 typedef struct _GumDukMemory GumDukMemory;
@@ -16,6 +18,11 @@ typedef struct _GumDukMemory GumDukMemory;
 struct _GumDukMemory
 {
   GumDukCore * core;
+
+  GumMemoryAccessMonitor * monitor;
+  GumDukHeapPtr on_access;
+
+  GumDukHeapPtr memory_access_details;
 };
 
 G_GNUC_INTERNAL void _gum_duk_memory_init (GumDukMemory * self,

--- a/bindings/gumjs/gumdukvalue.h
+++ b/bindings/gumjs/gumdukvalue.h
@@ -121,6 +121,11 @@ G_GNUC_INTERNAL void _gum_duk_push_exception_details (duk_context * ctx,
 G_GNUC_INTERNAL void _gum_duk_push_range (duk_context * ctx,
     const GumRangeDetails * details, GumDukCore * core);
 
+G_GNUC_INTERNAL GArray * _gum_duk_get_memory_ranges (duk_context * ctx,
+    duk_idx_t index, GumDukCore * core);
+G_GNUC_INTERNAL gboolean _gum_duk_get_memory_range (duk_context * ctx,
+    duk_idx_t index, GumDukCore * core, GumMemoryRange * range);
+
 G_GNUC_INTERNAL void _gum_duk_push_page_protection (duk_context * ctx,
     GumPageProtection prot);
 

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -144,10 +144,8 @@ static gboolean gum_append_match (GumAddress address, gsize size,
 GUMJS_DECLARE_FUNCTION (gumjs_memory_access_monitor_enable)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_access_monitor_disable)
 static void gum_v8_memory_clear_monitor (GumV8Memory * self);
-#ifdef G_OS_WIN32
 static void gum_v8_memory_on_access (GumMemoryAccessMonitor * monitor,
     const GumMemoryAccessDetails * details, GumV8Memory * self);
-#endif
 
 static const GumV8Function gumjs_memory_functions[] =
 {
@@ -230,7 +228,6 @@ _gum_v8_memory_dispose (GumV8Memory * self)
 void
 _gum_v8_memory_finalize (GumV8Memory * self)
 {
-  g_clear_object (&self->monitor);
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
@@ -1044,7 +1041,6 @@ gum_append_match (GumAddress address,
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_access_monitor_enable)
 {
-#ifdef G_OS_WIN32
   GArray * ranges;
   Local<Function> on_access;
   if (!_gum_v8_args_parse (args, "RF{onAccess}", &ranges, &on_access))
@@ -1085,26 +1081,16 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_access_monitor_enable)
     g_object_unref (module->monitor);
     module->monitor = NULL;
   }
-#else
-  _gum_v8_throw_ascii_literal (isolate,
-      "MemoryAccessMonitor is only available on Windows for now");
-#endif
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_access_monitor_disable)
 {
-#ifdef G_OS_WIN32
   gum_v8_memory_clear_monitor (module);
-#else
-  _gum_v8_throw_ascii_literal (isolate,
-      "MemoryAccessMonitor is only available on Windows for now");
-#endif
 }
 
 static void
 gum_v8_memory_clear_monitor (GumV8Memory * self)
 {
-#ifdef G_OS_WIN32
   if (self->monitor != NULL)
   {
     gum_memory_access_monitor_disable (self->monitor);
@@ -1114,10 +1100,7 @@ gum_v8_memory_clear_monitor (GumV8Memory * self)
 
   delete self->on_access;
   self->on_access = nullptr;
-#endif
 }
-
-#ifdef G_OS_WIN32
 
 static void
 gum_v8_memory_on_access (GumMemoryAccessMonitor * monitor,
@@ -1145,5 +1128,3 @@ gum_v8_memory_on_access (GumMemoryAccessMonitor * monitor,
       Undefined (isolate), G_N_ELEMENTS (argv), argv);
   (void) result;
 }
-
-#endif


### PR DESCRIPTION
This enable AccessMonitor on V8 for linux and duktape runtime implementation.

Do not review nor merge until https://github.com/frida/frida-gum/pull/352 gets pushed to master.