### PR TITLE
Add NativePointer#mapByteArray()

### DIFF
--- a/bindings/gumjs/gumdukmemory.c
+++ b/bindings/gumjs/gumdukmemory.c
@@ -124,6 +124,8 @@ GUMJS_DEFINE_MEMORY_READ_WRITE (UTF8_STRING)
 GUMJS_DEFINE_MEMORY_READ_WRITE (UTF16_STRING)
 GUMJS_DEFINE_MEMORY_READ_WRITE (ANSI_STRING)
 
+GUMJS_DECLARE_FUNCTION (gumjs_memory_map_byte_array)
+
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_ansi_string)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_utf8_string)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_utf16_string)
@@ -181,6 +183,8 @@ static const duk_function_list_entry gumjs_memory_functions[] =
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf8String", UTF8_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf16String", UTF16_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("AnsiString", ANSI_STRING),
+
+  { "_mapByteArray", gumjs_memory_map_byte_array, 2 },
 
   { "allocAnsiString", gumjs_memory_alloc_ansi_string, 1 },
   { "allocUtf8String", gumjs_memory_alloc_utf8_string, 1 },
@@ -796,6 +800,31 @@ gum_duk_memory_write (GumMemoryValueType type,
 #endif
 
   return 0;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_memory_map_byte_array)
+{
+  gpointer address;
+  gsize size;
+
+  _gum_duk_args_parse (args, "pZ", &address, &size);
+
+  if (address != NULL && size > 0)
+  {
+    duk_push_external_buffer (ctx);
+    duk_config_buffer (ctx, -1, address, size);
+  }
+  else
+  {
+    duk_push_fixed_buffer (ctx, 0);
+  }
+
+  duk_push_buffer_object (ctx, -1, 0, size, DUK_BUFOBJ_ARRAYBUFFER);
+
+  duk_swap (ctx, -2, -1);
+  duk_pop (ctx);
+
+  return 1;
 }
 
 #ifdef G_OS_WIN32

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -129,6 +129,8 @@ GUM_DEFINE_MEMORY_READ_WRITE (UTF8_STRING)
 GUM_DEFINE_MEMORY_READ_WRITE (UTF16_STRING)
 GUM_DEFINE_MEMORY_READ_WRITE (ANSI_STRING)
 
+GUMJS_DECLARE_FUNCTION (gumjs_memory_map_byte_array)
+
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_ansi_string)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_utf8_string)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc_utf16_string)
@@ -178,6 +180,8 @@ static const GumV8Function gumjs_memory_functions[] =
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf8String", UTF8_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf16String", UTF16_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("AnsiString", ANSI_STRING),
+
+  { "_mapByteArray", gumjs_memory_map_byte_array },
 
   { "allocAnsiString", gumjs_memory_alloc_ansi_string },
   { "allocUtf8String", gumjs_memory_alloc_utf8_string },
@@ -790,6 +794,28 @@ gum_v8_memory_write (GumMemoryValueType type,
 #ifdef _MSC_VER
 # pragma warning (pop)
 #endif
+
+GUMJS_DEFINE_FUNCTION (gumjs_memory_map_byte_array)
+{
+  Local<Value> result;
+
+  gpointer address;
+  gsize size;
+  if (!_gum_v8_args_parse (args, "pZ", &address, &size))
+    return;
+
+  if (address != NULL && size > 0)
+  {
+    result = ArrayBuffer::New (isolate, address, size,
+        ArrayBufferCreationMode::kExternalized);
+  }
+  else
+  {
+    result = ArrayBuffer::New (isolate, 0);
+  }
+
+  info.GetReturnValue ().Set (result);
+}
 
 #ifdef G_OS_WIN32
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -139,6 +139,10 @@ Object.keys(Memory)
     }
   });
 
+pointerPrototype.mapByteArray = function (size) {
+  return Memory._mapByteArray(this, size);
+};
+
 function makePointerReadMethod(read) {
   return function (...args) {
     return read.call(Memory, this, ...args);

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -114,6 +114,7 @@ TESTLIST_BEGIN (script)
     TESTENTRY (double_can_be_written)
     TESTENTRY (byte_array_can_be_read)
     TESTENTRY (byte_array_can_be_written)
+    TESTENTRY (byte_array_can_be_mapped)
     TESTENTRY (c_string_can_be_read)
     TESTENTRY (utf8_string_can_be_read)
     TESTENTRY (utf8_string_can_be_written)
@@ -5363,6 +5364,40 @@ TESTCASE (byte_array_can_be_written)
   g_assert_cmpint (val[0], ==, 0x04);
   g_assert_cmpint (val[1], ==, 0x05);
   g_assert_cmpint (val[2], ==, 0x03);
+}
+
+TESTCASE (byte_array_can_be_mapped)
+{
+  guint8 val[2] = { 13, 37 };
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "var val = new Uint8Array(" GUM_PTR_CONST ".mapByteArray(2));"
+      "send(val.length);"
+      "send(val[0]);"
+      "send(val[1]);"
+      "val[0] = 42;"
+      "val[1] = 24;",
+      val);
+  EXPECT_SEND_MESSAGE_WITH ("2");
+  EXPECT_SEND_MESSAGE_WITH ("13");
+  EXPECT_SEND_MESSAGE_WITH ("37");
+  g_assert_cmpint (val[0], ==, 42);
+  g_assert_cmpint (val[1], ==, 24);
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "var val = new Uint8Array(" GUM_PTR_CONST ".mapByteArray(0));"
+      "send(val.length);"
+      "send(typeof val[0]);",
+      val);
+  EXPECT_SEND_MESSAGE_WITH ("0");
+  EXPECT_SEND_MESSAGE_WITH ("\"undefined\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "var val = new Uint8Array(NULL);"
+      "send(val.length);"
+      "send(typeof val[0]);");
+  EXPECT_SEND_MESSAGE_WITH ("0");
+  EXPECT_SEND_MESSAGE_WITH ("\"undefined\"");
 }
 
 TESTCASE (c_string_can_be_read)


### PR DESCRIPTION
Useful if you want to avoid needing to constantly use .writeByteArray(...). Might solve #320.