### PR TITLE
Better discovery of the libc for linux and qnx.

### DIFF
--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -308,10 +308,14 @@ gum_try_init_libc_name (void)
 {
   Dl_info info = { NULL, };
 
-  dladdr (dlsym (RTLD_DEFAULT, "exit"), &info);
+  dladdr (dlsym (RTLD_DEFAULT, "__libc_start_main"), &info);
 
   if (info.dli_fname == NULL)
-    return NULL;
+  {
+    dladdr (dlsym (RTLD_DEFAULT, "exit"), &info);
+    if (info.dli_fname == NULL)
+      return NULL;
+  }
 
 #ifdef HAVE_ANDROID
   if (g_path_is_absolute (info.dli_fname))

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -118,10 +118,14 @@ gum_try_init_libc_name (void)
 {
   Dl_info info = { NULL, };
 
-  dladdr (dlsym (RTLD_DEFAULT, "exit"), &info);
+  dladdr (dlsym (RTLD_DEFAULT, "__libc_start_main"), &info);
 
   if (info.dli_fname == NULL)
-    return NULL;
+  {
+    dladdr (dlsym (RTLD_DEFAULT, "exit"), &info);
+    if (info.dli_fname == NULL)
+      return NULL;
+  }
 
   gum_libc_name = g_strdup (info.dli_fname);
 


### PR DESCRIPTION
The libc is currently detected by checking for the 'exit' symbol.
Whichever shared library contains a function named 'exit' could
falsely be detected to be the libc. This commit adds another check
for the '__libc_start_main' symbol which should be more libc-specific.

As a minimal example which shows the bug, the following program
crashes when frida attaches:

#include <stdio.h>;
void exit(int i) {
    printf("foo");
}
int main(int argc, char** argv) {
    printf("Hi!\n");
    getchar();
    printf("bye!\n");
    return 0;
}

If the libc_start_main symbol is not found, the old check for the exit function
will still happen - so this patch shouldn't make things worse, right?