### PR TITLE
fix IT block bug

### DIFF
--- a/gum/arch-arm/gumthumbrelocator.c
+++ b/gum/arch-arm/gumthumbrelocator.c
@@ -119,6 +119,7 @@ gum_thumb_relocator_reset (GumThumbRelocator * relocator,
   if (relocator->output != NULL)
     gum_thumb_writer_unref (relocator->output);
   relocator->output = output;
+  relocator->output_it_block.in_it_block = FALSE;
 
   relocator->inpos = 0;
   relocator->outpos = 0;
@@ -151,6 +152,19 @@ gum_thumb_relocator_increment_outpos (GumThumbRelocator * self)
 {
   self->outpos++;
   g_assert (self->outpos <= self->inpos);
+}
+
+inline guint8 get_it_instrument_scope(guint16 code) {
+  guint mask = code;
+
+  if (mask & 0x1)
+    return 4;
+  else if (mask & 0x2)
+    return 3;
+  else if (mask & 0x4)
+    return 2;
+  else
+    return 1;
 }
 
 guint
@@ -267,18 +281,139 @@ gum_thumb_relocator_skip_one (GumThumbRelocator * self)
   gum_thumb_relocator_increment_outpos (self);
 }
 
+gboolean 
+gum_thumb_relocator_rewrite_it_block_start (GumThumbRelocator * self, GumCodeGenCtx * ctx) {
+  gint32 i;
+  gint32 then_bit;
+  const cs_insn * else_insn[4];
+  GumThumbITBlock * it_block;
+  guint32 then_insn_count = 0;
+  guint16 it_code;
+  guint8 it_cond;
+
+  it_block = &self->output_it_block;
+  it_code = GUINT16_FROM_LE (*((guint16 *) ctx->insn->bytes));
+
+  it_block->insn_count = get_it_instrument_scope(it_code);
+  it_block->else_insn_count = 0;
+  it_block->curr_insn_pos = 0;
+  
+  it_cond = (it_code >> 4) & 0xf;
+  then_bit = (it_code >> 4) & 1;
+  for(i=0;i<it_block->insn_count;i++) {
+    guint8 cond_bit;
+    const cs_insn * sub_insn = gum_thumb_relocator_peek_next_write_insn (self);
+    g_assert(sub_insn != NULL);
+    gum_thumb_relocator_increment_outpos (self);
+    cond_bit = (it_code >> (4-i)) & 1;
+
+    if (cond_bit != then_bit) {
+      it_block->insns[it_block->else_insn_count] = sub_insn;
+      it_block->else_insn_count++;
+    } 
+    else 
+    {
+      else_insn[then_insn_count] = sub_insn;
+      then_insn_count++;
+    }
+  }
+
+  for(i=it_block->else_insn_count;i<it_block->insn_count;i++) 
+  {
+    it_block->insns[i] = else_insn[i-it_block->else_insn_count];
+  }
+
+  it_block->if_b_code.code = gum_thumb_writer_cur(self->output);
+  it_block->if_b_code.pc = gum_thumb_writer_cur_pc(self->output);
+
+  gum_thumb_writer_put_instruction(self->output, 0xd000 | (it_cond << 8));
+
+  it_block->else_b_code.pc = (GumAddress)NULL;
+  it_block->else_b_code.code = NULL;
+  
+  it_block->in_it_block = TRUE;
+  return TRUE;
+}
+
+void
+gum_thumb_relocator_rewrite_it_block_else(GumThumbRelocator * self, GumThumbITBlock * it_block) 
+{
+  GumAddress pc; 
+
+  it_block->else_b_code.code = gum_thumb_writer_cur(self->output);
+  it_block->else_b_code.pc = gum_thumb_writer_cur_pc(self->output);
+
+  gum_thumb_writer_put_instruction(self->output, 0xe000);
+
+  pc = gum_thumb_writer_cur_pc(self->output);
+  *it_block->if_b_code.code = *it_block->if_b_code.code | (pc - it_block->if_b_code.pc - 4) / 2;
+
+  it_block->if_b_code.code = NULL;
+  it_block->if_b_code.pc = 0;
+}
+
+void
+gum_thumb_relocator_rewrite_it_block_end(GumThumbRelocator * self, GumThumbITBlock * it_block) 
+{
+  GumAddress pc = gum_thumb_writer_cur_pc(self->output);;
+  if(it_block->if_b_code.pc != (GumAddress)NULL) 
+  {
+    *it_block->if_b_code.code = *it_block->if_b_code.code | (pc - it_block->if_b_code.pc - 4) / 2;
+  }
+
+  if(it_block->else_b_code.pc != (GumAddress)NULL)
+  {
+    *it_block->else_b_code.code = *it_block->else_b_code.code | (pc - it_block->else_b_code.pc - 4) / 2;
+  }
+}
+
+gboolean
+gum_thumb_relocator_fetch_instruction(GumThumbRelocator * self, const cs_insn ** insn)
+{
+  GumThumbITBlock * it_block = &self->output_it_block;
+  
+  if(it_block->in_it_block)
+  {
+    if(it_block->curr_insn_pos < it_block->insn_count)
+    {
+      if(it_block->curr_insn_pos == it_block->else_insn_count)
+        gum_thumb_relocator_rewrite_it_block_else(self, it_block);
+
+      *insn = it_block->insns[it_block->curr_insn_pos];
+      it_block->curr_insn_pos++;
+      return TRUE;
+    }
+    else
+    {
+      gum_thumb_relocator_rewrite_it_block_end(self, it_block);
+      it_block->in_it_block = FALSE;
+    }
+  } 
+  
+  if ((*insn = gum_thumb_relocator_peek_next_write_insn (self)) == NULL)
+    return FALSE;
+  
+  gum_thumb_relocator_increment_outpos (self);
+
+  return TRUE;
+}
+
 gboolean
 gum_thumb_relocator_write_one (GumThumbRelocator * self)
 {
   const cs_insn * insn;
   GumCodeGenCtx ctx;
   gboolean rewritten = FALSE;
+  GumThumbITBlock * it_block = &self->output_it_block;
 
-  if ((insn = gum_thumb_relocator_peek_next_write_insn (self)) == NULL)
+  gboolean succ = gum_thumb_relocator_fetch_instruction(self, &insn);
+  if(!succ)
     return FALSE;
-  gum_thumb_relocator_increment_outpos (self);
+
+  if(insn == NULL)
+    abort();
   ctx.insn = insn;
-  ctx.detail = &ctx.insn->detail->arm;
+  ctx.detail = &insn->detail->arm;
   ctx.pc = insn->address + 4;
   ctx.output = self->output;
 
@@ -291,7 +426,7 @@ gum_thumb_relocator_write_one (GumThumbRelocator * self)
       rewritten = gum_thumb_relocator_rewrite_add (self, &ctx);
       break;
     case ARM_INS_B:
-      if (gum_arm_branch_is_unconditional (ctx.insn))
+      if ( it_block->in_it_block || gum_arm_branch_is_unconditional (ctx.insn))
         rewritten = gum_thumb_relocator_rewrite_b (self, CS_MODE_THUMB, &ctx);
       else
         rewritten = gum_thumb_relocator_rewrite_b_cond (self, &ctx);
@@ -308,6 +443,9 @@ gum_thumb_relocator_write_one (GumThumbRelocator * self)
     case ARM_INS_CBZ:
     case ARM_INS_CBNZ:
       rewritten = gum_thumb_relocator_rewrite_cbz (self, &ctx);
+      break;
+    case ARM_INS_IT:
+      rewritten = gum_thumb_relocator_rewrite_it_block_start(self, &ctx);
       break;
   }
 

