### PR TITLE
Support linking against system GLib

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -18,6 +18,12 @@
 /* Define to 1 if you have the <elf.h> header file. */
 #mesondefine HAVE_ELF_H
 
+/* Define to 1 if using Frida's GLib. */
+#mesondefine HAVE_FRIDA_GLIB
+
+/* Define to 1 if using Frida's libffi. */
+#mesondefine HAVE_FRIDA_LIBFFI
+
 /* Define to 1 if libc is glibc. */
 #mesondefine HAVE_GLIBC
 

--- a/gum-32.vcxproj.filters
+++ b/gum-32.vcxproj.filters
@@ -470,4 +470,12 @@
       <Filter>vapi</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="gum\gumenumtypes.c.template">
+      <Filter>core</Filter>
+    </CustomBuild>
+    <CustomBuild Include="gum\gumenumtypes.h.template">
+      <Filter>core</Filter>
+    </CustomBuild>
+  </ItemGroup>
 </Project>

--- a/gum-64.vcxproj.filters
+++ b/gum-64.vcxproj.filters
@@ -473,4 +473,12 @@
       <Filter>vapi</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="gum\gumenumtypes.c.template">
+      <Filter>core</Filter>
+    </CustomBuild>
+    <CustomBuild Include="gum\gumenumtypes.h.template">
+      <Filter>core</Filter>
+    </CustomBuild>
+  </ItemGroup>
 </Project>

--- a/gum-common.props
+++ b/gum-common.props
@@ -3,7 +3,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_FRIDA_GLIB=1;HAVE_FRIDA_LIBFFI=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir)gum;$(ProjectDir)gum\arch-x86;$(ProjectDir)gum;$(ProjectDir)libs;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/gum-common.props
+++ b/gum-common.props
@@ -10,30 +10,24 @@
 
   <ItemGroup>
     <ClInclude Include="gum\gum.h" />
-    <ClInclude Include="gum\gum-init.h" />
     <ClInclude Include="gum\gumapiresolver.h" />
     <ClInclude Include="gum\gumbacktracer.h" />
     <ClInclude Include="gum\gumcloak.h" />
-    <ClInclude Include="gum\gumcloak-priv.h" />
     <ClInclude Include="gum\gumcodeallocator.h" />
     <ClInclude Include="gum\gumcodesegment.h" />
     <ClInclude Include="gum\gumdarwinmodule.h" />
     <ClInclude Include="gum\gumdefs.h" />
     <ClInclude Include="gum\gumexceptor.h" />
-    <ClInclude Include="gum\gumexceptorbackend.h" />
     <ClInclude Include="gum\gumevent.h" />
     <ClInclude Include="gum\gumeventsink.h" />
     <ClInclude Include="gum\gumfunction.h" />
     <ClInclude Include="gum\gumheapapi.h" />
     <ClInclude Include="gum\guminterceptor.h" />
-    <ClInclude Include="gum\guminterceptor-priv.h" />
     <ClInclude Include="gum\guminvocationcontext.h" />
     <ClInclude Include="gum\guminvocationlistener.h" />
     <ClInclude Include="gum\gumkernel.h" />
-    <ClInclude Include="gum\gumleb.h" />
     <ClInclude Include="gum\gumlibc.h" />
     <ClInclude Include="gum\gummemory.h" />
-    <ClInclude Include="gum\gummemory-priv.h" />
     <ClInclude Include="gum\gummemoryaccessmonitor.h" />
     <ClInclude Include="gum\gummemorymap.h" />
     <ClInclude Include="gum\gummetalarray.h" />
@@ -42,13 +36,49 @@
     <ClInclude Include="gum\gummodulemap.h" />
     <ClInclude Include="gum\gumprintf.h" />
     <ClInclude Include="gum\gumprocess.h" />
-    <ClInclude Include="gum\gumprocess-priv.h" />
     <ClInclude Include="gum\gumreturnaddress.h" />
     <ClInclude Include="gum\gumspinlock.h" />
     <ClInclude Include="gum\gumstalker.h" />
     <ClInclude Include="gum\gumsymbolutil.h" />
     <ClInclude Include="gum\gumsysinternals.h" />
     <ClInclude Include="gum\gumtls.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CustomBuild Include="gum\gumenumtypes.c.template">
