### PR TITLE
Ensure script context is destroyed even if the script is still unloaded

### DIFF
--- a/bindings/gumjs/gumdukscript.c
+++ b/bindings/gumjs/gumdukscript.c
@@ -313,6 +313,9 @@ gum_duk_script_dispose (GObject * object)
   }
   else
   {
+    if (self->state == GUM_SCRIPT_STATE_UNLOADED && self->ctx != NULL)
+      gum_duk_script_destroy_context (self);
+
     g_clear_pointer (&self->main_context, g_main_context_unref);
     g_clear_pointer (&self->backend, g_object_unref);
   }

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -208,6 +208,9 @@ gum_v8_script_dispose (GObject * object)
   }
   else
   {
+    if (self->state == GUM_SCRIPT_STATE_UNLOADED && self->context != NULL)
+      gum_v8_script_destroy_context (self);
+
     self->isolate = NULL;
 
     g_clear_pointer (&self->main_context, g_main_context_unref);


### PR DESCRIPTION
This ensures that ultimately the script core is disposed, which in turn disposes its reference to the exceptor.

Failing to do so caused indefinite hang when attaching after detaching in presence of unloaded scripts, for the exceptor thread remaining in the target process.