--- a/gum/arch-arm/gumthumbrelocator.h
+++ b/gum/arch-arm/gumthumbrelocator.h
@@ -14,6 +14,28 @@
 G_BEGIN_DECLS
 
 typedef struct _GumThumbRelocator GumThumbRelocator;
+typedef struct _GumThumbITBlock GumThumbITBlock;
+typedef struct _GumThumbITBlockPatch GumThumbITBlockPatch;
+
+struct _GumThumbITBlockPatch
+{
+    guint16 * code;
+    GumAddress pc;
+};
+
+struct _GumThumbITBlock
+{
+    gboolean in_it_block;
+    const cs_insn * insns[4];           //reordered instruction, "then" part before "else" part
+    guint8 insn_count;                  //total
+    guint8 else_insn_count;             //then part 
+    guint8 curr_insn_pos;               //write position
+    GumThumbITBlockPatch if_b_code;     //patch "if" header (a bxx instrument)
+    GumThumbITBlockPatch else_b_code;   //patch "else" part (a b instrument)
+};
+
+static csh capstone;
+static int capstone_inited = 0;
 
 struct _GumThumbRelocator
 {
@@ -26,6 +48,7 @@ struct _GumThumbRelocator
   GumAddress input_pc;
   cs_insn ** input_insns;
   GumThumbWriter * output;
+  GumThumbITBlock output_it_block;
 
   guint inpos;
   guint outpos;

--- a/gum/arch-arm/gumthumbwriter.c
+++ b/gum/arch-arm/gumthumbwriter.c
@@ -192,6 +192,12 @@ gum_thumb_writer_cur (GumThumbWriter * self)
   return self->code;
 }
 