+      <FileType>Document</FileType>
+      <Message>Generating gumenumtypes.c</Message>
+      <AdditionalInputs>@(ClInclude)</AdditionalInputs>
+      <Outputs>$(IntDir)gum\gumenumtypes.c</Outputs>
+      <OutputItemType>ClCompile</OutputItemType>
+      <LinkObjects>false</LinkObjects>
+      <Command>mkdir "$(IntDir)gum" 2&gt;NUL
+echo $(GLibMkenums) --output "$(IntDir)gum\%(Filename)" --template %(Identity) @(ClInclude, ' ')
+$(GLibMkenums) --output "$(IntDir)gum\%(Filename)" --template %(Identity) @(ClInclude, ' ')
+</Command>
+    </CustomBuild>
+    <CustomBuild Include="gum\gumenumtypes.h.template">
+      <FileType>Document</FileType>
+      <Message>Generating gumenumtypes.h</Message>
+      <AdditionalInputs>@(ClInclude)</AdditionalInputs>
+      <Outputs>$(IntDir)gum\gumenumtypes.h</Outputs>
+      <OutputItemType>ClInclude</OutputItemType>
+      <LinkObjects>false</LinkObjects>
+      <Command>mkdir "$(IntDir)gum" 2&gt;NUL
+echo $(GLibMkenums) --output "$(IntDir)gum\%(Filename)" --template %(Identity) @(ClInclude, ' ')
+$(GLibMkenums) --output "$(IntDir)gum\%(Filename)" --template %(Identity) @(ClInclude, ' ')
+</Command>
+    </CustomBuild>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="gum\gum-init.h" />
+    <ClInclude Include="gum\gumcloak-priv.h" />
+    <ClInclude Include="gum\gumexceptorbackend.h" />
+    <ClInclude Include="gum\guminterceptor-priv.h" />
+    <ClInclude Include="gum\gumleb.h" />
+    <ClInclude Include="gum\gummemory-priv.h" />
+    <ClInclude Include="gum\gumprocess-priv.h" />
     <ClInclude Include="gum\gumtls-priv.h" />
   </ItemGroup>
 

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -140,6 +140,8 @@ gum_darwin_query_page_size (mach_port_t task,
     case GUM_CPU_ARM64:
       *page_size = 16384;
       break;
+    default:
+      g_assert_not_reached ();
   }
 
   return TRUE;

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -807,30 +807,3 @@ gum_do_query_cpu_features (void)
 }
 
 #endif
-
-GType
-gum_cpu_type_get_type (void)
-{
-  static gsize gonce_value;
-
-  if (g_once_init_enter (&gonce_value))
-  {
-    static const GEnumValue values[] =
-    {
-      { GUM_CPU_INVALID, "GUM_CPU_INVALID", "invalid" },
-      { GUM_CPU_IA32, "GUM_CPU_IA32", "ia32" },
-      { GUM_CPU_AMD64, "GUM_CPU_AMD64", "amd64" },
-      { GUM_CPU_ARM, "GUM_CPU_ARM", "arm" },
-      { GUM_CPU_ARM64, "GUM_CPU_ARM64", "arm64" },
-      { GUM_CPU_MIPS, "GUM_CPU_MIPS", "mips" },
-      { 0, NULL, NULL }
-    };
-    GType etype;
-
-    etype = g_enum_register_static ("GumCpuType", values);
-
-    g_once_init_leave (&gonce_value, etype);
-  }
-
-  return (GType) gonce_value;
-}

--- a/gum/gumdarwinmodule.c
+++ b/gum/gumdarwinmodule.c
@@ -2981,30 +2981,6 @@ gum_darwin_export_details_init_from_node (GumDarwinExportDetails * details,
   }
 }
 
