### PR TITLE
Fix architecture detection on big-endian systems

### DIFF
--- a/gum/backend-linux/gumlinux.h
+++ b/gum/backend-linux/gumlinux.h
@@ -25,6 +25,8 @@ struct _GumLinuxNamedRange
 GUM_API GumCpuType gum_linux_cpu_type_from_file (const gchar * path,
     GError ** error);
 GUM_API GumCpuType gum_linux_cpu_type_from_pid (pid_t pid, GError ** error);
+GUM_API GumCpuType gum_linux_cpu_type_from_auxv (const guint8 * auxv,
+    gsize auxv_size);
 GUM_API void gum_linux_enumerate_modules_using_proc_maps (
     GumFoundModuleFunc func, gpointer user_data);
 GUM_API void gum_linux_enumerate_ranges (pid_t pid, GumPageProtection prot,

--- a/gum/backend-linux/gumlinux.h
+++ b/gum/backend-linux/gumlinux.h
@@ -25,7 +25,7 @@ struct _GumLinuxNamedRange
 GUM_API GumCpuType gum_linux_cpu_type_from_file (const gchar * path,
     GError ** error);
 GUM_API GumCpuType gum_linux_cpu_type_from_pid (pid_t pid, GError ** error);
-GUM_API GumCpuType gum_linux_cpu_type_from_auxv (const guint8 * auxv,
+GUM_API GumCpuType gum_linux_cpu_type_from_auxv (gconstpointer auxv,
     gsize auxv_size);
 GUM_API void gum_linux_enumerate_modules_using_proc_maps (
     GumFoundModuleFunc func, gpointer user_data);

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1761,13 +1761,12 @@ gum_linux_cpu_type_from_pid (pid_t pid,
                              GError ** error)
 {
   GumCpuType result = -1;
-  gchar * auxv_path;
-  guint8 * auxv;
+  gchar * auxv_path, * auxv;
   gsize auxv_size;
 
   auxv_path = g_strdup_printf ("/proc/%d/auxv", pid);
 
-  if (!g_file_get_contents (auxv_path, (gchar **) &auxv, &auxv_size, error))
+  if (!g_file_get_contents (auxv_path, &auxv, &auxv_size, error))
     goto beach;
 
   result = gum_linux_cpu_type_from_auxv (auxv, auxv_size);

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1844,7 +1844,7 @@ gum_linux_cpu_type_from_auxv (gconstpointer auxv,
 
     for (i = 0; i + sizeof (guint64) <= auxv_size; i += 16)
     {
-      guint64 * auxv_type = auxv + i;
+      const guint64 * auxv_type = auxv + i;
 
       if ((*auxv_type & G_GUINT64_CONSTANT (0xffffffff00000000)) != 0)
       {

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1763,14 +1763,29 @@ gum_linux_cpu_type_from_pid (pid_t pid,
   GumCpuType result = -1;
   gchar * auxv_path;
   guint8 * auxv;
-  gsize auxv_size, i;
-  GumCpuType cpu32, cpu64;
+  gsize auxv_size;
 
   auxv_path = g_strdup_printf ("/proc/%d/auxv", pid);
 
   if (!g_file_get_contents (auxv_path, (gchar **) &auxv, &auxv_size, error))
     goto beach;
 
+  result = gum_linux_cpu_type_from_auxv (auxv, auxv_size);
+
+beach:
+  g_free (auxv);
+  g_free (auxv_path);
+
+  return result;
+}
+
+GumCpuType
+gum_linux_cpu_type_from_auxv (const guint8 * auxv,
+                              gsize auxv_size)
+{
+  GumCpuType result = -1;
+  GumCpuType cpu32, cpu64;
+  gsize i;
 #if defined (HAVE_I386)
   cpu32 = GUM_CPU_IA32;
   cpu64 = GUM_CPU_AMD64;
@@ -1809,7 +1824,22 @@ gum_linux_cpu_type_from_pid (pid_t pid,
    * } Elf64_auxv_t;
   */
 
-  if (auxv[0] != AT_NULL)
+  /*
+   * If the auxiliary vector is 32-bits and contains only an AT_NULL entry (note
+   * that the documentation states that "The last entry contains two zeros"),
+   * this will mean it has no non-zero type codes and could be mistaken for a
+   * 64-bit format auxiliary vector. We therefore handle this special case.
+   *
+   * If the vector is less than 16 bytes it is not large enough to contain two
+   * 64-bit zero values. If it is larger, then if it is a 32-bit format vector,
+   * then it must contain at least one non-zero type code and hence the test
+   * below should work.
+   */
+  if (auxv_size < 2 * sizeof (guint64))
+  {
+    result = cpu32;
+  }
+  else
   {
     result = cpu64;
 
@@ -1823,14 +1853,6 @@ gum_linux_cpu_type_from_pid (pid_t pid,
       }
     }
   }
-  else
-  {
-    result = (auxv_size == 8) ? cpu32 : cpu64;
-  }
-
-beach:
-  g_free (auxv);
-  g_free (auxv_path);
 
   return result;
 }

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1780,12 +1780,13 @@ beach:
 }
 
 GumCpuType
-gum_linux_cpu_type_from_auxv (const guint8 * auxv,
+gum_linux_cpu_type_from_auxv (gconstpointer auxv,
                               gsize auxv_size)
 {
   GumCpuType result = -1;
   GumCpuType cpu32, cpu64;
   gsize i;
+
 #if defined (HAVE_I386)
   cpu32 = GUM_CPU_IA32;
   cpu64 = GUM_CPU_AMD64;
@@ -1822,9 +1823,7 @@ gum_linux_cpu_type_from_auxv (const guint8 * auxv,
    *     uint64_t a_val;
    *   } a_un;
    * } Elf64_auxv_t;
-  */
-
-  /*
+   *
    * If the auxiliary vector is 32-bits and contains only an AT_NULL entry (note
    * that the documentation states that "The last entry contains two zeros"),
    * this will mean it has no non-zero type codes and could be mistaken for a
@@ -1835,6 +1834,7 @@ gum_linux_cpu_type_from_auxv (const guint8 * auxv,
    * then it must contain at least one non-zero type code and hence the test
    * below should work.
    */
+
   if (auxv_size < 2 * sizeof (guint64))
   {
     result = cpu32;
@@ -1845,8 +1845,9 @@ gum_linux_cpu_type_from_auxv (const guint8 * auxv,
 
     for (i = 0; i + sizeof (guint64) <= auxv_size; i += 16)
     {
-      guint64 * auxv_type = (guint64 *) (auxv + i);
-      if ((*auxv_type & 0xffffffff00000000) != 0)
+      guint64 * auxv_type = auxv + i;
+
+      if ((*auxv_type & G_GUINT64_CONSTANT (0xffffffff00000000)) != 0)
       {
         result = cpu32;
         break;

--- a/tests/core/process.c
+++ b/tests/core/process.c
@@ -19,6 +19,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+#include <sys/auxv.h>
+#include "backend-linux/gumlinux.h"
+#endif
+
 #define TESTCASE(NAME) \
     void test_process_ ## NAME (void)
 #define TESTENTRY(NAME) \
@@ -60,6 +65,10 @@ TESTLIST_BEGIN (process)
 #endif
 #if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
   TESTENTRY (linux_process_modules)
+  TESTENTRY (linux_get_cpu_from_auxv_null_32bit)
+  TESTENTRY (linux_get_cpu_from_auxv_null_64bit)
+  TESTENTRY (linux_get_cpu_from_auxv_representative_32bit)
+  TESTENTRY (linux_get_cpu_from_auxv_representative_64bit)
 #endif
 TESTLIST_END ()
 
@@ -291,6 +300,120 @@ TESTCASE (linux_process_modules)
   gum_process_enumerate_modules (verify_module_bounds, &bounds);
 
   dlclose (lib);
+}
+
+TESTCASE (linux_get_cpu_from_auxv_null_32bit)
+{
+  GumCpuType cpu32;
+#if defined (HAVE_I386)
+  cpu32 = GUM_CPU_IA32;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu32 = GUM_CPU_ARM;
+#elif defined (HAVE_MIPS)
+  cpu32 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+  guint32 test_data[] =
+  {
+    AT_NULL, 0
+  };
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
+      sizeof (test_data)), ==, cpu32);
+}
+
+TESTCASE (linux_get_cpu_from_auxv_null_64bit)
+{
+  GumCpuType cpu64;
+#if defined (HAVE_I386)
+  cpu64 = GUM_CPU_AMD64;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu64 = GUM_CPU_ARM64;
+#elif defined (HAVE_MIPS)
+  cpu64 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+  guint64 test_data[] =
+  {
+    AT_NULL, 0
+  };
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
+      sizeof (test_data)), ==, cpu64);
+}
+
+TESTCASE (linux_get_cpu_from_auxv_representative_32bit)
+{
+  GumCpuType cpu32;
+#if defined (HAVE_I386)
+  cpu32 = GUM_CPU_IA32;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu32 = GUM_CPU_ARM;
+#elif defined (HAVE_MIPS)
+  cpu32 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+  guint32 test_data[] =
+  {
+    AT_EXECFN, 0xbaad0001,
+    AT_HWCAP, 0xdeadface,
+    AT_PAGESZ, 0x1000,
+    AT_CLKTCK, 0x64,
+    AT_PHDR, 0xbaad0002,
+    AT_PHENT, 0x38,
+    AT_PHNUM, 0xd,
+    AT_BASE, 0xbaad0003,
+    AT_FLAGS, 0x0,
+    AT_ENTRY, 0xbaad0004,
+    AT_UID, 0x3e8,
+    AT_EUID, 0x3e8,
+    AT_GID, 0x3e8,
+    AT_EGID, 0x3e8,
+    AT_SECURE, 0x0,
+    AT_RANDOM, 0xbaad0005,
+    AT_PLATFORM, 0xbaad0006,
+    AT_NULL, 0
+  };
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
+      sizeof (test_data)), ==, cpu32);
+}
+
+TESTCASE (linux_get_cpu_from_auxv_representative_64bit)
+{
+  GumCpuType cpu64;
+#if defined (HAVE_I386)
+  cpu64 = GUM_CPU_AMD64;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu64 = GUM_CPU_ARM64;
+#elif defined (HAVE_MIPS)
+  cpu64 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+  guint64 test_data[] =
+  {
+    AT_EXECFN, 0xcafecafebaad0001,
+    AT_HWCAP, 0xdeadface,
+    AT_PAGESZ, 0x1000,
+    AT_CLKTCK, 0x64,
+    AT_PHDR, 0xcafecafebaad0002,
+    AT_PHENT, 0x38,
+    AT_PHNUM, 0xd,
+    AT_BASE, 0xcafecafebaad0003,
+    AT_FLAGS, 0x0,
+    AT_ENTRY, 0xcafecafebaad0004,
+    AT_UID, 0x3e8,
+    AT_EUID, 0x3e8,
+    AT_GID, 0x3e8,
+    AT_EGID, 0x3e8,
+    AT_SECURE, 0x0,
+    AT_RANDOM, 0xcafecafebaad0005,
+    AT_PLATFORM, 0xcafecafebaad0006,
+    AT_NULL, 0
+  };
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
+      sizeof (test_data)), ==, cpu64);
 }
 
 static gboolean

