### PR TITLE
Support a NULL EventSink in Stalker

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -697,7 +697,7 @@ _gum_stalker_do_follow_me (GumStalker * self,
     return ret_addr;
   }
 
-  gum_event_sink_start (sink);
+  gum_event_sink_start (ctx->sink);
   ctx->sink_started = TRUE;
 
   return code_address;
@@ -972,9 +972,14 @@ gum_stalker_create_exec_ctx (GumStalker * self,
       GUM_STALKER_TRANSFORMER_GET_IFACE (ctx->transformer)->transform_block;
   g_queue_init (&ctx->callout_entries);
   gum_spinlock_init (&ctx->callout_lock);
-  ctx->sink = g_object_ref (sink);
-  ctx->sink_mask = gum_event_sink_query_mask (sink);
-  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (sink)->process;
+
+  if (sink != NULL)
+    ctx->sink = g_object_ref (sink);
+  else
+    ctx->sink = gum_event_sink_make_default ();
+
+  ctx->sink_mask = gum_event_sink_query_mask (ctx->sink);
+  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (ctx->sink)->process;
 
   ctx->frames =
       gum_memory_allocate (NULL, self->page_size, self->page_size, GUM_PAGE_RW);

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -636,7 +636,7 @@ _gum_stalker_do_follow_me (GumStalker * self,
     return ret_addr;
   }
 
-  gum_event_sink_start (sink);
+  gum_event_sink_start (ctx->sink);
   ctx->sink_started = TRUE;
 
   return code_address + GUM_RESTORATION_PROLOG_SIZE;
@@ -999,9 +999,14 @@ gum_stalker_create_exec_ctx (GumStalker * self,
       GUM_STALKER_TRANSFORMER_GET_IFACE (ctx->transformer)->transform_block;
   g_queue_init (&ctx->callout_entries);
   gum_spinlock_init (&ctx->callout_lock);
-  ctx->sink = g_object_ref (sink);
-  ctx->sink_mask = gum_event_sink_query_mask (sink);
-  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (sink)->process;
+
+  if (sink != NULL)
+    ctx->sink = g_object_ref (sink);
+  else
+    ctx->sink = gum_event_sink_make_default ();
+
+  ctx->sink_mask = gum_event_sink_query_mask (ctx->sink);
+  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (ctx->sink)->process;
 
   ctx->frames =
       gum_memory_allocate (NULL, self->page_size, self->page_size, GUM_PAGE_RW);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -810,7 +810,7 @@ _gum_stalker_do_follow_me (GumStalker * self,
     return;
   }
 
-  gum_event_sink_start (sink);
+  gum_event_sink_start (ctx->sink);
   ctx->sink_started = TRUE;
 
   *ret_addr_ptr = code_address;
@@ -1272,9 +1272,14 @@ gum_stalker_create_exec_ctx (GumStalker * self,
       GUM_STALKER_TRANSFORMER_GET_IFACE (ctx->transformer)->transform_block;
   g_queue_init (&ctx->callout_entries);
   gum_spinlock_init (&ctx->callout_lock);
-  ctx->sink = g_object_ref (sink);
-  ctx->sink_mask = gum_event_sink_query_mask (sink);
-  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (sink)->process;
+
+  if (sink != NULL)
+    ctx->sink = g_object_ref (sink);
+  else
+    ctx->sink = gum_event_sink_make_default ();
+
+  ctx->sink_mask = gum_event_sink_query_mask (ctx->sink);
+  ctx->sink_process_impl = GUM_EVENT_SINK_GET_IFACE (ctx->sink)->process;
 
   ctx->infect_thunk = (guint8 *) ctx +
       (base_size - thunk_size) * self->page_size;

--- a/gum/gumeventsink.c
+++ b/gum/gumeventsink.c
@@ -6,7 +6,25 @@
 
 #include "gumeventsink.h"
 
+struct _GumDefaultEventSink
+{
+  GObject parent;
+};
+
+static void gum_default_event_sink_iface_init (gpointer g_iface,
+    gpointer iface_data);
+static GumEventType gum_default_event_sink_query_mask (GumEventSink * sink);
+static void gum_default_event_sink_process (GumEventSink * sink,
+    const GumEvent * ev);
+
 G_DEFINE_INTERFACE (GumEventSink, gum_event_sink, G_TYPE_OBJECT)
+
+G_DEFINE_TYPE_EXTENDED (GumDefaultEventSink,
+                        gum_default_event_sink,
+                        G_TYPE_OBJECT,
+                        0,
+                        G_IMPLEMENT_INTERFACE (GUM_TYPE_EVENT_SINK,
+                            gum_default_event_sink_iface_init))
 
 static void
 gum_event_sink_default_init (GumEventSinkInterface * iface)
@@ -60,3 +78,42 @@ gum_event_sink_stop (GumEventSink * self)
   if (iface->stop != NULL)
     iface->stop (self);
 }
+
+GumEventSink *
+gum_event_sink_make_default (void)
+{
+  return GUM_EVENT_SINK (g_object_new (GUM_TYPE_DEFAULT_EVENT_SINK, NULL));
+}
+
+static void
+gum_default_event_sink_class_init (GumDefaultEventSinkClass * klass)
+{
+}
+
+static void
+gum_default_event_sink_iface_init (gpointer g_iface,
+                                   gpointer iface_data)
+{
+  GumEventSinkInterface * iface = g_iface;
+
+  iface->query_mask = gum_default_event_sink_query_mask;
+  iface->process = gum_default_event_sink_process;
+}
+
+static void
+gum_default_event_sink_init (GumDefaultEventSink * self)
+{
+}
+
+static GumEventType
+gum_default_event_sink_query_mask (GumEventSink * sink)
+{
+  return GUM_NOTHING;
+}
+
+static void
+gum_default_event_sink_process (GumEventSink * sink,
+                                const GumEvent * ev)
+{
+}
+

--- a/gum/gumeventsink.h
+++ b/gum/gumeventsink.h
@@ -16,6 +16,10 @@ G_BEGIN_DECLS
 #define GUM_TYPE_EVENT_SINK (gum_event_sink_get_type ())
 G_DECLARE_INTERFACE (GumEventSink, gum_event_sink, GUM, EVENT_SINK, GObject)
 
+#define GUM_TYPE_DEFAULT_EVENT_SINK (gum_default_event_sink_get_type ())
+G_DECLARE_FINAL_TYPE (GumDefaultEventSink, gum_default_event_sink, GUM,
+    DEFAULT_EVENT_SINK, GObject)
+
 struct _GumEventSinkInterface
 {
   GTypeInterface parent;
@@ -32,6 +36,8 @@ GUM_API void gum_event_sink_start (GumEventSink * self);
 GUM_API void gum_event_sink_process (GumEventSink * self, const GumEvent * ev);
 GUM_API void gum_event_sink_flush (GumEventSink * self);
 GUM_API void gum_event_sink_stop (GumEventSink * self);
+
+GUM_API GumEventSink * gum_event_sink_make_default (void);
 
 G_END_DECLS
 

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -92,6 +92,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (unfollow_should_be_allowed_before_second_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_second_transform)
   TESTENTRY (unfollow_should_be_allowed_after_second_transform)
+  TESTENTRY (follow_me_should_support_nullable_event_sink)
 
   TESTENTRY (follow_syscall)
   TESTENTRY (follow_thread)
@@ -2503,6 +2504,16 @@ unfollow_during_transform (GumStalkerIterator * iterator,
   }
 
   ctx->num_blocks_transformed++;
+}
+
+TESTCASE (follow_me_should_support_nullable_event_sink)
+{
+  gpointer p;
+
+  gum_stalker_follow_me (fixture->stalker, NULL, NULL);
+  p = malloc (1);
+  free (p);
+  gum_stalker_unfollow_me (fixture->stalker);
 }
 
 TESTCASE (follow_syscall)

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -32,6 +32,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (unfollow_should_be_allowed_before_second_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_second_transform)
   TESTENTRY (unfollow_should_be_allowed_after_second_transform)
+  TESTENTRY (follow_me_should_support_nullable_event_sink)
 
   /* EXCLUSION */
   TESTENTRY (exclude_bl)
@@ -490,6 +491,16 @@ unfollow_during_transform (GumStalkerIterator * iterator,
   }
 
   ctx->num_blocks_transformed++;
+}
+
+TESTCASE (follow_me_should_support_nullable_event_sink)
+{
+  gpointer p;
+
+  gum_stalker_follow_me (fixture->stalker, NULL, NULL);
+  p = malloc (1);
+  free (p);
+  gum_stalker_unfollow_me (fixture->stalker);
 }
 
 TESTCASE (exclude_bl)

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -25,6 +25,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (unfollow_should_be_allowed_before_second_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_second_transform)
   TESTENTRY (unfollow_should_be_allowed_after_second_transform)
+  TESTENTRY (follow_me_should_support_nullable_event_sink)
 
   TESTENTRY (unconditional_jumps)
   TESTENTRY (short_conditional_jump_true)
@@ -768,6 +769,16 @@ unfollow_during_transform (GumStalkerIterator * iterator,
   }
 
   ctx->num_blocks_transformed++;
+}
+
+TESTCASE (follow_me_should_support_nullable_event_sink)
+{
+  gpointer p;
+
+  gum_stalker_follow_me (fixture->stalker, NULL, NULL);
+  p = malloc (1);
+  free (p);
+  gum_stalker_unfollow_me (fixture->stalker);
 }
 
 TESTCASE (unconditional_jumps)


### PR DESCRIPTION
~~This PR is still in the proposal phase as I haven't added ARM64 or MIPS support nor reasonable tests.~~

For background: in my personal project hotwax, my [`event_sink.c`](https://github.com/meme/hotwax/blob/master/src/event_sink.c) simply acts as a stub which does nothing (and returns a query_mask of 0). Now, in another project where I use the Frida Stalker, I've run into the same problem: I do not need an EventSink, but are required to provide one.

So, I propose that we allow EventSink to be `NULL` so that a user can provide ONLY a transformer and nothing else. Or alternatively, they can provide no Transformer or EventSink (not sure what the use-case is for this, but it is now allowed)

So my goals for this PR are _speed_. I want to provide reasonable speed benefits if you do not provide an EventSink. This is why I ask for your feedback @oleavr to see:
1) If this is reasonable
2) How we can design this so that it provides the most speed benefit