### PR TITLE
Added support for 'size_t' and 'ssize_t' (as discussed privately)

### DIFF
--- a/bindings/gumjs/gumffi.c
+++ b/bindings/gumjs/gumffi.c
@@ -39,13 +39,13 @@ ffi_type ffi_type_##name = {	\
 // - gum_quick_value_from_ffi
 // - gum_v8_value_to_ffi_type
 // - gum_v8_value_from_ffi_type
-#if SIZE_MAX == UINT64_MAX
+#if SIZE_WIDTH == 64
 FFI_TYPEDEF(size_t, UINT64, FFI_TYPE_UINT64);
 FFI_TYPEDEF(ssize_t, SINT64, FFI_TYPE_SINT64);
-#elif SIZE_MAX == UINT32_MAX
+#elif SIZE_WIDTH == 32
 FFI_TYPEDEF(size_t, UINT32, FFI_TYPE_UINT32);
 FFI_TYPEDEF(ssize_t, SINT32, FFI_TYPE_SINT32);
-#elif SIZE_MAX == UINT16_MAX
+#elif SIZE_WIDTH == 16
 FFI_TYPEDEF(size_t, UINT16, FFI_TYPE_UINT16);
 FFI_TYPEDEF(ssize_t, SINT16, FFI_TYPE_SINT16);
 #else

--- a/bindings/gumjs/gumffi.c
+++ b/bindings/gumjs/gumffi.c
@@ -41,7 +41,9 @@ static const GumFFITypeMapping gum_ffi_type_mappings[] =
   { "uint32", &ffi_type_uint32 },
   { "int64", &ffi_type_sint64 },
   { "uint64", &ffi_type_uint64 },
-  { "bool", &ffi_type_schar }
+  { "bool", &ffi_type_schar },
+  { "size_t", &ffi_type_size_t },
+  { "ssize_t", &ffi_type_ssize_t }
 };
 
 static const GumFFIABIMapping gum_ffi_abi_mappings[] =

--- a/bindings/gumjs/gumffi.c
+++ b/bindings/gumjs/gumffi.c
@@ -45,11 +45,30 @@ FFI_TYPEDEF(ssize_t, SINT64, FFI_TYPE_SINT64);
 #elif SIZE_WIDTH == 32
 FFI_TYPEDEF(size_t, UINT32, FFI_TYPE_UINT32);
 FFI_TYPEDEF(ssize_t, SINT32, FFI_TYPE_SINT32);
-#elif SIZE_WIDTH == 16
+#elif SIZE_WIDTH == 16  
 FFI_TYPEDEF(size_t, UINT16, FFI_TYPE_UINT16);
 FFI_TYPEDEF(ssize_t, SINT16, FFI_TYPE_SINT16);
 #else
-# error "size_t size not supported"
+// SIZE_MAX fallback for Android
+
+#   if SIZE_MAX == UINT64_MAX
+FFI_TYPEDEF(size_t, UINT64, FFI_TYPE_UINT64);
+FFI_TYPEDEF(ssize_t, SINT64, FFI_TYPE_SINT64);
+#   elif SIZE_MAX == UINT32_MAX
+FFI_TYPEDEF(size_t, UINT32, FFI_TYPE_UINT32);
+FFI_TYPEDEF(ssize_t, SINT32, FFI_TYPE_SINT32);
+#   elif SIZE_MAX == UINT16_MAX
+FFI_TYPEDEF(size_t, UINT16, FFI_TYPE_UINT16);
+FFI_TYPEDEF(ssize_t, SINT16, FFI_TYPE_SINT16);
+#   else
+#     define VALUE_TO_STRING(x) #x
+#     define VALUE(x) VALUE_TO_STRING(x)
+#     define VAR_NAME_VALUE(var) #var "="  VALUE(var)
+#     pragma message(VAR_NAME_VALUE(SIZE_MAX))
+#     pragma message(VAR_NAME_VALUE(SIZE_WIDTH))
+#     pragma message(VAR_NAME_VALUE(__SIZE_WIDTH__))
+#     error "size_t size not supported" 
+#   endif
 #endif
 
 