--- a/tests/core/process.c
+++ b/tests/core/process.c
@@ -304,7 +304,7 @@ TESTCASE (linux_process_modules)
 
 TESTCASE (linux_get_cpu_from_auxv_null_32bit)
 {
-  guint32 v[] = { AT_NULL, 0 };
+  const guint32 v[] = { AT_NULL, 0 };
   GumCpuType cpu32;
 
 #if defined (HAVE_I386)
@@ -322,7 +322,7 @@ TESTCASE (linux_get_cpu_from_auxv_null_32bit)
 
 TESTCASE (linux_get_cpu_from_auxv_null_64bit)
 {
-  guint64 v[] = { AT_NULL, 0 };
+  const guint64 v[] = { AT_NULL, 0 };
   GumCpuType cpu64;
 
 #if defined (HAVE_I386)
@@ -340,7 +340,7 @@ TESTCASE (linux_get_cpu_from_auxv_null_64bit)
 
 TESTCASE (linux_get_cpu_from_auxv_representative_32bit)
 {
-  guint32 v[] = {
+  const guint32 v[] = {
     AT_EXECFN, 0xbaad0001,
     AT_HWCAP, 0xdeadface,
     AT_PAGESZ, 0x1000,
@@ -377,7 +377,7 @@ TESTCASE (linux_get_cpu_from_auxv_representative_32bit)
 
 TESTCASE (linux_get_cpu_from_auxv_representative_64bit)
 {
-  guint64 v[] = {
+  const guint64 v[] = {
     AT_EXECFN, 0xcafecafebaad0001,
     AT_HWCAP, 0xdeadface,
     AT_PAGESZ, 0x1000,

--- a/tests/core/process.c
+++ b/tests/core/process.c
@@ -304,7 +304,9 @@ TESTCASE (linux_process_modules)
 
 TESTCASE (linux_get_cpu_from_auxv_null_32bit)
 {
+  guint32 v[] = { AT_NULL, 0 };
   GumCpuType cpu32;
+
 #if defined (HAVE_I386)
   cpu32 = GUM_CPU_IA32;
 #elif defined (HAVE_ARM) || defined (HAVE_ARM64)
@@ -314,17 +316,15 @@ TESTCASE (linux_get_cpu_from_auxv_null_32bit)
 #else
 # error Unsupported architecture
 #endif
-  guint32 test_data[] =
-  {
-    AT_NULL, 0
-  };
-  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
-      sizeof (test_data)), ==, cpu32);
+
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv (v, sizeof (v)), ==, cpu32);
 }
 
 TESTCASE (linux_get_cpu_from_auxv_null_64bit)
 {
+  guint64 v[] = { AT_NULL, 0 };
   GumCpuType cpu64;
+
 #if defined (HAVE_I386)
   cpu64 = GUM_CPU_AMD64;
 #elif defined (HAVE_ARM) || defined (HAVE_ARM64)
@@ -334,28 +334,13 @@ TESTCASE (linux_get_cpu_from_auxv_null_64bit)
 #else
 # error Unsupported architecture
 #endif
-  guint64 test_data[] =
-  {
-    AT_NULL, 0
-  };
-  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
-      sizeof (test_data)), ==, cpu64);
+
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv (v, sizeof (v)), ==, cpu64);
 }
 
 TESTCASE (linux_get_cpu_from_auxv_representative_32bit)
 {
-  GumCpuType cpu32;
-#if defined (HAVE_I386)
-  cpu32 = GUM_CPU_IA32;
-#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
-  cpu32 = GUM_CPU_ARM;
-#elif defined (HAVE_MIPS)
-  cpu32 = GUM_CPU_MIPS;
-#else
-# error Unsupported architecture
-#endif
-  guint32 test_data[] =
-  {
+  guint32 v[] = {
     AT_EXECFN, 0xbaad0001,
     AT_HWCAP, 0xdeadface,
     AT_PAGESZ, 0x1000,
@@ -375,24 +360,24 @@ TESTCASE (linux_get_cpu_from_auxv_representative_32bit)
     AT_PLATFORM, 0xbaad0006,
     AT_NULL, 0
   };
-  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
-      sizeof (test_data)), ==, cpu32);
+  GumCpuType cpu32;
+
+#if defined (HAVE_I386)
+  cpu32 = GUM_CPU_IA32;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu32 = GUM_CPU_ARM;
+#elif defined (HAVE_MIPS)
+  cpu32 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv (v, sizeof (v)), ==, cpu32);
 }
 
 TESTCASE (linux_get_cpu_from_auxv_representative_64bit)
 {
-  GumCpuType cpu64;
-#if defined (HAVE_I386)
-  cpu64 = GUM_CPU_AMD64;
-#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
-  cpu64 = GUM_CPU_ARM64;
-#elif defined (HAVE_MIPS)
-  cpu64 = GUM_CPU_MIPS;
-#else
-# error Unsupported architecture
-#endif
-  guint64 test_data[] =
-  {
+  guint64 v[] = {
     AT_EXECFN, 0xcafecafebaad0001,
     AT_HWCAP, 0xdeadface,
     AT_PAGESZ, 0x1000,
@@ -412,8 +397,19 @@ TESTCASE (linux_get_cpu_from_auxv_representative_64bit)
     AT_PLATFORM, 0xcafecafebaad0006,
     AT_NULL, 0
   };
-  g_assert_cmpuint (gum_linux_cpu_type_from_auxv ((const guint8 *)test_data,
-      sizeof (test_data)), ==, cpu64);
+  GumCpuType cpu64;
+
+#if defined (HAVE_I386)
+  cpu64 = GUM_CPU_AMD64;
+#elif defined (HAVE_ARM) || defined (HAVE_ARM64)
+  cpu64 = GUM_CPU_ARM64;
+#elif defined (HAVE_MIPS)
+  cpu64 = GUM_CPU_MIPS;
+#else
+# error Unsupported architecture
+#endif
+
+  g_assert_cmpuint (gum_linux_cpu_type_from_auxv (v, sizeof (v)), ==, cpu64);
 }
 
 static gboolean


### PR DESCRIPTION
Fix for #464. Implementation changed to expose a test seam in lieu of a mocking framework. Logic corrected.