### PR TITLE
Fix ARM Stalker mov pc, <reg> Thumb interworking

### DIFF
--- a/gum/arch-arm/gumthumbwriter.c
+++ b/gum/arch-arm/gumthumbwriter.c
@@ -1279,6 +1279,34 @@ gum_thumb_writer_put_and_reg_reg_imm (GumThumbWriter * self,
 }
 
 gboolean
+gum_thumb_writer_put_or_reg_reg_imm (GumThumbWriter * self,
+                                     arm_reg dst_reg,
+                                     arm_reg left_reg,
+                                     gssize right_value)
+{
+  GumArmRegInfo dst, left;
+  guint16 imm8, insn_high, insn_low;
+
+  gum_arm_reg_describe (dst_reg, &dst);
+  gum_arm_reg_describe (left_reg, &left);
+
+  /*
+   * Thumb does allow up to a 12bit immediate, but the encoded form for this is
+   * complex and we don't yet need it for our use-cases.
+   */
+  if (!GUM_IS_WITHIN_UINT8_RANGE (right_value))
+    return FALSE;
+
+  imm8 = right_value & 0xff;
+  insn_high = 0xf040 | left.index;
+  insn_low = (dst.index << 8) | imm8;
+
+  gum_thumb_writer_put_instruction_wide (self, insn_high, insn_low);
+
+  return TRUE;
+}
+
+gboolean
 gum_thumb_writer_put_lsls_reg_reg_imm (GumThumbWriter * self,
                                        arm_reg dst_reg,
                                        arm_reg left_reg,

--- a/gum/arch-arm/gumthumbwriter.h
+++ b/gum/arch-arm/gumthumbwriter.h
@@ -155,6 +155,8 @@ GUM_API gboolean gum_thumb_writer_put_sub_reg_reg_imm (GumThumbWriter * self,
     arm_reg dst_reg, arm_reg left_reg, gssize right_value);
 GUM_API gboolean gum_thumb_writer_put_and_reg_reg_imm (GumThumbWriter * self,
     arm_reg dst_reg, arm_reg left_reg, gssize right_value);
+GUM_API gboolean gum_thumb_writer_put_or_reg_reg_imm (GumThumbWriter * self,
+    arm_reg dst_reg, arm_reg left_reg, gssize right_value);
 GUM_API gboolean gum_thumb_writer_put_lsls_reg_reg_imm (GumThumbWriter * self,
     arm_reg dst_reg, arm_reg left_reg, guint8 right_value);
 GUM_API gboolean gum_thumb_writer_put_lsrs_reg_reg_imm (GumThumbWriter * self,

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -1901,7 +1901,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = op1->reg;
         value->offset = 0;
-        value->thumb_interworking = true;
+        value->thumb_interworking = TRUE;
       }
       else
       {
@@ -2022,7 +2022,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
       value->reg = op2->reg;
       value->offset = 0;
-      value->thumb_interworking = false;
+      value->thumb_interworking = FALSE;
 
       break;
     }
@@ -2053,7 +2053,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = base->reg;
         value->offset = (insn->id == ARM_INS_SUB) ? -index->imm : index->imm;
-        value->thumb_interworking = false;
+        value->thumb_interworking = FALSE;
       }
 
       break;
