### PR TITLE
Fix linker lookup in Android

### DIFF
--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -640,8 +640,6 @@ no_vdso:
   }
 
 beach:
-  g_free (linker_path);
-
   g_strfreev (lines);
   g_free (maps);
 


### PR DESCRIPTION
That g_free call shouldn't be here as `linker_path` is being accessed later from `GumModuleDetails`
Fixes: https://github.com/frida/frida/issues/1046