-GType
-gum_darwin_module_flags_get_type (void)
-{
-  static gsize gonce_value;
-
-  if (g_once_init_enter (&gonce_value))
-  {
-    static const GFlagsValue values[] =
-    {
-      { GUM_DARWIN_MODULE_FLAGS_NONE, "GUM_DARWIN_MODULE_FLAGS_NONE", "none" },
-      { GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY,
-        "GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY", "header-only" },
-      { 0, NULL, NULL }
-    };
-    GType ftype;
-
-    ftype = g_flags_register_static ("GumDarwinModuleFlags", values);
-
-    g_once_init_leave (&gonce_value, ftype);
-  }
-
-  return (GType) gonce_value;
-}
-
 static GumCpuType
 gum_cpu_type_from_darwin (GumDarwinCpuType cpu_type)
 {

--- a/gum/gumdarwinmodule.h
+++ b/gum/gumdarwinmodule.h
@@ -17,13 +17,10 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (GumDarwinModule, gum_darwin_module, GUM_DARWIN, MODULE,
     GObject)
 
-#define GUM_TYPE_DARWIN_MODULE_FLAGS (gum_darwin_module_flags_get_type ())
-
 #define GUM_DARWIN_PORT_NULL 0
 #define GUM_DARWIN_EXPORT_KIND_MASK 3
 
 typedef guint GumDarwinModuleFiletype;
-typedef guint GumDarwinModuleFlags;
 typedef gint GumDarwinCpuType;
 typedef gint GumDarwinCpuSubtype;
 
@@ -77,6 +74,11 @@ typedef gboolean (* GumFoundDarwinDependencyFunc) (const gchar * path,
 typedef struct _GumDyldInfoCommand GumDyldInfoCommand;
 typedef struct _GumSymtabCommand GumSymtabCommand;
 typedef struct _GumDysymtabCommand GumDysymtabCommand;
+
+typedef enum {
+  GUM_DARWIN_MODULE_FLAGS_NONE        = 0,
+  GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY = (1 << 0),
+} GumDarwinModuleFlags;
 
 struct _GumDarwinModule
 {
@@ -142,12 +144,6 @@ enum _GumDarwinModuleFiletype
   GUM_DARWIN_MODULE_FILETYPE_DSYM,
   GUM_DARWIN_MODULE_FILETYPE_KEXT_BUNDLE,
   GUM_DARWIN_MODULE_FILETYPE_FILESET,
-};
-
-enum _GumDarwinModuleFlags
-{
-  GUM_DARWIN_MODULE_FLAGS_NONE        = 0,
-  GUM_DARWIN_MODULE_FLAGS_HEADER_ONLY = (1 << 0),
 };
 
 enum _GumDarwinCpuArchType
@@ -417,8 +413,6 @@ GUM_API GumDarwinModuleImage * gum_darwin_module_image_new (void);
 GUM_API GumDarwinModuleImage * gum_darwin_module_image_dup (
     const GumDarwinModuleImage * other);
 GUM_API void gum_darwin_module_image_free (GumDarwinModuleImage * image);
-
-GUM_API GType gum_darwin_module_flags_get_type (void) G_GNUC_CONST;
 
 G_END_DECLS
 

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -7,7 +7,7 @@
 #ifndef __GUMDEFS_H__
 #define __GUMDEFS_H__
 
-#include <glib-object.h>
+#include <gum/gumenumtypes.h>
 
 #if !defined (GUM_STATIC) && defined (G_OS_WIN32)
 #  ifdef GUM_EXPORTS
@@ -52,10 +52,8 @@ typedef guint64 GumAddress;
 typedef guint GumOS;
 typedef guint GumCallingConvention;
 typedef guint GumAbiType;
-typedef guint GumCpuType;
 typedef guint GumCpuFeatures;
 typedef guint GumInstructionEncoding;
-#define GUM_TYPE_CPU_TYPE (gum_cpu_type_get_type ())
 typedef guint GumArgType;
 typedef struct _GumArgument GumArgument;
 typedef guint GumBranchHint;
@@ -147,15 +145,14 @@ enum _GumAbiType
   GUM_ABI_WINDOWS
 };
 
-enum _GumCpuType
-{
+typedef enum {
   GUM_CPU_INVALID,
   GUM_CPU_IA32,
   GUM_CPU_AMD64,
   GUM_CPU_ARM,
   GUM_CPU_ARM64,
   GUM_CPU_MIPS
-};
+} GumCpuType;
 
 enum _GumCpuFeatures
 {
@@ -495,7 +492,6 @@ GUM_API void gum_cpu_context_replace_return_value (GumCpuContext * self,
     gpointer value);
 
 GUM_API GType gum_address_get_type (void) G_GNUC_CONST;
-GUM_API GType gum_cpu_type_get_type (void) G_GNUC_CONST;
 
 G_END_DECLS
 

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -78,28 +78,46 @@ typedef struct _GumMipsCpuContext GumMipsCpuContext;
 #if !defined (__arm__) && !defined (__aarch64__) && !defined (__mips__)
 # define GUM_DEFAULT_CS_ARCH CS_ARCH_X86
 # if GLIB_SIZEOF_VOID_P == 4
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 #  define GUM_DEFAULT_CS_MODE CS_MODE_32
 typedef GumIA32CpuContext GumCpuContext;
 # else
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 #  define GUM_DEFAULT_CS_MODE CS_MODE_64
 typedef GumX64CpuContext GumCpuContext;
 # endif
 #elif defined (__arm__) && !defined (__aarch64__)
 # define GUM_DEFAULT_CS_ARCH CS_ARCH_ARM
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 # define GUM_DEFAULT_CS_MODE \
     ((cs_mode) (CS_MODE_ARM | CS_MODE_V8 | GUM_DEFAULT_CS_ENDIAN))
 # define GUM_PSR_T_BIT 0x20
 typedef GumArmCpuContext GumCpuContext;
 #elif defined (__aarch64__)
 # define GUM_DEFAULT_CS_ARCH CS_ARCH_ARM64
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 # define GUM_DEFAULT_CS_MODE GUM_DEFAULT_CS_ENDIAN
 typedef GumArm64CpuContext GumCpuContext;
 #elif defined (__mips__)
 # define GUM_DEFAULT_CS_ARCH CS_ARCH_MIPS
 # if GLIB_SIZEOF_VOID_P == 4
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 #  define GUM_DEFAULT_CS_MODE ((cs_mode) \
     (CS_MODE_MIPS32 | GUM_DEFAULT_CS_ENDIAN))
 # else
+/**
+ * GUM_DEFAULT_CS_MODE: (skip)
+ */
 #  define GUM_DEFAULT_CS_MODE ((cs_mode) \
     (CS_MODE_MIPS64 | GUM_DEFAULT_CS_ENDIAN))
 # endif

