### PR TITLE
Handle correctly arm/thumb when restoring exception on Darwin

### DIFF
--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -2171,10 +2171,6 @@ gum_darwin_unparse_native_thread_state (const GumCpuContext * ctx,
   guint n;
 
   ts->__cpsr = ctx->cpsr;
-  if (ctx->pc & 1)
-    ts->__cpsr |= GUM_PSR_THUMB;
-  else
-    ts->__cpsr &= ~GUM_PSR_THUMB;
   ts->__pc = ctx->pc & ~1;
   ts->__sp = ctx->sp;
 


### PR DESCRIPTION
Use the same fix used in https://github.com/frida/frida-gum/pull/352 for Darwin ARM devices - I don't have any to test but it should work.