### PR TITLE
Update gumarm64writer.c to make it compatible with macOS ARM

### DIFF
--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -1429,7 +1429,7 @@ gum_arm64_writer_strip (GumArm64Writer * self,
   if (self->ptrauth_support != GUM_PTRAUTH_SUPPORTED)
     return value;
 
-  if (self->target_os == GUM_OS_IOS || self->target_os == GUM_OS_MACOS)
+  if (self->target_os == GUM_OS_MACOS || self->target_os == GUM_OS_IOS)
     return value & G_GUINT64_CONSTANT (0x7fffffffff);
 
   return value;

--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -1429,7 +1429,7 @@ gum_arm64_writer_strip (GumArm64Writer * self,
   if (self->ptrauth_support != GUM_PTRAUTH_SUPPORTED)
     return value;
 
-  if (self->target_os == GUM_OS_IOS)
+  if (self->target_os == GUM_OS_IOS || self->target_os == GUM_OS_MACOS)
     return value & G_GUINT64_CONSTANT (0x7fffffffff);
 
   return value;


### PR DESCRIPTION
PACed ptrs need to be stripped also on macOS arm64e.