--- a/gum/gumenumtypes.c.template
+++ b/gum/gumenumtypes.c.template
@@ -1,0 +1,39 @@
+/*** BEGIN file-header ***/
+#include "gumenumtypes.h"
+
+#include <gum/gum.h>
+
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+
+/* Enumerations from "@basename@" */
+/*** END file-production ***/
+
+/*** BEGIN value-header ***/
+GType
+@enum_name@_get_type (void)
+{
+  static gsize static_g_define_type_id = 0;
+
+  if (g_once_init_enter (&static_g_define_type_id))
+  {
+    static const G@Type@Value values[] = {
+/*** END value-header ***/
+
+/*** BEGIN value-production ***/
+      { @VALUENAME@, "@VALUENAME@", "@valuenick@" },
+/*** END value-production ***/
+
+/*** BEGIN value-tail ***/
+      { 0, NULL, NULL }
+    };
+    GType g_define_type_id = g_@type@_register_static (
+        g_intern_static_string ("@EnumName@"), values);
+    g_once_init_leave (&static_g_define_type_id, g_define_type_id);
+  }
+
+  return static_g_define_type_id;
+}
+
+/*** END value-tail ***/

--- a/gum/gumenumtypes.h.template
+++ b/gum/gumenumtypes.h.template
@@ -1,0 +1,24 @@
+/*** BEGIN file-header ***/
+#ifndef __GUM_ENUM_TYPES_H__
+#define __GUM_ENUM_TYPES_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+
+/* Enumerations from "@basename@" */
+/*** END file-production ***/
+
+/*** BEGIN value-header ***/
+GType @enum_name@_get_type (void) G_GNUC_CONST;
+#define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
+/*** END value-header ***/
+
+/*** BEGIN file-tail ***/
+G_END_DECLS
+
+#endif /* __GUM_ENUM_TYPES_H__ */
+/*** END file-tail ***/

--- a/gum/gumexceptor.h
+++ b/gum/gumexceptor.h
@@ -25,7 +25,9 @@ G_DECLARE_FINAL_TYPE (GumExceptor, gum_exceptor, GUM, EXCEPTOR, GObject)
 #else
 # define GUM_NATIVE_SETJMP(env) sigsetjmp (env, TRUE)
 # define GUM_NATIVE_LONGJMP siglongjmp
+# if !defined (GUM_GIR_COMPILATION)
   typedef sigjmp_buf GumExceptorNativeJmpBuf;
+# endif
 #endif
 
 typedef struct _GumExceptionDetails GumExceptionDetails;

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -172,29 +172,6 @@ gum_store_address_if_name_matches (const GumSymbolDetails * details,
   return carry_on;
 }
 