+GumAddress
+gum_thumb_writer_cur_pc (GumThumbWriter * self)
+{
+  return self->pc;
+}
+
 guint
 gum_thumb_writer_offset (GumThumbWriter * self)
 {

--- a/gum/arch-arm/gumthumbwriter.h
+++ b/gum/arch-arm/gumthumbwriter.h
@@ -47,6 +47,7 @@ GUM_API void gum_thumb_writer_reset (GumThumbWriter * writer,
 GUM_API void gum_thumb_writer_set_target_os (GumThumbWriter * self, GumOS os);
 
 GUM_API gpointer gum_thumb_writer_cur (GumThumbWriter * self);
+GumAddress gum_thumb_writer_cur_pc (GumThumbWriter * self);
 GUM_API guint gum_thumb_writer_offset (GumThumbWriter * self);
 GUM_API void gum_thumb_writer_skip (GumThumbWriter * self, guint n_bytes);
 

--- a/tests/core/arch-arm/thumbrelocator.c
+++ b/tests/core/arch-arm/thumbrelocator.c
@@ -237,7 +237,8 @@ TESTCASE (bl_sequence_should_be_rewritten)
   g_assert_cmpint (insn->id, ==, ARM_INS_PUSH);
   g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 6);
   g_assert_cmpint (insn->id, ==, ARM_INS_BL);
-  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 10);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==,
+     10);
   g_assert_cmpint (insn->id, ==, ARM_INS_BLX);
   gum_thumb_relocator_write_all (&fixture->rl);
   gum_thumb_writer_flush (&fixture->tw);
@@ -625,7 +626,8 @@ TESTCASE (it_block_with_pc_relative_should_be_rewritten)
   insn = NULL;
 
   g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 2);
-  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 10);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==,
+     10);
   assert_outbuf_still_zeroed_from_offset (0);
 
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
@@ -635,7 +637,8 @@ TESTCASE (it_block_with_pc_relative_should_be_rewritten)
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
   g_assert_false (gum_thumb_relocator_write_one (&fixture->rl));
 
-  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output,
+   sizeof(expected_output)),
       ==, 0);
 }
 
@@ -661,7 +664,7 @@ TESTCASE (it_block_with_b_should_be_rewritten)
     GUINT16_TO_LE (0xf101),     /* .L1 ...                   */
     GUINT16_TO_LE (0x37ff),     /* add.w	r7, r1, #-1 */
     GUINT16_TO_LE (0xb401),     /* push	{ r0 }               */
-    GUINT16_TO_LE (0x4800),     /* ldr	r0, [pc, #0]        */ /* blxeq xxxx,lable to fill */
+    GUINT16_TO_LE (0x4800),     /* ldr	r0, [pc, #0]        */ 
     GUINT16_TO_LE (0x4686),     /* mov	lr, r0               */   
     GUINT16_TO_LE (0xbc01),     /* pop	{r0}                 */
     GUINT16_TO_LE (0x47f0),     /* blx	lr                   */
