### PR TITLE
Improve address resolution in the libdwarf backend

### DIFF
--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -634,7 +634,7 @@ static gboolean
 gum_collect_symbol_if_function (const GumElfSymbolDetails * details,
                                 gpointer user_data)
 {
-  gboolean include_symbols = (gboolean) user_data;
+  gboolean include_symbols = GPOINTER_TO_INT (user_data);
   const gchar * name;
   gpointer address;
   GArray * addresses;

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -363,7 +363,7 @@ gum_find_nearest_symbol_by_address (gpointer address,
   GHashTable * table;
   gchar * name;
   GList * keys, * cur;
-  gpointer current_address, closest_address;
+  gpointer current_address, nearest_address;
 
   table = gum_get_address_symbols ();
 
@@ -375,31 +375,31 @@ gum_find_nearest_symbol_by_address (gpointer address,
     return TRUE;
   }
 
-  closest_address = NULL;
+  nearest_address = NULL;
   keys = g_hash_table_get_keys (table);
   for (cur = keys; cur != NULL; cur = cur->next)
   {
     current_address = cur->data;
-    if (closest_address == NULL)
+    if (nearest_address == NULL)
     {
-      closest_address = current_address;
+      nearest_address = current_address;
       continue;
     }
 
     if (address < current_address)
       continue;
 
-    if (address - current_address >= address - closest_address)
+    if (address - current_address >= address - nearest_address)
       continue;
 
-    closest_address = current_address;
+    nearest_address = current_address;
   }
   g_list_free (keys);
 
-  if (closest_address != NULL)
+  if (nearest_address != NULL)
   {
-    nearest->address = closest_address;
-    nearest->name = g_hash_table_lookup (table, closest_address);
+    nearest->address = nearest_address;
+    nearest->name = g_hash_table_lookup (table, nearest_address);
     return TRUE;
   }
 
@@ -639,7 +639,6 @@ gum_collect_symbol_if_function (const GumElfSymbolDetails * details,
   gpointer address;
   GArray * addresses;
   gboolean already_collected;
-  gchar * symbol_name;
 
   if (details->section_header_index == SHN_UNDEF || details->type != STT_FUNC)
     return TRUE;
@@ -674,7 +673,7 @@ gum_collect_symbol_if_function (const GumElfSymbolDetails * details,
 
   if (include_symbols)
   {
-    symbol_name = g_hash_table_lookup (gum_address_symbols, address);
+    gchar * symbol_name = g_hash_table_lookup (gum_address_symbols, address);
     if (symbol_name == NULL)
       g_hash_table_insert (gum_address_symbols, address, g_strdup (name));
   }

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -93,7 +93,7 @@ struct _GumDieDetails
   Dwarf_Debug dbg;
 };
 
-static gboolean gum_find_nearest_symbol_by_address (const gpointer address,
+static gboolean gum_find_nearest_symbol_by_address (gpointer address,
     GumNearestSymbolDetails * nearest);
 static GumModuleEntry * gum_module_entry_from_address (gpointer address,
     GumNearestSymbolDetails * nearest);
@@ -357,19 +357,17 @@ gum_find_function (const gchar * name)
 }
 
 static gboolean
-gum_find_nearest_symbol_by_address (const gpointer address,
+gum_find_nearest_symbol_by_address (gpointer address,
                                     GumNearestSymbolDetails * nearest)
 {
   GHashTable * table;
   gchar * name;
-  GList * keys;
-  GList * current;
-  gpointer current_address;
-  gpointer closest_address = NULL;
+  GList * keys, * cur;
+  gpointer current_address, closest_address;
 
   table = gum_get_address_symbols ();
-  name = g_hash_table_lookup (table, address);
 
+  name = g_hash_table_lookup (table, address);
   if (name != NULL)
   {
     nearest->name = name;
@@ -377,10 +375,11 @@ gum_find_nearest_symbol_by_address (const gpointer address,
     return TRUE;
   }
 
+  closest_address = NULL;
   keys = g_hash_table_get_keys (table);
-  for (current = keys; current != NULL; current = current->next)
+  for (cur = keys; cur != NULL; cur = cur->next)
   {
-    current_address = current->data;
+    current_address = cur->data;
     if (closest_address == NULL)
     {
       closest_address = current_address;
@@ -395,7 +394,6 @@ gum_find_nearest_symbol_by_address (const gpointer address,
 
     closest_address = current_address;
   }
-
   g_list_free (keys);
 
   if (closest_address != NULL)
@@ -711,11 +709,11 @@ gum_symbol_util_deinitialize (void)
 {
   g_clear_pointer (&gum_cache_timer, g_timer_destroy);
 
-  g_hash_table_unref (gum_function_addresses);
-  gum_function_addresses = NULL;
-
   g_hash_table_unref (gum_address_symbols);
   gum_address_symbols = NULL;
+
+  g_hash_table_unref (gum_function_addresses);
+  gum_function_addresses = NULL;
 
   g_hash_table_unref (gum_module_entries);
   gum_module_entries = NULL;

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -389,7 +389,7 @@ gum_find_nearest_symbol_by_address (gpointer address,
     if (address < current_address)
       continue;
 
-    if ((address - current_address) >= (address - closest_address))
+    if (address - current_address >= address - closest_address)
       continue;
 
     closest_address = current_address;

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -623,7 +623,7 @@ gum_collect_module_functions (const GumModuleDetails * details,
       gum_collect_symbol_if_function, GINT_TO_POINTER (FALSE));
 
   gum_elf_module_enumerate_symbols (entry->module,
-      gum_collect_symbol_if_function, (gpointer) TRUE);
+      gum_collect_symbol_if_function, GINT_TO_POINTER (TRUE));
 
   entry->collected = TRUE;
 

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -620,7 +620,7 @@ gum_collect_module_functions (const GumModuleDetails * details,
     return TRUE;
 
   gum_elf_module_enumerate_dynamic_symbols (entry->module,
-      gum_collect_symbol_if_function, (gpointer) FALSE);
+      gum_collect_symbol_if_function, GINT_TO_POINTER (FALSE));
 
   gum_elf_module_enumerate_symbols (entry->module,
       gum_collect_symbol_if_function, (gpointer) TRUE);


### PR DESCRIPTION
GUM previously relied upon 'dladdr' to find symbol names when trying to make a debug symbol from an address. This only works when symbols are in the .dynamic section. It will not incorporate those in the .symtab section.

The dwarf engine already walks the .symtab and .dynamic section to build a hashtable indexed on names to lookup addresses.This patch builds a hashtable of the reverse, but only for the .symtab section (we can rely on the existing implementation working for .dynamic). We can then use this hash table to do the reverse lookup.

This issue will not affect binaries built with -rdynamic, and may also not affect those built with -pie. Obviously, this doesn't affect shared objects by their nature.