-GType
-gum_code_signing_policy_get_type (void)
-{
-  static gsize gonce_value;
-
-  if (g_once_init_enter (&gonce_value))
-  {
-    static const GEnumValue values[] =
-    {
-      { GUM_CODE_SIGNING_OPTIONAL, "GUM_CODE_SIGNING_OPTIONAL", "optional" },
-      { GUM_CODE_SIGNING_REQUIRED, "GUM_CODE_SIGNING_REQUIRED", "required" },
-      { 0, NULL, NULL }
-    };
-    GType etype;
-
-    etype = g_enum_register_static ("GumCodeSigningPolicy", values);
-
-    g_once_init_leave (&gonce_value, etype);
-  }
-
-  return (GType) gonce_value;
-}
-
 const gchar *
 gum_code_signing_policy_to_string (GumCodeSigningPolicy policy)
 {

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -13,11 +13,9 @@
 #define GUM_THREAD_ID_INVALID ((GumThreadId) -1)
 
 #define GUM_TYPE_MODULE_DETAILS (gum_module_details_get_type ())
-#define GUM_TYPE_CODE_SIGNING_POLICY (gum_code_signing_policy_get_type ())
 
 G_BEGIN_DECLS
 
-typedef guint GumCodeSigningPolicy;
 typedef guint GumProcessId;
 typedef gsize GumThreadId;
 typedef guint GumThreadState;
@@ -34,11 +32,10 @@ typedef struct _GumRangeDetails GumRangeDetails;
 typedef struct _GumFileMapping GumFileMapping;
 typedef struct _GumMallocRangeDetails GumMallocRangeDetails;
 
-enum _GumCodeSigningPolicy
-{
+typedef enum {
   GUM_CODE_SIGNING_OPTIONAL,
   GUM_CODE_SIGNING_REQUIRED
-};
+} GumCodeSigningPolicy;
 
 enum _GumThreadState
 {
@@ -202,7 +199,6 @@ GUM_API GumAddress gum_module_find_export_by_name (const gchar * module_name,
 GUM_API GumAddress gum_module_find_symbol_by_name (const gchar * module_name,
     const gchar * symbol_name);
 
-GUM_API GType gum_code_signing_policy_get_type (void) G_GNUC_CONST;
 GUM_API const gchar * gum_code_signing_policy_to_string (
     GumCodeSigningPolicy policy);
 

--- a/gum/meson.build
+++ b/gum/meson.build
@@ -1,3 +1,5 @@
+gnome = import('gnome')
+
 gum_headers = [
   'gum.h',
   'gumapiresolver.h',
@@ -75,8 +77,10 @@ gum_sources = [
   'arch-mips/gummipsrelocator.c',
 ]
 
+gum_backend_headers = []
+
 if host_os_family == 'windows'
-  gum_headers += [
+  gum_backend_headers += [
     'backend-windows/gumwindows.h',
     'backend-dbghelp/gumdbghelp.h',
     'backend-dbghelp/gumdbghelpbacktracer.h',
@@ -98,7 +102,7 @@ else
 endif
 
 if host_os_family == 'darwin'
-  gum_headers += [
+  gum_backend_headers += [
     'backend-darwin/gumdarwin.h',
     'backend-darwin/gumdarwinbacktracer.h',
     'backend-darwin/gumdarwinsymbolicator.h',
@@ -124,7 +128,7 @@ if host_os_family == 'darwin'
 endif
 
 if host_os_family == 'linux'
-  gum_headers += [
+  gum_backend_headers += [
     'backend-linux/gumlinux.h',
   ]
   gum_sources += [
@@ -135,7 +139,7 @@ if host_os_family == 'linux'
     'backend-posix/gumexceptor-posix.c',
   ]
   if host_os == 'android'
-    gum_headers += [
+    gum_backend_headers += [
       'backend-linux/gumandroid.h',
     ]
     gum_sources += [
@@ -145,7 +149,7 @@ if host_os_family == 'linux'
 endif
 
 if host_os_family == 'qnx'
-  gum_headers += [
+  gum_backend_headers += [
     'backend-qnx/gumqnx.h',
   ]
   gum_sources += [
@@ -158,7 +162,7 @@ if host_os_family == 'qnx'
 endif
 
 if host_os_family == 'linux' or host_os_family == 'qnx'
-  gum_headers += [
+  gum_backend_headers += [
     'backend-elf/gumelfmodule.h',
   ]
   gum_sources += [
@@ -250,7 +254,7 @@ if host_arch == 'mips'
 endif
 
 if unwind_dep.found()
-  gum_headers += [
+  gum_backend_headers += [
     'backend-libunwind/gumunwbacktracer.h',
   ]
   gum_sources += [
@@ -264,7 +268,7 @@ if have_libdwarf
   ]
 endif
 
-install_headers(gum_headers, subdir: install_header_subdir)
+install_headers(gum_headers + gum_backend_headers, subdir: install_header_subdir)
 install_headers(gum_x86_headers, subdir: install_header_subdir + '/arch-x86')
 install_headers(gum_arm_headers, subdir: install_header_subdir + '/arch-arm')
 install_headers(gum_arm64_headers, subdir: install_header_subdir + '/arch-arm64')
@@ -277,6 +281,26 @@ gum = library('frida-gum-' + api_version, gum_sources,
   dependencies: [glib_dep, gobject_dep, gio_dep, ffi_dep, capstone_dep] + extra_deps,
   install: true,
 )
+
+if gir.found()
+  gir_args = [
+    '--quiet',
+    '-DGUM_GIR_COMPILATION',
+  ]
+
+  gnome.generate_gir(gum,
+    sources: gum_sources + gum_headers,
+    namespace: 'Gum',
+    nsversion: api_version,
+    identifier_prefix: 'Gum',
+    symbol_prefix: 'gum',
+    export_packages: 'gum',
+    includes: ['GLib-2.0', 'GObject-2.0', 'Gio-2.0'],
+    header: 'gum/gum.h',
+    extra_args: gir_args + extra_libs_private,
+    install: true,
+  )
+endif
 
 gum_dep = declare_dependency(link_with: gum,
   include_directories: gum_incdirs,

--- a/gum/meson.build
+++ b/gum/meson.build
@@ -274,7 +274,19 @@ install_headers(gum_arm_headers, subdir: install_header_subdir + '/arch-arm')
 install_headers(gum_arm64_headers, subdir: install_header_subdir + '/arch-arm64')
 install_headers(gum_mips_headers, subdir: install_header_subdir + '/arch-mips')
 
-gum = library('frida-gum-' + api_version, gum_sources,
+gum_enums = gnome.mkenums('gum-enum-types',
+  sources: gum_headers,
+  c_template: 'gumenumtypes.c.template',
+  h_template: 'gumenumtypes.h.template',
+  install_dir: install_header_subdir,
+  install_header: true,
+)
+
+gum_enums_dep = declare_dependency(sources: gum_enums)
+
+gum_enum_h = gum_enums[1]
+
+gum = library('frida-gum-' + api_version, gum_sources + gum_enums,
   c_args: frida_component_cflags,
   include_directories: gum_incdirs,
   link_args: extra_libs_private,
@@ -289,7 +301,7 @@ if gir.found()
   ]
 
   gnome.generate_gir(gum,
-    sources: gum_sources + gum_headers,
+    sources: gum_sources + gum_headers + [gum_enum_h],
     namespace: 'Gum',
     nsversion: api_version,
     identifier_prefix: 'Gum',
@@ -305,7 +317,7 @@ endif
 gum_dep = declare_dependency(link_with: gum,
   include_directories: gum_incdirs,
   link_args: extra_libs_private,
-  dependencies: [glib_dep, gobject_dep, gio_dep, capstone_dep],
+  dependencies: [glib_dep, gobject_dep, gio_dep, capstone_dep, gum_enums_dep],
 )
 
 pkg = import('pkgconfig')

--- a/meson.build
+++ b/meson.build
@@ -194,6 +194,14 @@ extra_deps = []
 extra_requires_private = []
 extra_libs_private = []
 
+if cc.has_function('g_thread_set_callbacks', dependencies: [glib_dep])
+  cdata.set('HAVE_FRIDA_GLIB', 1)
+endif
+
+if cc.has_function('ffi_set_mem_callbacks', dependencies: [ffi_dep])
+  cdata.set('HAVE_FRIDA_LIBFFI', 1)
+endif
+
 if host_os == 'android'
   extra_libs_private += ['-llog']
 endif

--- a/meson.build
+++ b/meson.build
@@ -194,6 +194,20 @@ extra_deps = []
 extra_requires_private = []
 extra_libs_private = []
 
+glib_flavor_src = '''
+#include <glib.h>
+
+#ifdef GLIB_STATIC_COMPILATION
+# error GLib is static
+#endif
+'''
+have_shared_glib = cc.compiles(glib_flavor_src, name: 'compiling with shared GLib', dependencies: [glib_dep])
+if have_shared_glib
+  gir = find_program('g-ir-scanner')
+else
+  gir = disabler()
+endif
+
 if cc.has_function('g_thread_set_callbacks', dependencies: [glib_dep])
   cdata.set('HAVE_FRIDA_GLIB', 1)
 endif

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -37,7 +37,9 @@ TESTLIST_BEGIN (interceptor)
   TESTENTRY (attach_detach_torture)
 #endif
   TESTENTRY (thread_id)
-#if !(defined (HAVE_ANDROID) && defined (HAVE_ARM64)) && !defined (HAVE_ASAN)
+#if defined (HAVE_FRIDA_GLIB) && \
+    !(defined (HAVE_ANDROID) && defined (HAVE_ARM64)) && \
+    !defined (HAVE_ASAN)
   TESTENTRY (intercepted_free_in_thread_exit)
 #endif
   TESTENTRY (function_arguments)
@@ -54,10 +56,12 @@ TESTLIST_BEGIN (interceptor)
 
   TESTENTRY (i_can_has_replaceability)
   TESTENTRY (already_replaced)
-# ifndef HAVE_ASAN
+#ifndef HAVE_ASAN
   TESTENTRY (replace_one)
+# ifdef HAVE_FRIDA_GLIB
   TESTENTRY (replace_two)
 # endif
+#endif
   TESTENTRY (replace_then_attach)
 
 #ifdef HAVE_QNX
@@ -233,6 +237,10 @@ TESTCASE (thread_id)
   g_assert_cmpuint (second_thread_id, !=, first_thread_id);
 }
 
+#if defined (HAVE_FRIDA_GLIB) && \
+    !(defined (HAVE_ANDROID) && defined (HAVE_ARM64)) && \
+    !defined (HAVE_ASAN)
+
 TESTCASE (intercepted_free_in_thread_exit)
 {
   interceptor_fixture_attach (fixture, 0, interceptor_fixture_get_libc_free (),
@@ -240,6 +248,8 @@ TESTCASE (intercepted_free_in_thread_exit)
   g_thread_join (g_thread_new ("interceptor-test-thread-exit",
       target_nop_function_a, NULL));
 }
+
+#endif
 
 TESTCASE (function_arguments)
 {
@@ -582,6 +592,8 @@ static gpointer replacement_malloc_calling_malloc_and_replaced_free (
     gsize size);
 static void replacement_free_doing_nothing (gpointer mem);
 
+#ifdef HAVE_FRIDA_GLIB
+
 TESTCASE (replace_two)
 {
   gpointer malloc_impl, free_impl;
@@ -612,6 +624,8 @@ TESTCASE (replace_two)
 
   free (ret);
 }
+
+#endif
 
 static gpointer
 replacement_malloc_calling_malloc_and_replaced_free (gsize size)

--- a/tests/gum-tests.vcxproj
+++ b/tests/gum-tests.vcxproj
@@ -88,7 +88,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>.;.\stubs;..;..\gum;..\gum\arch-x86;..\gum\arch-arm;..\gum\arch-arm64;..\libs;..\libs\gum\heap;..\libs\gum\prof;..\bindings\gumjs;..\bindings\gumpp;$(IntDir)..\gum-32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;HAVE_GIOSCHANNEL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_FRIDA_GLIB=1;HAVE_FRIDA_LIBFFI=1;HAVE_GIOSCHANNEL=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4100;4152;4210;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -109,7 +109,7 @@ copy /B /Y "$(SolutionDir)build\frida-windows\$(Platform)-$(ConfigurationName)\b
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>.;.\stubs;..;..\gum;..\gum\arch-x86;..\gum\arch-arm;..\gum\arch-arm64;..\libs;..\libs\gum\heap;..\libs\gum\prof;..\bindings\gumjs;..\bindings\gumpp;$(IntDir)..\gum-64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;HAVE_GIOSCHANNEL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_FRIDA_GLIB=1;HAVE_FRIDA_LIBFFI=1;HAVE_GIOSCHANNEL=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4100;4152;4210;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -130,7 +130,7 @@ copy /B /Y "$(SolutionDir)build\frida-windows\$(Platform)-$(ConfigurationName)\b
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>.;.\stubs;..;..\gum;..\gum\arch-x86;..\gum\arch-arm;..\gum\arch-arm64;..\libs;..\libs\gum\heap;..\libs\gum\prof;..\bindings\gumjs;..\bindings\gumpp;$(IntDir)..\gum-32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;HAVE_GIOSCHANNEL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_FRIDA_GLIB=1;HAVE_FRIDA_LIBFFI=1;HAVE_GIOSCHANNEL=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4100;4152;4210;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -151,7 +151,7 @@ copy /B /Y "$(SolutionDir)build\frida-windows\$(Platform)-$(ConfigurationName)\b
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>.;.\stubs;..;..\gum;..\gum\arch-x86;..\gum\arch-arm;..\gum\arch-arm64;..\libs;..\libs\gum\heap;..\libs\gum\prof;..\bindings\gumjs;..\bindings\gumpp;$(IntDir)..\gum-64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;HAVE_GIOSCHANNEL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GUM_STATIC;HAVE_I386=1;HAVE_WINDOWS=1;HAVE_GUMPP=1;HAVE_GUMJS=1;HAVE_FRIDA_GLIB=1;HAVE_FRIDA_LIBFFI=1;HAVE_GIOSCHANNEL=1;HAVE_QUICKJS=1;HAVE_TINYCC=1;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4100;4152;4210;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>

--- a/tests/gumtest.c
+++ b/tests/gumtest.c
@@ -44,7 +44,7 @@ static guint get_number_of_tests_in_suite (GTestSuite * suite);
 gint
 main (gint argc, gchar * argv[])
 {
-#if !DEBUG_HEAP_LEAKS && !defined (HAVE_ASAN)
+#if defined (HAVE_FRIDA_GLIB) && !DEBUG_HEAP_LEAKS && !defined (HAVE_ASAN)
   GMemVTable mem_vtable = {
     gum_malloc,
     gum_realloc,
@@ -104,14 +104,18 @@ main (gint argc, gchar * argv[])
   }
   else
   {
+#ifdef HAVE_FRIDA_GLIB
     g_mem_set_vtable (&mem_vtable);
+#endif
   }
 #else
   g_setenv ("G_SLICE", "always-malloc", TRUE);
 #endif
   g_setenv ("G_DEBUG", "fatal-warnings:fatal-criticals", TRUE);
+#ifdef HAVE_FRIDA_GLIB
   glib_init ();
   gio_init ();
+#endif
 #ifdef HAVE_GIOSCHANNEL
   g_io_module_schannel_register ();
 #endif
@@ -266,7 +270,7 @@ main (gint argc, gchar * argv[])
   TESTLIST_REGISTER (profiler);
 #endif
 
-#if defined (HAVE_GUMJS)
+#if defined (HAVE_GUMJS) && defined (HAVE_FRIDA_GLIB)
   /* GumJS */
   {
     GumScriptBackend * qjs_backend, * v8_backend;

--- a/tests/prof/sampler.c
+++ b/tests/prof/sampler.c
@@ -10,7 +10,7 @@
 TESTLIST_BEGIN (sampler)
   TESTENTRY (cycle)
   TESTENTRY (busy_cycle)
-#ifndef HAVE_ASAN
+#if defined (HAVE_FRIDA_GLIB) && !defined (HAVE_ASAN)
   TESTENTRY (malloc_count)
 #endif
   TESTENTRY (multiple_call_counters)
@@ -75,6 +75,8 @@ struct _MallocCountHelperContext
   GumSample count;
 };
 
+#if defined (HAVE_FRIDA_GLIB) && !defined (HAVE_ASAN)
+
 TESTCASE (malloc_count)
 {
   const GumHeapApiList * heap_apis;
@@ -123,6 +125,8 @@ TESTCASE (malloc_count)
   g_assert_cmpuint (gum_call_count_sampler_peek_total_count (
       GUM_CALL_COUNT_SAMPLER (fixture->sampler)), >=, 3 + 1);
 }
+
+#endif
 
 TESTCASE (multiple_call_counters)
 {


### PR DESCRIPTION
This PR adds support for linking against a system GLib, as well as adds support for building GObject Introspection files (if the user has the required tools installed on their system).

The Frida build system HAS NOT been updated to support this change as more work is planned for that. However, it's straightfoward to test:

```diff
 # We need these legacy paths for dependencies that don't use pkg-config.
 legacy_includes="-I$FRIDA_PREFIX/include"
-legacy_libpaths="-L$FRIDA_PREFIX/lib"
+#legacy_libpaths="-L$FRIDA_PREFIX/lib"
 if [ "$FRIDA_ENV_SDK" != 'none' ]; then
   legacy_includes="$legacy_includes -I$FRIDA_SDKROOT/include"
-  legacy_libpaths="$legacy_libpaths -L$FRIDA_SDKROOT/lib"
+  #legacy_libpaths="$legacy_libpaths -L$FRIDA_SDKROOT/lib"
 fi
 CPPFLAGS="$CPPFLAGS $legacy_includes"
-LDFLAGS="$LDFLAGS $legacy_libpaths"
+#LDFLAGS="$LDFLAGS $legacy_libpaths"
 
 meson_legacy_includes=$(flags_to_args "$legacy_includes")
 meson_legacy_libpaths=$(flags_to_args "$legacy_libpaths")
@@ -870,9 +870,11 @@ chmod 755 "$strip_wrapper"
 
 PKG_CONFIG=$FRIDA_BUILD/${FRIDA_ENV_NAME:-frida}-${host_platform_arch}-pkg-config
 
-pkg_config="$FRIDA_TOOLROOT/bin/pkg-config"
+pkg_config="pkg-config"
+# pkg_config="$FRIDA_TOOLROOT/bin/pkg-config"
 pkg_config_flags=""
-pkg_config_path="$FRIDA_PREFIX_LIB/pkgconfig"
+pkg_config_path="/usr/lib/pkgconfig"
+# pkg_config_path="$FRIDA_PREFIX_LIB/pkgconfig"
 if [ "$FRIDA_ENV_SDK" != 'none' ]; then
   pkg_config_flags=" --define-variable=frida_sdk_prefix=$FRIDA_SDKROOT"
   pkg_config_path="$pkg_config_path:$FRIDA_SDKROOT/lib/pkgconfig"
@@ -880,7 +882,7 @@ fi
 (
   echo "#!/bin/sh"
   echo "export PKG_CONFIG_PATH=\"$pkg_config_path\""
-  echo "exec \"$pkg_config\"$pkg_config_flags --static \"\$@\""
+  echo "exec \"$pkg_config\"$pkg_config_flags \"\$@\""
 ) > "$PKG_CONFIG"
 chmod 755 "$PKG_CONFIG"
```
(This is a crap changeset, but it makes the build system use the system's `pkg-config`, as well as removes the Frida path from `LDFLAGS`.)

The test suite has been modified to disable tests that cease to function on a non-Frida GLib as those tests required the patches applied to Frida's GLib. Tests still pass on the original build configuration as well as this new one.