--- a/bindings/gumjs/gumffi.c
+++ b/bindings/gumjs/gumffi.c
@@ -23,7 +23,7 @@ typedef signed int   SINT64 __attribute__((__mode__(__DI__)));
 struct struct_align_##name {			\
   char c;					\
   type x;					\
-};						\
+};                \
 ffi_type ffi_type_##name = {	\
   sizeof(type),					\
   offsetof(struct struct_align_##name, x),	\

--- a/bindings/gumjs/gumffi.h
+++ b/bindings/gumjs/gumffi.h
@@ -17,8 +17,8 @@ G_BEGIN_DECLS
 typedef union _GumFFIValue GumFFIValue;
 
 // strong typedef in gumffi.c
-ffi_type ffi_type_size_t;
-ffi_type ffi_type_ssize_t;
+FFI_EXTERN ffi_type ffi_type_size_t;
+FFI_EXTERN ffi_type ffi_type_ssize_t;
 
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
 

--- a/bindings/gumjs/gumffi.h
+++ b/bindings/gumjs/gumffi.h
@@ -41,6 +41,7 @@ union _GumFFIValue
   guint32 v_uint32;
   gint64 v_sint64;
   guint64 v_uint64;
+  gsize v_gsize;
 };
 
 #else

--- a/bindings/gumjs/gumffi.h
+++ b/bindings/gumjs/gumffi.h
@@ -10,10 +10,22 @@
 
 #include <ffi.h>
 #include <glib-object.h>
+#include <stdint.h>
 
 G_BEGIN_DECLS
 
 typedef union _GumFFIValue GumFFIValue;
+
+// Requires careful testing, SIZE_MAX must be 65535 at least, but also could exceed UINT_MAX
+#if SIZE_MAX == ULONG_MAX
+# define ffi_type_size_t       ffi_type_ulong
+# define ffi_type_ssize_t       ffi_type_slong
+#elif SIZE_MAX == UINT_MAX
+# define ffi_type_size_t       ffi_type_uint
+# define ffi_type_ssize_t       ffi_type_sint
+#else
+ #error "size_t size not supported"
+#endif
 
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
 

--- a/bindings/gumjs/gumffi.h
+++ b/bindings/gumjs/gumffi.h
@@ -16,16 +16,9 @@ G_BEGIN_DECLS
 
 typedef union _GumFFIValue GumFFIValue;
 