@@ -674,13 +677,14 @@ TESTCASE (it_block_with_b_should_be_rewritten)
 
   g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 2);
   g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 4);
-  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 16);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==,
+       16);
   assert_outbuf_still_zeroed_from_offset (0);
 
   gum_thumb_relocator_write_all(&fixture->rl);
 
-  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
-      ==, 0);
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output
+      , sizeof(expected_output)), ==, 0);
 }
 TESTCASE (it_block_should_be_rewritten_as_a_whole)
 {
@@ -720,8 +724,8 @@ TESTCASE (it_block_should_be_rewritten_as_a_whole)
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
   g_assert_false (gum_thumb_relocator_write_one (&fixture->rl));
 
-  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
-      ==, 0);
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output,
+      sizeof(expected_output)), ==, 0);
 }
 
 TESTCASE (eob_and_eoi_on_ret)

--- a/tests/core/arch-arm/thumbrelocator.c
+++ b/tests/core/arch-arm/thumbrelocator.c
@@ -25,6 +25,7 @@ TESTLIST_BEGIN (thumbrelocator)
   TESTENTRY (cbz_should_be_rewritten)
   TESTENTRY (cbnz_should_be_rewritten)
   TESTENTRY (b_cond_should_be_rewritten)
+  TESTENTRY (it_block_with_b_should_be_rewritten)
   TESTENTRY (it_block_should_be_rewritten_as_a_whole)
   TESTENTRY (eob_and_eoi_on_ret)
 TESTLIST_END ()
@@ -597,6 +598,90 @@ TESTCASE (b_cond_should_be_rewritten)
       sizeof (expected_output)), ==, 0);
 }
 
