### PR TITLE
Fix flags for CPSR thumb detection

### DIFF
--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -585,7 +585,7 @@ gum_disassemble_instruction_at (gconstpointer address,
 #if defined (HAVE_I386)
   err = cs_open (CS_ARCH_X86, GUM_CPU_MODE, &capstone);
 #elif defined (HAVE_ARM)
-  if (context->cpsr & 0x20)
+  if ((context->cpsr & 0x20) != 0)
     err = cs_open (CS_ARCH_ARM, CS_MODE_THUMB, &capstone);
   else
     err = cs_open (CS_ARCH_ARM, CS_MODE_ARM, &capstone);

--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -585,7 +585,7 @@ gum_disassemble_instruction_at (gconstpointer address,
 #if defined (HAVE_I386)
   err = cs_open (CS_ARCH_X86, GUM_CPU_MODE, &capstone);
 #elif defined (HAVE_ARM)
-  if (context->cpsr & ARM_GRP_THUMB)
+  if (context->cpsr & 0x20)
     err = cs_open (CS_ARCH_ARM, CS_MODE_THUMB, &capstone);
   else
     err = cs_open (CS_ARCH_ARM, CS_MODE_ARM, &capstone);


### PR DESCRIPTION
Code was previously using a value of 0d150 = 0x96 as the CPSR mask to determine whether it was running in ARM mode.

/// Group of ARM instructions
typedef enum arm_insn_group {
	ARM_GRP_INVALID = 0, ///< = CS_GRP_INVALID

	// Generic groups
	// all jump instructions (conditional+direct+indirect jumps)
	ARM_GRP_JUMP,	///< = CS_GRP_JUMP
	ARM_GRP_CALL,	///< = CS_GRP_CALL
	ARM_GRP_INT = 4, ///< = CS_GRP_INT
	ARM_GRP_PRIVILEGE = 6, ///< = CS_GRP_PRIVILEGE
	ARM_GRP_BRANCH_RELATIVE, ///< = CS_GRP_BRANCH_RELATIVE

	// Architecture-specific groups
	ARM_GRP_CRYPTO = 128,
	ARM_GRP_DATABARRIER,
	ARM_GRP_DIVIDE,
	ARM_GRP_FPARMV8,
	ARM_GRP_MULTPRO,
	ARM_GRP_NEON,
	ARM_GRP_T2EXTRACTPACK,
	ARM_GRP_THUMB2DSP,
	ARM_GRP_TRUSTZONE,
	ARM_GRP_V4T,
	ARM_GRP_V5T,
	ARM_GRP_V5TE,
	ARM_GRP_V6,
	ARM_GRP_V6T2,
	ARM_GRP_V7,
	ARM_GRP_V8,
	ARM_GRP_VFP2,
	ARM_GRP_VFP3,
	ARM_GRP_VFP4,
	ARM_GRP_ARM,
	ARM_GRP_MCLASS,
	ARM_GRP_NOTMCLASS,
	*ARM_GRP_THUMB*,
	ARM_GRP_THUMB1ONLY,
	ARM_GRP_THUMB2,
	ARM_GRP_PREV8,
	ARM_GRP_FPVMLX,
	ARM_GRP_MULOPS,
	ARM_GRP_CRC,
	ARM_GRP_DPVFP,
	ARM_GRP_V6M,
	ARM_GRP_VIRTUALIZATION,

	ARM_GRP_ENDING,
} arm_insn_group;

However, the documentation states that bit 5 of the CPSR dictates the mode.
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0360e/ch02s09s07.html

This resulted in the failure of tests on linux-arm32 (little endian) as the code stream was incorrectly identified as thumb and hence the wrong instruction was decoded and the read/write of the resulting fault was therefore inverted.:
/Core/MemoryAccessMonitor/notify_on_read_access
/Core/MemoryAccessMonitor/notify_on_write_access
