### PR TITLE
Make frida-gum linker seeking future-proof on Android

### DIFF
--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -639,7 +639,6 @@ no_vdso:
 
 beach:
   g_strfreev (lines);
-  g_free (linker_path);
   g_free (maps);
 
   return result;
@@ -651,41 +650,26 @@ gum_find_linker_path ()
   gchar *linker_expected_path, *linker_path = NULL;
 
   if (sizeof (gpointer) == 4)
-  {
     linker_expected_path = "/system/bin/linker";
-  }
   else
-  {
     linker_expected_path = "/system/bin/linker64";
-  }
 
   // If there are no linker file, fail
   if (!g_file_test (linker_expected_path, G_FILE_TEST_EXISTS))
-  {
-    goto result;
-  }
+    return NULL;
 
   if (g_file_test (linker_expected_path, G_FILE_TEST_IS_SYMLINK))
   {
     linker_path = g_file_read_link (linker_expected_path, NULL);
-    if (linker_path == NULL)
-    {
-      // Issue reading the link, fall back to backwards compatible path
-      // linker_true_path = &linker_expected_path[0];
-      strcpy (linker_path, linker_expected_path);
-    }
-  }
-  else
-  {
-    // Expected path is a real file, use it
-    // linker_true_path = &linker_expected_path[0];
-      strcpy (linker_path, linker_expected_path);
+
+    // Issue reading the link, fall back to backwards compatible path
+    if (linker_path != NULL)
+      return linker_path;
   }
 
-  result:
-  g_free (linker_expected_path);
-
-  return linker_path;
+  // If file was not a symlink or symlink resolution doesn't work, fall back
+  // to expected file
+  return linker_expected_path;
 }
 
 static gboolean

--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -323,7 +323,8 @@ struct _GumFunctionSignature
 static const GumModuleDetails * gum_try_init_linker_details (void);
 static gchar * gum_find_linker_path (void);
 static gboolean gum_try_parse_linker_proc_maps_line (const gchar * line,
-    const gchar * linker_path, GumModuleDetails * module, GumMemoryRange * range);
+    const gchar * linker_path, GumModuleDetails * module,
+    GumMemoryRange * range);
 
 static gboolean gum_store_module_handle_if_name_matches (
     const GumSoinfoDetails * details, GumGetModuleHandleContext * ctx);
@@ -600,7 +601,6 @@ gum_try_init_linker_details (void)
       break;
     }
   }
-
   if (vdso_index == -1)
     goto no_vdso;
 

--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -572,8 +572,9 @@ static const GumModuleDetails *
 gum_try_init_linker_details (void)
 {
   const GumModuleDetails * result = NULL;
-  gchar ** lines, * linker_path, * maps;
+  gchar * maps, ** lines;
   gint num_lines, vdso_index, i;
+  gchar * linker_path = NULL;
 
   /*
    * Using /proc/self/maps means there might be false positives, as the
@@ -600,10 +601,10 @@ gum_try_init_linker_details (void)
     }
   }
 
-  linker_path = gum_find_linker_path ();
-
   if (vdso_index == -1)
     goto no_vdso;
+
+  linker_path = gum_find_linker_path ();
 
   for (i = vdso_index + 1; i != num_lines; i++)
   {


### PR DESCRIPTION
Per https://github.com/frida/frida/issues/1026 and https://github.com/frida/frida-gum/pull/354 -
I looked into how the linker is meant to be established in Android going forward. According to
https://source.android.com/devices/architecture/modular-system/runtime#bionic-changes - Google
intends to maintain both `/system/bin/linker` and `/system/bin/linker64` as a symlink, pointing
to what the real file will be.

This means if we look for those files and they are symlinks, the linker should be mapped to memory
using the files realpath. So for future changes, looking to see what the symlink resolves as should
make this work in all future version (and keep its backwards compatibility).

Tested this on Android 5, 7.2, 8.0.1, 9 and 10.