### PR TITLE
Honor masks_count also as input argument

### DIFF
--- a/gum/backend-darwin/gumexceptor-darwin.c
+++ b/gum/backend-darwin/gumexceptor-darwin.c
@@ -1131,11 +1131,15 @@ gum_exception_port_set_extract (GumExceptionPortSet * self,
 {
   size_t max_size = *masks_count * sizeof (mach_port_t);
 
-  memcpy (masks, self->masks, MIN (max_size, sizeof (self->masks)));
+  memcpy (masks, self->masks,
+      MIN (max_size, sizeof (self->masks)));
   *masks_count = MIN (*masks_count, self->count);
-  memcpy (old_handlers, self->handlers, MIN (max_size, sizeof (self->handlers)));
-  memcpy (old_behaviors, self->behaviors, MIN (max_size, sizeof (self->behaviors)));
-  memcpy (old_flavors, self->flavors, MIN (max_size, sizeof (self->flavors)));
+  memcpy (old_handlers, self->handlers,
+      MIN (max_size, sizeof (self->handlers)));
+  memcpy (old_behaviors, self->behaviors,
+      MIN (max_size, sizeof (self->behaviors)));
+  memcpy (old_flavors, self->flavors,
+      MIN (max_size, sizeof (self->flavors)));
 }
 
 static void

--- a/gum/backend-darwin/gumexceptor-darwin.c
+++ b/gum/backend-darwin/gumexceptor-darwin.c
@@ -1129,11 +1129,13 @@ gum_exception_port_set_extract (GumExceptionPortSet * self,
                                 exception_behavior_array_t old_behaviors,
                                 exception_flavor_array_t old_flavors)
 {
-  memcpy (masks, self->masks, sizeof (self->masks));
-  *masks_count = self->count;
-  memcpy (old_handlers, self->handlers, sizeof (self->handlers));
-  memcpy (old_behaviors, self->behaviors, sizeof (self->behaviors));
-  memcpy (old_flavors, self->flavors, sizeof (self->flavors));
+  size_t max_size = *masks_count * sizeof (mach_port_t);
+
+  memcpy (masks, self->masks, MIN (max_size, sizeof (self->masks)));
+  *masks_count = MIN (*masks_count, self->count);
+  memcpy (old_handlers, self->handlers, MIN (max_size, sizeof (self->handlers)));
+  memcpy (old_behaviors, self->behaviors, MIN (max_size, sizeof (self->behaviors)));
+  memcpy (old_flavors, self->flavors, MIN (max_size, sizeof (self->flavors)));
 }
 
 static void


### PR DESCRIPTION
So that it's used as maximum size for output arrays. The semantics of this in/out argument is the same in `task_get_exception_ports` and `task_swap_exception_ports`.

Excerpt from the man page:

> [pointer to in/out scalar]
On input, the maximum size of the array
buffers; on output, the number of returned <exception type mask,
exception port, behavior, flavor> sets returned.