+TESTCASE (it_block_with_pc_relative_should_be_rewritten)
+{
+ const guint16 input[] = {
+   GUINT16_TO_LE (0x2800),     /* cmp r0, #0             */
+   GUINT16_TO_LE (0xbf06),     /* itte eq                */
+   GUINT16_TO_LE (0x4801),     /* ldreq r0, [pc, #4]     */
+   GUINT16_TO_LE (0x3001),     /* addeq r0, #1           */
+   GUINT16_TO_LE (0x3001),     /* addne r0, #1           */
+ };
+
+ const guint16 expected_output[] = {
+   GUINT16_TO_LE (0x2800),     /* cmp r0, #0             */
+   GUINT16_TO_LE (0xd001),     /* beq.n .L1              */
+   GUINT16_TO_LE (0x3001),     /* adds r0, #1            */
+   GUINT16_TO_LE (0xe002),     /* b.n .L2                */
+   GUINT16_TO_LE (0x4800),     /* .L1: ldr r0, [pc, #0]  */
+   GUINT16_TO_LE (0x6800),     /* ldr r0, [r0, #0]       */
+   GUINT16_TO_LE (0x3001),     /* adds r0, #1            */
+                               /* .L2:                   */
+ };
+
+  const cs_insn * insn;
+
+  SETUP_RELOCATOR_WITH (input);
+  insn = NULL;
+
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 2);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 10);
+  assert_outbuf_still_zeroed_from_offset (0);
+
+  g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
+  g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
+  g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
+  g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
+  g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
+  g_assert_false (gum_thumb_relocator_write_one (&fixture->rl));
+
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
+      ==, 0);
+}
+
+TESTCASE (it_block_with_b_should_be_rewritten) 
+{
+  const guint16 input[] = {
+    GUINT16_TO_LE (0xb580),     /* push	{r7, lr}             */
+    GUINT16_TO_LE (0x2801),     /* cmp	r0, #1               */
+    GUINT16_TO_LE (0xbf0a),     /* itet	eq                   */
+    GUINT16_TO_LE (0xf101),     /* ...                       */
+    GUINT16_TO_LE (0x37ff),     /* addeq.w	r7, r1, #-1      */
+    GUINT16_TO_LE (0x1c4f),     /* addne	r7, r1, #1         */
+    GUINT16_TO_LE (0xf7ff),     /* ...                       */
+    GUINT16_TO_LE (0xef08),     /* blxeq xxxx                */
+  };
+  
+  const guint16 expected_output[] = {
+    GUINT16_TO_LE (0xb580),     /* push	{r7, lr}             */
+    GUINT16_TO_LE (0x2801),     /* cmp	r0, #1               */
+    GUINT16_TO_LE (0xd001),     /* beq.n	.L1                */
+    GUINT16_TO_LE (0x1c4f),     /* adds	r7, r1, #1           */
+    GUINT16_TO_LE (0xe006),     /* b.n  .L2                  */
+    GUINT16_TO_LE (0xf101),     /* .L1 ...                   */
+    GUINT16_TO_LE (0x37ff),     /* add.w	r7, r1, #-1 */
+    GUINT16_TO_LE (0xb401),     /* push	{ r0 }               */
+    GUINT16_TO_LE (0x4800),     /* ldr	r0, [pc, #0]        */ /* blxeq xxxx,lable to fill */
+    GUINT16_TO_LE (0x4686),     /* mov	lr, r0               */   
+    GUINT16_TO_LE (0xbc01),     /* pop	{r0}                 */
+    GUINT16_TO_LE (0x47f0),     /* blx	lr                   */
+  };
+
+  const cs_insn * insn;
+
+  SETUP_RELOCATOR_WITH (input);
+  insn = NULL;
+
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 2);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 4);
+  g_assert_cmpuint (gum_thumb_relocator_read_one (&fixture->rl, &insn), ==, 16);
+  assert_outbuf_still_zeroed_from_offset (0);
+
+  gum_thumb_relocator_write_all(&fixture->rl);
+
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
+      ==, 0);
+}
 TESTCASE (it_block_should_be_rewritten_as_a_whole)
 {
   const guint16 input[] = {
@@ -605,6 +690,16 @@ TESTCASE (it_block_should_be_rewritten_as_a_whole)
     GUINT16_TO_LE (0x6800), /* ldrne r0, [r0] */
     GUINT16_TO_LE (0x2800)  /* cmpne r0, #0   */
   };
+
+  const guint16 expected_output[] = {
+    GUINT16_TO_LE (0x2800), /* cmp r0, #0            */
+    GUINT16_TO_LE (0xd100), /* bne.n	.L1            */
+    GUINT16_TO_LE (0xe001), /* b.n .L2               */
+    GUINT16_TO_LE (0x6800), /* .L1: ldr r0, [r0,#0]  */
+    GUINT16_TO_LE (0x2800), /* cmp r0, #0            */
+                            /* .L2:                  */
+  };
+
   const cs_insn * insn;
 
   SETUP_RELOCATOR_WITH (input);
@@ -620,17 +715,13 @@ TESTCASE (it_block_should_be_rewritten_as_a_whole)
   assert_outbuf_still_zeroed_from_offset (0);
 
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
-  g_assert_cmpint (memcmp (fixture->output, input, 2), ==, 0);
-  assert_outbuf_still_zeroed_from_offset (2);
-
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
   g_assert_true (gum_thumb_relocator_write_one (&fixture->rl));
-  g_assert_cmpint (memcmp (((guint8 *) fixture->output) + 2, input + 1, 6),
-      ==, 0);
-  assert_outbuf_still_zeroed_from_offset (8);
-
   g_assert_false (gum_thumb_relocator_write_one (&fixture->rl));
+
+  g_assert_cmpint (memcmp (((guint8 *) fixture->output), expected_output, sizeof(expected_output)),
+      ==, 0);
 }
 
 TESTCASE (eob_and_eoi_on_ret)


### PR DESCRIPTION
see https://github.com/frida/frida-gum/issues/383

Fixed the issue where single instruction was rewritten into multiple instructions in IT instruction;
Fixed the problem that the B instruction with condition in the IT instruction condition needs to be removed after “rewrite”;
Rewritten IT instruction block “rewrite” logic
See test cases for details