-// Requires careful testing, SIZE_MAX must be 65535 at least, but also could exceed UINT_MAX
-#if SIZE_MAX == ULONG_MAX
-# define ffi_type_size_t       ffi_type_ulong
-# define ffi_type_ssize_t       ffi_type_slong
-#elif SIZE_MAX == UINT_MAX
-# define ffi_type_size_t       ffi_type_uint
-# define ffi_type_ssize_t       ffi_type_sint
-#else
- #error "size_t size not supported"
-#endif
+// strong typedef in gumffi.c
+ffi_type ffi_type_size_t;
+ffi_type ffi_type_ssize_t;
 
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
 

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -4140,10 +4140,39 @@ gum_quick_value_to_ffi (JSContext * ctx,
   gint64 i64;
   guint64 u64;
   gdouble d;
-
+  
+  //printf("to ffi type is size_t %d, type is uint64_t %d, type size=%zu\n", type == &ffi_type_size_t, type == &ffi_type_uint64, type->size);
   if (type == &ffi_type_void)
   {
     val->v_pointer = NULL;
+  }
+  else if (type == &ffi_type_size_t)
+  {
+    if (type->size == 8)
+    {
+      if (!_gum_quick_uint64_get (ctx, sval, core, &u64))
+        return FALSE;
+      //val->v_gsize = u64;
+      val->v_uint64 = u64;
+    }
+    else if (type->size == 4)
+    {
+      if (!_gum_quick_uint_get (ctx, sval, &u))
+        return FALSE;
+      //val->v_gsize = u;
+      val->v_uint32 = u;
+    }
+    else if (type->size == 2)
+    {
+      if (!_gum_quick_uint_get (ctx, sval, &u))
+        return FALSE;
+      //val->v_gsize = u;
+      val->v_uint16 = u;
+    }
+    else
+    {
+      g_assert_not_reached ();
+    }    
   }
   else if (type == &ffi_type_pointer)
   {
@@ -4270,9 +4299,29 @@ gum_quick_value_from_ffi (JSContext * ctx,
                           const ffi_type * type,
                           GumQuickCore * core)
 {
+  //printf("from ffi type is size_t %d, type is uint64_t %d, type size=%zu\n", type == &ffi_type_size_t, type == &ffi_type_uint64, type->size);
   if (type == &ffi_type_void)
   {
     return JS_UNDEFINED;
+  }
+  else if (type == &ffi_type_size_t)
+  {
+    if (type->size == 8)
+    {
+      return _gum_quick_uint64_new (ctx, val->v_uint64, core);
+    }
+    else if (type->size == 4)
+    {
+      return _gum_quick_uint64_new (ctx, val->v_uint32, core);
+    }
+    else if (type->size == 2)
+    {
+      return _gum_quick_uint64_new (ctx, val->v_uint16, core);
+    }
+    else
+    {
+      g_assert_not_reached ();
+    }    
   }
   else if (type == &ffi_type_pointer)
   {

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -4151,7 +4151,7 @@ gum_quick_value_to_ffi (JSContext * ctx,
     // temporary storing in guint64 has to be tested on (physical) 32bit arch
     if (!_gum_quick_uint64_get (ctx, sval, core, &u64))
       return FALSE;
-    printf("QJS size_t to native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
+    //printf("QJS size_t to native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
     
     switch (type->size) {
       case 8:
@@ -4174,7 +4174,7 @@ gum_quick_value_to_ffi (JSContext * ctx,
     // temporary storing in guint64 has to be tested on (physical) 32bit arch
     if (!_gum_quick_int64_get (ctx, sval, core, &i64))
       return FALSE;
-    printf("QJS ssize_t to native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);
+    //printf("QJS ssize_t to native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);
     
     switch (type->size) {
       case 8:
@@ -4339,7 +4339,7 @@ gum_quick_value_from_ffi (JSContext * ctx,
         g_assert_not_reached ();
     }
     
-    printf("QJS size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);    
+    //printf("QJS size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);    
     return _gum_quick_uint64_new (ctx, u64, core);
   }
   else if (type == &ffi_type_ssize_t)
@@ -4360,7 +4360,7 @@ gum_quick_value_from_ffi (JSContext * ctx,
         g_assert_not_reached ();
     }
     
-    printf("QJS ssize_t from native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);    
+    //printf("QJS ssize_t from native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);    
     return _gum_quick_int64_new (ctx, i64, core);
   }
   else if (type == &ffi_type_pointer)

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -4152,7 +4152,8 @@ gum_quick_value_to_ffi (JSContext * ctx,
     // temporary storing in guint64 has to be tested on (physical) 32bit arch
     if (!_gum_quick_uint64_get (ctx, sval, core, &u64))
       return FALSE;
-    printf("QJS size_t to native %lu (%#016lx)\n", u64, u64);
+    printf("QJS size_t to native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
+    
     switch (type->size) {
       case 8:
         val->v_uint64 = u64;
@@ -4317,7 +4318,7 @@ gum_quick_value_from_ffi (JSContext * ctx,
         g_assert_not_reached ();
     }
     
-    printf("QJS size_t from native %lu (%#016lx)\n", u64, u64);
+    printf("QJS size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);    
     return _gum_quick_uint64_new (ctx, u64, core);
   }
   else if (type == &ffi_type_pointer)

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3358,7 +3358,7 @@ gum_v8_value_to_ffi_type (GumV8Core * core,
     if (!_gum_v8_uint64_get (svalue, &tmpU64, core))
       return FALSE;
     
-    printf("V8 size_t to native %" PRIu64 " (%#" PRIx64 ")\n", tmpU64, tmpU64);
+    //printf("V8 size_t to native %" PRIu64 " (%#" PRIx64 ")\n", tmpU64, tmpU64);
 
     switch (type->size)
     {
@@ -3384,7 +3384,7 @@ gum_v8_value_to_ffi_type (GumV8Core * core,
     if (!_gum_v8_int64_get (svalue, &tmpI64, core))
       return FALSE;
     
-    printf("V8 ssize_t to native %" PRId64 " (%#" PRIx64 ")\n", tmpI64, tmpI64);
+    //printf("V8 ssize_t to native %" PRId64 " (%#" PRIx64 ")\n", tmpI64, tmpI64);
 
     switch (type->size)
     {
@@ -3564,7 +3564,7 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
         return FALSE;
     }
 
-    printf("V8 size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
+    //printf("V8 size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
     *svalue = _gum_v8_uint64_new (u64, core);
   }
   else if (type == &ffi_type_ssize_t)
@@ -3586,7 +3586,7 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
         return FALSE;
     }
 
-    printf("V8 ssize_t from native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);
+    //printf("V8 ssize_t from native %" PRId64 " (%#" PRIx64 ")\n", i64, i64);
     *svalue = _gum_v8_int64_new (i64, core);
   }
   else if (type == &ffi_type_pointer)

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3358,7 +3358,8 @@ gum_v8_value_to_ffi_type (GumV8Core * core,
     guint64 tmpU64;
     if (!_gum_v8_uint64_get (svalue, &tmpU64, core))
       return FALSE;
-    printf("V8 size_t to native %lu (%#016lx)\n", tmpU64, tmpU64);
+    
+    printf("V8 size_t to native %" PRIu64 " (%#" PRIx64 ")\n", tmpU64, tmpU64);
 
     switch (type->size)
     {
@@ -3528,7 +3529,7 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
       case 8:
         u64 = value->v_uint64;
         break;
-      case 4:
+      case 4:    
         u64 = value->v_uint32;
         break;  
       case 2:
@@ -3539,7 +3540,7 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
         return FALSE;
     }
 
-    printf("V8 size_t from native %lu (%#016lx)\n", u64, u64);
+    printf("V8 size_t from native %" PRIu64 " (%#" PRIx64 ")\n", u64, u64);
     *svalue = _gum_v8_uint64_new (u64, core);
   }
   else if (type == &ffi_type_pointer)

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -1069,20 +1069,19 @@ TESTCASE (native_function_can_be_invoked_with_size_t)
   // 32                               int64         <->   int32 (temporary gint64 during conversion)
   // 16                               int64         <->   int16 (temporary gint64 during conversion)
   //
-  // Issues
+  // Additional notes
   // 
-  // 1) As on the JS end 'size_t' shall be represented as Uint64, values have to be created with the 'uint64()'
-  //    constructor (as done in the test cases). Maybe an alias should be created, which allows using 'size_t("number string")'
-  // 2) ssize_t seems to be POSIX defined, but not C99
-  // 3) ptrdiff_t is not implemented (but C99 defined) ... normally ssize_t should be able to store ptrdiff_t, but this requires
+  // 1) ssize_t seems to be POSIX defined, but not C99
+  // 2) ptrdiff_t is not implemented (but C99 defined) ... normally ssize_t should be able to store ptrdiff_t, but this requires
   //    further testing
-  // 4) Focus was put on size_t implementation, which is tested and working. ssize_t/ptrdiff_t are not in main scope
+  // 3) Focus was put on size_t implementation, which is tested and working. ssize_t/ptrdiff_t are not in main scope
   //    and require additional testing (+ implementation of ptrdiff_t, if not casted to size_t).
   //    The test for 'ssize_t' uses a simple pass-through function which is called with a) PTRDIFF_MAX and b) PTRDIFF_MIN
   //
   // External:
   // - discussion on SSIZE_MAX weirdness https://sourceware.org/bugzilla/show_bug.cgi?id=13575
 
+  // size_t tests
 
   // returns SIZE_MAX
   sprintf(ret, "\"%zu\"", SIZE_MAX);
@@ -2120,12 +2119,12 @@ static size_t gum_add_size(size_t sz) {
 }
 
 static size_t gum_pass_size(size_t sz) {
-  printf("value in gum_pass_size %zu\n", sz);
+  //printf("value in gum_pass_size %zu\n", sz);
   return sz;
 }
 
 static size_t gum_pass_ssize(ssize_t ssz) {
-  printf("value in gum_pass_ssize %zd\n", ssz);
+  //printf("value in gum_pass_ssize %zd\n", ssz);
   return ssz;
 }
 

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -395,6 +395,7 @@ static gint gum_clobber_system_error (gint value);
 static size_t gum_get_size_max(void);
 static gboolean gum_test_size_max(size_t sz);
 static size_t gum_add_size(size_t sz);
+static size_t gum_pass_size(size_t u64);
 static gint gum_get_answer_to_life_universe_and_everything (void);
 static gint gum_toupper (gchar * str, gint limit);
 static gint64 gum_classify_timestamp (gint64 timestamp);
@@ -1091,6 +1092,7 @@ TESTCASE (native_function_can_be_invoked_with_size_t)
   //    run the tests for different architectures).
   //    Note: If this approach works, i see no need to extend '_GumFFIValue' (gumffi.h) with 'gsize' and 'gssize'.
 
+
   // returns SIZE_MAX
   sprintf(ret, "\"%zu\"", SIZE_MAX);
   COMPILE_AND_LOAD_SCRIPT (
@@ -1108,7 +1110,7 @@ TESTCASE (native_function_can_be_invoked_with_size_t)
     gum_add_size, arg);
   EXPECT_SEND_MESSAGE_WITH (ret);
   EXPECT_NO_MESSAGES ();
-  
+
   // checks if given size_t argument is SIZE_MAX
   sprintf(arg, "%zu", SIZE_MAX);
   COMPILE_AND_LOAD_SCRIPT (
@@ -1117,6 +1119,17 @@ TESTCASE (native_function_can_be_invoked_with_size_t)
       gum_test_size_max, arg);
   EXPECT_SEND_MESSAGE_WITH ("true");
   EXPECT_NO_MESSAGES ();
+
+
+  sprintf(arg, "%zu", SIZE_MAX);
+  sprintf(ret, "\"%zu\"", SIZE_MAX);
+  COMPILE_AND_LOAD_SCRIPT (
+    "var passSize = new NativeFunction(" GUM_PTR_CONST ", 'size_t', ['size_t']);"
+    "send(passSize(uint64(\"%s\")));",
+    gum_pass_size, arg);
+  EXPECT_SEND_MESSAGE_WITH (ret);
+  EXPECT_NO_MESSAGES ();
+
 
   // ToDo: ssize_t test 
 }
@@ -2092,6 +2105,11 @@ static gboolean gum_test_size_max(size_t sz) {
 
 static size_t gum_add_size(size_t sz) {
   return sz + (size_t) 1;
+}
+
+static size_t gum_pass_size(size_t sz) {
+  printf("value in gum_pass_size %zu\n", sz);
+  return sz;
 }
 
 static gint

--- a/tests/run-android-x86_64_new.sh
+++ b/tests/run-android-x86_64_new.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+arch=arm
+#apex_libdir=/apex/com.android.runtime/lib64
+apex_libdir=/system/lib
+
+remote_prefix=/data/local/tmp/frida-tests-$arch
+
+gum_tests=$(dirname "$0")
+cd "$gum_tests/../../build/tmp-android-$arch/frida-gum" || exit 1
+pwd
+. ../../frida-meson-env-linux-x86_64.rc
+
+ninja || exit 1
+cd tests
+adb shell "mkdir $remote_prefix"
+adb push gum-tests data $remote_prefix || exit 1
+adb shell "LD_LIBRARY_PATH='$apex_libdir' $remote_prefix/gum-tests $@"

--- a/tests/run-host-linux-x86_64-target-arm.sh
+++ b/tests/run-host-linux-x86_64-target-arm.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# build:  linux_x86_64
+# host:   linux_x86_64
+# target: Android 9; armeabi/armeabi-v7a
+
 arch=arm
 #apex_libdir=/apex/com.android.runtime/lib64
 apex_libdir=/system/lib


### PR DESCRIPTION
- 'size_t' is converted to UInt64 for JS runtime
- 'ssize_t' is converted to Int64 for JS runtime
- for usage see test cases