### PR TITLE
Handle nested signals

### DIFF
--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -209,7 +209,7 @@ gum_exceptor_backend_attach (GumExceptorBackend * self)
 
   action.sa_sigaction = gum_exceptor_backend_on_signal;
   sigemptyset (&action.sa_mask);
-  action.sa_flags = SA_SIGINFO;
+  action.sa_flags = SA_SIGINFO | SA_NODEFER;
   for (i = 0; i != G_N_ELEMENTS (handled_signals); i++)
   {
     gint sig = handled_signals[i];

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -145,6 +145,7 @@ TESTLIST_BEGIN (script)
     TESTENTRY (process_platform_is_available)
     TESTENTRY (process_page_size_is_available)
     TESTENTRY (process_pointer_size_is_available)
+    TESTENTRY (process_nested_signal_handling)
 #ifndef HAVE_QNX
     TESTENTRY (process_debugger_status_is_available)
 #endif
@@ -2812,6 +2813,16 @@ TESTCASE (process_pointer_size_is_available)
 {
   COMPILE_AND_LOAD_SCRIPT ("send(Process.pointerSize);");
   EXPECT_SEND_MESSAGE_WITH (G_STRINGIFY (GLIB_SIZEOF_VOID_P));
+}
+
+TESTCASE (process_nested_signal_handling)
+{
+  COMPILE_AND_LOAD_SCRIPT ("Process.setExceptionHandler(function (details) { try { ptr(\"0x41414141\").readS8(); } catch (e) { send (2); }});"
+          "var kill = Module.getExportByName(\"libc.so.6\",\"kill\");"
+          "kill = new NativeFunction(kill, 'int', ['int', 'int']);"
+          "kill(0, 11);"
+          );
+  EXPECT_SEND_MESSAGE_WITH ("2");
 }
 
 TESTCASE (process_debugger_status_is_available)


### PR DESCRIPTION
Fixed the issue here: https://github.com/frida/frida/issues/1193

Short is that by default linux won't allow handling of the same signal inside itself. I.e.: segfault handling inside segfault handling.

NOTE: The way I have to test this involves sending a signal, which kills the process after being caught. The test passes but based on the way the tests for frida-gum work, any test after it fails due to the process crashing.

Not sure how to handle that, since it's not really a failed test, just how the harness handles tests.