### PR TITLE
Fix handling of long symbol names

### DIFF
--- a/gum/backend-darwin/gumdarwinsymbolicator.c
+++ b/gum/backend-darwin/gumdarwinsymbolicator.c
@@ -319,11 +319,12 @@ gum_darwin_symbolicator_details_from_address (GumDarwinSymbolicator * self,
   owner = CSSymbolGetSymbolOwner (symbol);
 
   details->address = address;
-  strcpy (details->module_name, CSSymbolOwnerGetName (owner));
+  g_strlcpy (details->module_name, CSSymbolOwnerGetName (owner),
+      sizeof (details->module_name));
   name = CSSymbolGetName (symbol);
   if (name != NULL)
   {
-    strcpy (details->symbol_name, name);
+    g_strlcpy (details->symbol_name, name, sizeof (details->symbol_name));
   }
   else
   {
@@ -336,7 +337,8 @@ gum_darwin_symbolicator_details_from_address (GumDarwinSymbolicator * self,
       GPOINTER_TO_SIZE (address), kCSNow);
   if (!CSIsNull (info))
   {
-    strcpy (details->file_name, CSSourceInfoGetFilename (info));
+    g_strlcpy (details->file_name, CSSourceInfoGetFilename (info),
+        sizeof (details->file_name));
     details->line_number = CSSourceInfoGetLineNumber (info);
   }
   else

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -337,7 +337,7 @@ enum _GumRelocationScenario
 
 #define GUM_MAX_PATH                 260
 #define GUM_MAX_TYPE_NAME             16
-#define GUM_MAX_SYMBOL_NAME         2000
+#define GUM_MAX_SYMBOL_NAME         2048
 
 #define GUM_MAX_THREADS              768
 #define GUM_MAX_CALL_DEPTH            32


### PR DESCRIPTION
Also bump max symbol name length to 2048.

C++ types are really chatty, so symbols like `IPC::callMemberFunctionImpl<WebKit::WebPageProxy, void (WebKit::WebPageProxy::*)(WTF::ObjectIdentifier<WebCore::FrameIdentifierType>, WebCore::SecurityOriginData&&, WebCore::PolicyCheckIdentifier, unsigned long long, WebKit::NavigationActionData&&, WebKit::FrameInfoData&&, WTF::Optional<WTF::ObjectIdentifier<WebKit::WebPageProxyIdentifierType> >, WebCore::ResourceRequest const&, WebCore::ResourceRequest&&, IPC::FormDataReference&&, WebCore::ResourceResponse&&, WebKit::UserData const&, unsigned long long), std::__1::tuple<WTF::ObjectIdentifier<WebCore::FrameIdentifierType>, WebCore::SecurityOriginData, WebCore::PolicyCheckIdentifier, unsigned long long, WebKit::NavigationActionData, WebKit::FrameInfoData, WTF::Optional<WTF::ObjectIdentifier<WebKit::WebPageProxyIdentifierType> >, WebCore::ResourceRequest, WebCore::ResourceRequest, IPC::FormDataReference, WebCore::ResourceResponse, WebKit::UserData, unsigned long long>, 0ul, 1ul, 2ul, 3ul, 4ul, 5ul, 6ul, 7ul, 8ul, 9ul, 10ul, 11ul, 12ul>(WebKit::WebPageProxy*, void (WebKit::WebPageProxy::*)(WTF::ObjectIdentifier<WebCore::FrameIdentifierType>, WebCore::SecurityOriginData&&, WebCore::PolicyCheckIdentifier, unsigned long long, WebKit::NavigationActionData&&, WebKit::FrameInfoData&&, WTF::Optional<WTF::ObjectIdentifier<WebKit::WebPageProxyIdentifierType> >, WebCore::ResourceRequest const&, WebCore::ResourceRequest&&, IPC::FormDataReference&&, WebCore::ResourceResponse&&, WebKit::UserData const&, unsigned long long), std::__1::tuple<WTF::ObjectIdentifier<WebCore::FrameIdentifierType>, WebCore::SecurityOriginData, WebCore::PolicyCheckIdentifier, unsigned long long, WebKit::NavigationActionData, WebKit::FrameInfoData, WTF::Optional<WTF::ObjectIdentifier<WebKit::WebPageProxyIdentifierType> >, WebCore::ResourceRequest, WebCore::ResourceRequest, IPC::FormDataReference, WebCore::ResourceResponse, WebKit::UserData, unsigned long long>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul, 3ul, 4ul, 5ul, 6ul, 7ul, 8ul, 9ul, 10ul, 11ul, 12ul>)` could have caused an attempted OOB write, resulting in a runtime exception.