### PR TITLE
Fix deadlock when the thread holding the JS lock crashes

### DIFF
--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -63,6 +64,7 @@ struct _GumQuickCore
   JSContext * ctx;
   GHashTable * module_data;
   GumQuickScope * current_scope;
+  GumThreadId current_owner;
 
   GRecMutex * mutex;
   volatile guint usage_count;
@@ -178,6 +180,7 @@ struct _GumQuickScope
 {
   GumQuickCore * core;
   GumQuickScope * previous_scope;
+  GumThreadId previous_owner;
   guint previous_mutex_depth;
   JSRuntimeThreadState thread_state;
 

--- a/bindings/gumjs/gumquickprocess.c
+++ b/bindings/gumjs/gumquickprocess.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -523,6 +524,9 @@ gum_quick_exception_handler_on_exception (GumExceptionDetails * details,
   GumQuickScope scope;
   JSValue d, r;
   GumQuickCpuContext * cpu_context;
+
+  if (gum_quick_script_backend_is_scope_mutex_trapped (core->backend))
+    return FALSE;
 
   _gum_quick_scope_enter (&scope, core);
 

--- a/bindings/gumjs/gumquickscriptbackend-priv.h
+++ b/bindings/gumjs/gumquickscriptbackend-priv.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -24,6 +25,10 @@ G_GNUC_INTERNAL JSValue gum_quick_script_backend_read_program (
 G_GNUC_INTERNAL GRecMutex * gum_quick_script_backend_get_scope_mutex (
     GumQuickScriptBackend * self);
 G_GNUC_INTERNAL GumScriptScheduler * gum_quick_script_backend_get_scheduler (
+    GumQuickScriptBackend * self);
+G_GNUC_INTERNAL gboolean gum_quick_script_backend_is_scope_mutex_trapped (
+    GumQuickScriptBackend * self);
+G_GNUC_INTERNAL void gum_quick_script_backend_mark_scope_mutex_trapped (
     GumQuickScriptBackend * self);
 
 G_END_DECLS

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -53,6 +54,7 @@ struct GumV8Core
   v8::Isolate * isolate;
 
   ScriptScope * current_scope;
+  GumThreadId current_owner;
   volatile guint usage_count;
   volatile GumV8FlushNotify flush_notify;
 

--- a/bindings/gumjs/gumv8process.cpp
+++ b/bindings/gumjs/gumv8process.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -419,6 +420,9 @@ gum_v8_exception_handler_on_exception (GumExceptionDetails * details,
                                        GumV8ExceptionHandler * handler)
 {
   auto core = handler->core;
+
+  if (gum_v8_script_backend_is_scope_mutex_trapped (core->backend))
+    return FALSE;
 
   ScriptScope scope (core->script);
   auto isolate = core->isolate;

--- a/bindings/gumjs/gumv8scope.h
+++ b/bindings/gumjs/gumv8scope.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -63,6 +64,7 @@ private:
   ScriptInterceptorScope interceptor_scope;
   ScriptScope * root_scope;
   ScriptScope * next_scope;
+  GumThreadId next_owner;
   GQueue * tick_callbacks;
   GQueue * scheduled_sources;
   GQueue tick_callbacks_storage;
@@ -94,6 +96,7 @@ private:
   private:
     GumV8Core * core;
     ScriptScope * scope;
+    GumThreadId owner;
   };
 
   class ExitIsolateScope

--- a/bindings/gumjs/gumv8scriptbackend.h
+++ b/bindings/gumjs/gumv8scriptbackend.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -21,6 +22,10 @@ G_GNUC_INTERNAL gpointer gum_v8_script_backend_get_platform (
 G_GNUC_INTERNAL gpointer gum_v8_script_backend_get_isolate (
     GumV8ScriptBackend * self);
 G_GNUC_INTERNAL GumScriptScheduler * gum_v8_script_backend_get_scheduler (
+    GumV8ScriptBackend * self);
+G_GNUC_INTERNAL gboolean gum_v8_script_backend_is_scope_mutex_trapped (
+    GumV8ScriptBackend * self);
+G_GNUC_INTERNAL void gum_v8_script_backend_mark_scope_mutex_trapped (
     GumV8ScriptBackend * self);
 
 G_END_DECLS

--- a/gum/gumexceptor.c
+++ b/gum/gumexceptor.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -248,6 +249,18 @@ gum_exceptor_catch (GumExceptor * self,
   GUM_EXCEPTOR_UNLOCK ();
 
   return scope->exception_occurred;
+}
+
+gboolean
+gum_exceptor_has_scope (GumExceptor * self, GumThreadId thread_id)
+{
+  GumExceptorScope * scope;
+
+  GUM_EXCEPTOR_LOCK ();
+  scope = g_hash_table_lookup (self->scopes, GSIZE_TO_POINTER (thread_id));
+  GUM_EXCEPTOR_UNLOCK ();
+
+  return scope != NULL;
 }
 
 gchar *

--- a/gum/gumexceptor.h
+++ b/gum/gumexceptor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -104,6 +105,8 @@ GUM_API void gum_exceptor_remove (GumExceptor * self, GumExceptionHandler func,
 #endif
 GUM_API gboolean gum_exceptor_catch (GumExceptor * self,
     GumExceptorScope * scope);
+GUM_API gboolean gum_exceptor_has_scope (GumExceptor * self,
+    GumThreadId thread_id);
 
 GUM_API gchar * gum_exception_details_to_string (
     const GumExceptionDetails * details);

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -8,6 +9,8 @@
 #define __GUM_PROCESS_H__
 
 #include <gum/gummemory.h>
+
+#define GUM_THREAD_ID_INVALID ((GumThreadId) -1)
 
 #define GUM_TYPE_MODULE_DETAILS (gum_module_details_get_type ())
 #define GUM_TYPE_CODE_SIGNING_POLICY (gum_code_signing_policy_get_type ())

--- a/tests/gumjs/script-fixture.c
+++ b/tests/gumjs/script-fixture.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2013 Karl Trygve Kalleberg <karltk@boblycat.org>
+ * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -33,6 +34,9 @@
 # include <sys/socket.h>
 # include <sys/un.h>
 # include <unistd.h>
+#endif
+#if HAVE_DARWIN
+# include <mach/mach.h>
 #endif
 #ifdef HAVE_QNX
 # include <unix.h>


### PR DESCRIPTION
- use the exceptor to detect this condition
- when that happens, the scope mutex is marked as "trapped" in the backend
    - in this condition the mutex remains locked, but `with_lock_held` won't block
    - so that the `ThreadSuspendMonitor` doesn't create deadlocks
    - also, all JS exception handlers are skipped in this state

This will allow crashes of this kind to actually surface instead of causing a deadlock. 

This can be improved over time, but for how this is implemented right now it's not really possible to "catch" and handle this kind of exceptions, because that would require forcibly unlock the scope mutex even if it belongs to a crashed thread.

The test case runs in "slow" mode only

```
gum-tests -m slow -p /GumJS/Script/crash_on_thread_holding_js_lock_should_not_deadlock#V8
gum-tests -m slow -p /GumJS/Script/crash_on_thread_holding_js_lock_should_not_deadlock#QJS
```