@@ -3439,6 +3439,7 @@ gum_exec_block_write_arm_handle_kuser_helper (GumExecBlock * block,
   ret_target.type = GUM_TARGET_DIRECT_REG_OFFSET;
   ret_target.value.direct_reg_offset.reg = ARM_REG_LR;
   ret_target.value.direct_reg_offset.offset = 0;
+  ret_target.value.direct_reg_offset.thumb_interworking = TRUE;
 
   /*
    * We pop the stack frame here since the actual kuser_helper will have been

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -238,6 +238,7 @@ struct _GumBranchDirectRegOffset
 {
   arm_reg reg;
   gssize offset;
+  gboolean thumb_interworking;
 };
 
 struct _GumBranchDirectRegShift
@@ -1900,6 +1901,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = op1->reg;
         value->offset = 0;
+        value->thumb_interworking = true;
       }
       else
       {
@@ -2020,6 +2022,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
       value->reg = op2->reg;
       value->offset = 0;
+      value->thumb_interworking = false;
 
       break;
     }
@@ -2050,6 +2053,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = base->reg;
         value->offset = (insn->id == ARM_INS_SUB) ? -index->imm : index->imm;
+        value->thumb_interworking = false;
       }
 
       break;
@@ -2618,6 +2622,9 @@ gum_exec_ctx_write_thumb_mov_branch_target (GumExecCtx * ctx,
       gum_exec_ctx_thumb_load_real_register_into (ctx, reg, value->reg, gc);
 
       gum_thumb_writer_put_add_reg_reg_imm (cw, reg, reg, value->offset);
+
+      if (!value->thumb_interworking)
+        gum_thumb_writer_put_or_reg_reg_imm (cw, reg, reg, 0x1);
 
       break;
     }
@@ -3516,6 +3523,7 @@ gum_exec_block_write_thumb_handle_kuser_helper (GumExecBlock * block,
   ret_target.type = GUM_TARGET_DIRECT_REG_OFFSET;
   ret_target.value.direct_reg_offset.reg = ARM_REG_LR;
   ret_target.value.direct_reg_offset.offset = 0;
+  ret_target.value.direct_reg_offset.thumb_interworking = TRUE;
 
   gum_exec_block_write_thumb_pop_stack_frame (block, &ret_target, gc);
   gum_exec_block_write_thumb_call_replace_block (block, &ret_target,

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -44,6 +44,7 @@ typedef struct _GumGeneratorContext GumGeneratorContext;
 typedef struct _GumCalloutEntry GumCalloutEntry;
 typedef struct _GumInstruction GumInstruction;
 typedef guint GumBranchTargetType;
+typedef guint GumArmMode;
 typedef struct _GumBranchTarget GumBranchTarget;
 typedef struct _GumBranchDirectAddress GumBranchDirectAddress;
 typedef struct _GumBranchDirectRegOffset GumBranchDirectRegOffset;
@@ -229,6 +230,12 @@ enum _GumBranchTargetType
   GUM_TARGET_INDIRECT_PCREL_TABLE
 };
 
+enum _GumArmMode
+{
+  GUM_ARM_MODE_AUTO,
+  GUM_ARM_MODE_CURRENT
+};
+
 struct _GumBranchDirectAddress
 {
   gpointer address;
@@ -238,7 +245,7 @@ struct _GumBranchDirectRegOffset
 {
   arm_reg reg;
   gssize offset;
-  gboolean thumb_interworking;
+  GumArmMode mode;
 };
 
 struct _GumBranchDirectRegShift
@@ -1901,7 +1908,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = op1->reg;
         value->offset = 0;
-        value->thumb_interworking = TRUE;
+        value->mode = GUM_ARM_MODE_AUTO;
       }
       else
       {
@@ -2022,7 +2029,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
       value->reg = op2->reg;
       value->offset = 0;
-      value->thumb_interworking = FALSE;
+      value->mode = GUM_ARM_MODE_CURRENT;
 
       break;
     }
@@ -2053,7 +2060,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
         value->reg = base->reg;
         value->offset = (insn->id == ARM_INS_SUB) ? -index->imm : index->imm;
-        value->thumb_interworking = FALSE;
+        value->mode = GUM_ARM_MODE_CURRENT;
       }
 
       break;
@@ -2623,7 +2630,7 @@ gum_exec_ctx_write_thumb_mov_branch_target (GumExecCtx * ctx,
 
       gum_thumb_writer_put_add_reg_reg_imm (cw, reg, reg, value->offset);
 
-      if (!value->thumb_interworking)
+      if (value->mode == GUM_ARM_MODE_CURRENT)
         gum_thumb_writer_put_or_reg_reg_imm (cw, reg, reg, 0x1);
 
       break;
@@ -3439,7 +3446,7 @@ gum_exec_block_write_arm_handle_kuser_helper (GumExecBlock * block,
   ret_target.type = GUM_TARGET_DIRECT_REG_OFFSET;
   ret_target.value.direct_reg_offset.reg = ARM_REG_LR;
   ret_target.value.direct_reg_offset.offset = 0;
-  ret_target.value.direct_reg_offset.thumb_interworking = TRUE;
+  ret_target.value.direct_reg_offset.mode = GUM_ARM_MODE_AUTO;
 
   /*
    * We pop the stack frame here since the actual kuser_helper will have been
@@ -3524,7 +3531,7 @@ gum_exec_block_write_thumb_handle_kuser_helper (GumExecBlock * block,
   ret_target.type = GUM_TARGET_DIRECT_REG_OFFSET;
   ret_target.value.direct_reg_offset.reg = ARM_REG_LR;
   ret_target.value.direct_reg_offset.offset = 0;
-  ret_target.value.direct_reg_offset.thumb_interworking = TRUE;
+  ret_target.value.direct_reg_offset.mode = GUM_ARM_MODE_AUTO;
 
   gum_exec_block_write_thumb_pop_stack_frame (block, &ret_target, gc);
   gum_exec_block_write_thumb_call_replace_block (block, &ret_target,

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -44,7 +44,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (thumb_cbz_cbnz_block_events_generated)
 
   TESTENTRY (thumb2_mov_pc_reg_exec_events_generated)
-  TESTENTRY (thumb2_mov_pc_reg_no_interworking)
+  TESTENTRY (thumb2_mov_pc_reg_without_thumb_bit_set)
 
   /*
    * The following tests have no Thumb equivalent as Thumb does not support
@@ -1142,7 +1142,7 @@ TESTCASE (thumb2_mov_pc_reg_exec_events_generated)
   GUM_ASSERT_EVENT_ADDR (exec, 7, location, func + 18);
 }
 
-TESTCASE (thumb2_mov_pc_reg_no_interworking)
+TESTCASE (thumb2_mov_pc_reg_without_thumb_bit_set)
 {
   GumAddress func;
 

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -44,6 +44,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (thumb_cbz_cbnz_block_events_generated)
 
   TESTENTRY (thumb2_mov_pc_reg_exec_events_generated)
+  TESTENTRY (thumb2_mov_pc_reg_no_interworking)
 
   /*
    * The following tests have no Thumb equivalent as Thumb does not support
@@ -1127,6 +1128,26 @@ TESTCASE (thumb2_mov_pc_reg_exec_events_generated)
 
   func = DUP_TESTCODE (thumb2_mov_pc_reg);
   patch_code_pointer (func, 6 * 2, func + (8 * 2) + 1);
+
+  fixture->sink->mask = GUM_EXEC;
+  g_assert_cmpuint (FOLLOW_AND_INVOKE (func + 1), ==, 1);
+
+  g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_INSN_COUNT + 6);
+
+  GUM_ASSERT_EVENT_ADDR (exec, 2, location, func);
+  GUM_ASSERT_EVENT_ADDR (exec, 3, location, func + 2);
+  GUM_ASSERT_EVENT_ADDR (exec, 4, location, func + 4);
+  GUM_ASSERT_EVENT_ADDR (exec, 5, location, func + 6);
+  GUM_ASSERT_EVENT_ADDR (exec, 6, location, func + 16);
+  GUM_ASSERT_EVENT_ADDR (exec, 7, location, func + 18);
+}
+
+TESTCASE (thumb2_mov_pc_reg_no_interworking)
+{
+  GumAddress func;
+
+  func = DUP_TESTCODE (thumb2_mov_pc_reg);
+  patch_code_pointer (func, 6 * 2, func + (8 * 2) + 0);
 
   fixture->sink->mask = GUM_EXEC;
   g_assert_cmpuint (FOLLOW_AND_INVOKE (func + 1), ==, 1);


### PR DESCRIPTION
This fix adds a `thumb_interworking` flag to `_GumBranchDirectRegOffset`. This type is used during MOV, ADD, SUB and BX instruction handling. It's value is set `false` except for `BX` instructions. It's value should be considered meaningful only during Thumb operation.

Whilst its value is set in `gum_stalker_get_target_address` which is used in both ARM and Thumb modes, it is only used in 
`gum_exec_ctx_write_thumb_mov_branch_target` and not `gum_exec_ctx_write_arm_mov_branch_target` and hence any setting of this value in `gum_stalker_get_target_address` when operating in ARM mode is benign.

Similarly, the value is set in `gum_exec_block_write_thumb_handle_kuser_helper` and not in `gum_exec_block_write_arm_handle_kuser_helper`.