### PR TITLE
Fix linking during .gir generation

### DIFF
--- a/gum/meson.build
+++ b/gum/meson.build
@@ -309,7 +309,7 @@ if gir.found()
     export_packages: 'gum',
     includes: ['GLib-2.0', 'GObject-2.0', 'Gio-2.0'],
     header: 'gum/gum.h',
-    extra_args: gir_args + extra_libs_private,
+    extra_args: gir_args + extra_gir_args_private,
     install: true,
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -193,6 +193,7 @@ lzma_dep = dependency('liblzma')
 extra_deps = []
 extra_requires_private = []
 extra_libs_private = []
+extra_gir_args_private = []
 
 glib_flavor_src = '''
 #include <glib.h>
@@ -231,18 +232,17 @@ elif host_os_family == 'linux' or host_os_family == 'qnx'
 endif
 
 if host_os_family == 'linux' or host_os_family == 'qnx'
-  have_libelf = cc.has_header('libelf.h')
-  if not have_libelf
-    error('libelf is required')
-  endif
+  elf_dep = dependency('libelf')
+  extra_deps += [elf_dep]
   have_libdwarf = cc.has_header('libdwarf.h')
   if not have_libdwarf
     error('libdwarf is required')
   endif
   if host_os_family == 'linux'
-    extra_libs_private += ['-ldwarf', '-lelf', '-ldl', '-lz']
+    extra_libs_private += ['-ldwarf', '-ldl', '-lz']
+    extra_gir_args_private += ['--extra-library=dwarf']
   else
-    extra_libs_private += ['-ldwarf', '-lelf', '-lz']
+    extra_libs_private += ['-ldwarf', '-lz']
   endif
 else
   have_libdwarf = false


### PR DESCRIPTION
During set-up I ran into another bug that I somehow missed in the original PR.

When linking against `libelf` and `libdwarf` using `extra_libs_private` it will only add `-lelf` and `-ldwarf`. However this apparently doesn't do what I thought it did so you'll get a bunch of errors for missing symbols in `libelf`.

It turns out that `g-ir-scanner` expects _instead_ to receive e.g.: `--extra-library=elf`. By using `dependency` and having it link against `gum` (via `extra_deps`) Meson will automatically add `--extra-library=elf`.

So we can either use a `dependency`, or we can add the `--extra-library=` flags manually into `extra_libs_private`