### PR TITLE
Fix mishandled relocation of rip relative indirect call in x86_64

### DIFF
--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -538,6 +538,7 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
 {
   cs_insn * insn = ctx->insn;
   cs_x86 * x86 = &insn->detail->x86;
+  GumX86Writer * cw = ctx->code_writer;
   guint mod, reg, rm;
   gboolean is_rip_relative;
   GumCpuReg cpu_regs[7] = {
@@ -575,14 +576,11 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
      */
     if (cpu_regs[i] == other_reg)
       continue;
-    else if (insn->id == X86_INS_CMPXCHG && cpu_regs[i] == GUM_REG_RAX)
+    if (insn->id == X86_INS_CMPXCHG && cpu_regs[i] == GUM_REG_RAX)
       continue;
-    else if (insn->id == X86_INS_CALL &&
-        !(cpu_regs[i] == GUM_REG_RBX || cpu_regs[i] == GUM_REG_RBP))
+    if (cs_reg_read (self->capstone, ctx->insn, cs_regs[i]))
       continue;
-    else if (cs_reg_read (self->capstone, ctx->insn, cs_regs[i]))
-      continue;
-    else if (cs_reg_write (self->capstone, ctx->insn, cs_regs[i]))
+    if (cs_reg_write (self->capstone, ctx->insn, cs_regs[i]))
       continue;
     rip_reg_index = i;
   }
@@ -594,23 +592,22 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
 
   if (insn->id == X86_INS_PUSH)
   {
-    gum_x86_writer_put_push_reg (ctx->code_writer, GUM_REG_RAX);
+    gum_x86_writer_put_push_reg (cw, GUM_REG_RAX);
   }
 
   if (target_abi == GUM_ABI_UNIX)
   {
-    gum_x86_writer_put_lea_reg_reg_offset (ctx->code_writer, GUM_REG_RSP,
-        GUM_REG_RSP, -GUM_RED_ZONE_SIZE);
+    gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_REG_RSP, GUM_REG_RSP,
+        -GUM_RED_ZONE_SIZE);
   }
-  gum_x86_writer_put_push_reg (ctx->code_writer, rip_reg);
-  gum_x86_writer_put_mov_reg_address (ctx->code_writer, rip_reg,
+  gum_x86_writer_put_push_reg (cw, rip_reg);
+  gum_x86_writer_put_mov_reg_address (cw, rip_reg,
       GUM_ADDRESS (ctx->end));
 
   if (insn->id == X86_INS_PUSH)
   {
-    gum_x86_writer_put_mov_reg_reg_offset_ptr (ctx->code_writer, rip_reg,
-        rip_reg, x86->disp);
-    gum_x86_writer_put_mov_reg_offset_ptr_reg (ctx->code_writer,
+    gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, rip_reg, rip_reg, x86->disp);
+    gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
         GUM_REG_RSP,
         0x08 + ((target_abi == GUM_ABI_UNIX) ? GUM_RED_ZONE_SIZE : 0),
         rip_reg);
@@ -619,14 +616,14 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   {
     gum_memcpy (code, ctx->start, ctx->len);
     code[x86->encoding.modrm_offset] = (mod << 6) | (reg << 3) | rm;
-    gum_x86_writer_put_bytes (ctx->code_writer, code, ctx->len);
+    gum_x86_writer_put_bytes (cw, code, ctx->len);
   }
 
-  gum_x86_writer_put_pop_reg (ctx->code_writer, rip_reg);
+  gum_x86_writer_put_pop_reg (cw, rip_reg);
   if (target_abi == GUM_ABI_UNIX)
   {
-    gum_x86_writer_put_lea_reg_reg_offset (ctx->code_writer, GUM_REG_RSP,
-        GUM_REG_RSP, GUM_RED_ZONE_SIZE);
+    gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_REG_RSP, GUM_REG_RSP,
+        GUM_RED_ZONE_SIZE);
   }
 
   return TRUE;

--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -319,7 +319,6 @@ gum_x86_relocator_write_one_instruction (GumX86Relocator * self)
       break;
   }
 
-
   if (!rewritten)
     gum_x86_writer_put_bytes (ctx.code_writer, ctx.start, ctx.len);
 
@@ -464,15 +463,16 @@ gum_x86_relocator_rewrite_unconditional_branch (GumX86Relocator * self,
 
     return TRUE;
   }
-  else if ((ctx->insn->id == X86_INS_CALL || ctx->insn->id == X86_INS_JMP)
-          && op->type == X86_OP_MEM)
+  else if ((ctx->insn->id == X86_INS_CALL || ctx->insn->id == X86_INS_JMP) &&
+      op->type == X86_OP_MEM)
   {
-    if (self->output->target_cpu == GUM_CPU_AMD64) {
-      return gum_x86_relocator_rewrite_if_rip_relative(self, ctx);
-    }
+    if (self->output->target_cpu == GUM_CPU_AMD64)
+      return gum_x86_relocator_rewrite_if_rip_relative (self, ctx);
+
     return FALSE;
   }
-  else if (ctx->insn->id == X86_INS_JMP && op->type == X86_OP_IMM && op->size == 8)
+  else if (ctx->insn->id == X86_INS_JMP && op->type == X86_OP_IMM &&
+      op->size == 8)
   {
     return FALSE;
   }
@@ -552,7 +552,7 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   GumCpuReg other_reg, rip_reg;
   GumAbiType target_abi = self->output->target_abi;
   guint8 code[16];
-  
+
   if (x86->encoding.modrm_offset == 0)
     return FALSE;
 
@@ -577,7 +577,8 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
       continue;
     else if (insn->id == X86_INS_CMPXCHG && cpu_regs[i] == GUM_REG_RAX)
       continue;
-    else if (insn->id == X86_INS_CALL && !(cpu_regs[i] == GUM_REG_RBX || cpu_regs[i] == GUM_REG_RBP))
+    else if (insn->id == X86_INS_CALL &&
+        !(cpu_regs[i] == GUM_REG_RBX || cpu_regs[i] == GUM_REG_RBP))
       continue;
     else if (cs_reg_read (self->capstone, ctx->insn, cs_regs[i]))
       continue;

--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -570,10 +570,6 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   rip_reg_index = -1;
   for (i = 0; i != G_N_ELEMENTS (cs_regs) && rip_reg_index == -1; i++)
   {
-    /*
-     * FIXME: These first two checks shouldn't be necessary.
-     *        Need to have a closer look at capstone's mappings.
-     */
     if (cpu_regs[i] == other_reg)
       continue;
     if (insn->id == X86_INS_CMPXCHG && cpu_regs[i] == GUM_REG_RAX)

--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -319,6 +319,7 @@ gum_x86_relocator_write_one_instruction (GumX86Relocator * self)
       break;
   }
 
+
   if (!rewritten)
     gum_x86_writer_put_bytes (ctx.code_writer, ctx.start, ctx.len);
 
@@ -463,9 +464,15 @@ gum_x86_relocator_rewrite_unconditional_branch (GumX86Relocator * self,
 
     return TRUE;
   }
-  else if (((ctx->insn->id == X86_INS_CALL || ctx->insn->id == X86_INS_JMP)
-          && op->type == X86_OP_MEM) ||
-      (ctx->insn->id == X86_INS_JMP && op->type == X86_OP_IMM && op->size == 8))
+  else if ((ctx->insn->id == X86_INS_CALL || ctx->insn->id == X86_INS_JMP)
+          && op->type == X86_OP_MEM)
+  {
+    if (self->output->target_cpu == GUM_CPU_AMD64) {
+      return gum_x86_relocator_rewrite_if_rip_relative(self, ctx);
+    }
+    return FALSE;
+  }
+  else if (ctx->insn->id == X86_INS_JMP && op->type == X86_OP_IMM && op->size == 8)
   {
     return FALSE;
   }
@@ -545,7 +552,7 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   GumCpuReg other_reg, rip_reg;
   GumAbiType target_abi = self->output->target_abi;
   guint8 code[16];
-
+  
   if (x86->encoding.modrm_offset == 0)
     return FALSE;
 
@@ -569,6 +576,8 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
     if (cpu_regs[i] == other_reg)
       continue;
     else if (insn->id == X86_INS_CMPXCHG && cpu_regs[i] == GUM_REG_RAX)
+      continue;
+    else if (insn->id == X86_INS_CALL && !(cpu_regs[i] == GUM_REG_RBX || cpu_regs[i] == GUM_REG_RBP))
       continue;
     else if (cs_reg_read (self->capstone, ctx->insn, cs_regs[i]))
       continue;

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -20,6 +20,9 @@ TESTLIST_BEGIN (interceptor)
   TESTENTRY (absolute_indirect_proxy_function)
   TESTENTRY (two_indirects_to_function)
   TESTENTRY (relocation_of_early_call)
+#if GLIB_SIZEOF_VOID_P == 8
+  TESTENTRY (relocation_of_early_rip_relative_call)
+#endif
 #endif
 
   TESTENTRY (attach_one)
@@ -67,6 +70,7 @@ TESTLIST_BEGIN (interceptor)
 #ifdef HAVE_QNX
   TESTENTRY (intercept_malloc_and_create_thread)
 #endif
+
 TESTLIST_END ()
 
 #ifdef HAVE_QNX
@@ -550,6 +554,21 @@ TESTCASE (relocation_of_early_call)
   proxy_func_free (proxy_func);
 }
 
+#if GLIB_SIZEOF_VOID_P == 8
+TESTCASE (relocation_of_early_rip_relative_call)
+{
+  ProxyFunc proxy_func;
+
+  proxy_func = proxy_func_new_early_rip_relative_call_with_target(target_function);
+
+  interceptor_fixture_attach (fixture, 0, proxy_func, '>', '<');
+  proxy_func (fixture->result);
+  g_assert_cmpstr (fixture->result->str, ==, ">|<");
+  interceptor_fixture_detach (fixture, 0);
+
+  proxy_func_free (proxy_func);
+}
+#endif /* GLIB_SIZEOF_VOID_P */
 #endif /* HAVE_I386 */
 
 #ifndef HAVE_ASAN

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -70,7 +70,6 @@ TESTLIST_BEGIN (interceptor)
 #ifdef HAVE_QNX
   TESTENTRY (intercept_malloc_and_create_thread)
 #endif
-
 TESTLIST_END ()
 
 #ifdef HAVE_QNX
@@ -555,11 +554,13 @@ TESTCASE (relocation_of_early_call)
 }
 
 #if GLIB_SIZEOF_VOID_P == 8
+
 TESTCASE (relocation_of_early_rip_relative_call)
 {
   ProxyFunc proxy_func;
 
-  proxy_func = proxy_func_new_early_rip_relative_call_with_target(target_function);
+  proxy_func =
+      proxy_func_new_early_rip_relative_call_with_target (target_function);
 
   interceptor_fixture_attach (fixture, 0, proxy_func, '>', '<');
   proxy_func (fixture->result);
@@ -568,7 +569,9 @@ TESTCASE (relocation_of_early_rip_relative_call)
 
   proxy_func_free (proxy_func);
 }
+
 #endif /* GLIB_SIZEOF_VOID_P */
+
 #endif /* HAVE_I386 */
 
 #ifndef HAVE_ASAN

--- a/tests/lowlevelhelpers.c
+++ b/tests/lowlevelhelpers.c
@@ -474,7 +474,7 @@ proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func)
 
   code[0] = 0xff; /* call [rip + x] */
   code[1] = 0x15;
-  *((gssize *) (code + 2)) = 13;
+  *((gint32 *) (code + 2)) = 13;
   code += 6;
 
   code[0] = 0x48; /* add rsp, 0x38 */

--- a/tests/lowlevelhelpers.c
+++ b/tests/lowlevelhelpers.c
@@ -452,6 +452,46 @@ proxy_func_new_two_jumps_with_target (TargetFunc target_func)
   return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
 }
 
+#if GLIB_SIZEOF_VOID_P == 8
+ProxyFunc
+proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func)
+{
+  GumAddressSpec addr_spec;
+  guint8 * func, * code;
+
+  addr_spec.near_address = target_func;
+  addr_spec.max_distance = G_MAXINT32 - gum_query_page_size ();
+  func = (guint8 *) gum_alloc_n_pages_near (1, GUM_PAGE_RWX, &addr_spec);
+  
+  code = func;
+
+  code[0] = 0x48;
+  code[1] = 0x83;
+  code[2] = 0xec;
+  code[3] = 0x38; // sub rsp, 0x38
+
+  code += 4;
+  code[0] = 0xff;
+  code[1] = 0x15;
+
+  *((gssize *) (code + 2)) = 13; // call [rip + x]
+
+  code += 6;
+  code[0] = 0x48;
+  code[1] = 0x83;
+  code[2] = 0xc4;
+  code[3] = 0x38; // add rsp, 0x38
+
+  code += 4;
+  code[0] = 0xc3; // retn
+  
+  code += 9;
+  *((guint64 *) (code)) = (guint64) target_func; // abs addr
+
+  return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
+}
+#endif
+
 ProxyFunc
 proxy_func_new_early_call_with_target (TargetFunc target_func)
 {

--- a/tests/lowlevelhelpers.c
+++ b/tests/lowlevelhelpers.c
@@ -452,48 +452,6 @@ proxy_func_new_two_jumps_with_target (TargetFunc target_func)
   return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
 }
 
-#if GLIB_SIZEOF_VOID_P == 8
-
-ProxyFunc
-proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func)
-{
-  GumAddressSpec addr_spec;
-  guint8 * func, * code;
-
-  addr_spec.near_address = target_func;
-  addr_spec.max_distance = G_MAXINT32 - gum_query_page_size ();
-  func = gum_alloc_n_pages_near (1, GUM_PAGE_RWX, &addr_spec);
-
-  code = func;
-
-  code[0] = 0x48; /* sub rsp, 0x38 */
-  code[1] = 0x83;
-  code[2] = 0xec;
-  code[3] = 0x38;
-  code += 4;
-
-  code[0] = 0xff; /* call [rip + x] */
-  code[1] = 0x15;
-  *((gint32 *) (code + 2)) = 13;
-  code += 6;
-
-  code[0] = 0x48; /* add rsp, 0x38 */
-  code[1] = 0x83;
-  code[2] = 0xc4;
-  code[3] = 0x38;
-  code += 4;
-
-  code[0] = 0xc3; /* ret */
-  code++;
-
-  code += 8;
-  *((TargetFunc *) code) = target_func;
-
-  return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
-}
-
-#endif
-
 ProxyFunc
 proxy_func_new_early_call_with_target (TargetFunc target_func)
 {
@@ -541,6 +499,48 @@ proxy_func_new_early_call_with_target (TargetFunc target_func)
 
   return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
 }
+
+#if GLIB_SIZEOF_VOID_P == 8
+
+ProxyFunc
+proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func)
+{
+  GumAddressSpec addr_spec;
+  guint8 * func, * code;
+
+  addr_spec.near_address = target_func;
+  addr_spec.max_distance = G_MAXINT32 - gum_query_page_size ();
+  func = gum_alloc_n_pages_near (1, GUM_PAGE_RWX, &addr_spec);
+
+  code = func;
+
+  code[0] = 0x48; /* sub rsp, 0x38 */
+  code[1] = 0x83;
+  code[2] = 0xec;
+  code[3] = 0x38;
+  code += 4;
+
+  code[0] = 0xff; /* call [rip + x] */
+  code[1] = 0x15;
+  *((gint32 *) (code + 2)) = 13;
+  code += 6;
+
+  code[0] = 0x48; /* add rsp, 0x38 */
+  code[1] = 0x83;
+  code[2] = 0xc4;
+  code[3] = 0x38;
+  code += 4;
+
+  code[0] = 0xc3; /* ret */
+  code++;
+
+  code += 8;
+  *((TargetFunc *) code) = target_func;
+
+  return GUM_POINTER_TO_FUNCPTR (ProxyFunc, func);
+}
+
+#endif
 
 void
 proxy_func_free (ProxyFunc proxy_func)

--- a/tests/lowlevelhelpers.h
+++ b/tests/lowlevelhelpers.h
@@ -47,6 +47,9 @@ ProxyFunc proxy_func_new_relative_with_target (TargetFunc target_func);
 ProxyFunc proxy_func_new_absolute_indirect_with_target (TargetFunc target_func);
 ProxyFunc proxy_func_new_two_jumps_with_target (TargetFunc target_func);
 ProxyFunc proxy_func_new_early_call_with_target (TargetFunc target_func);
+#if GLIB_SIZEOF_VOID_P == 8
+ProxyFunc proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func);
+#endif
 void proxy_func_free (ProxyFunc proxy_func);
 #endif
 

--- a/tests/lowlevelhelpers.h
+++ b/tests/lowlevelhelpers.h
@@ -48,7 +48,8 @@ ProxyFunc proxy_func_new_absolute_indirect_with_target (TargetFunc target_func);
 ProxyFunc proxy_func_new_two_jumps_with_target (TargetFunc target_func);
 ProxyFunc proxy_func_new_early_call_with_target (TargetFunc target_func);
 #if GLIB_SIZEOF_VOID_P == 8
-ProxyFunc proxy_func_new_early_rip_relative_call_with_target (TargetFunc target_func);
+ProxyFunc proxy_func_new_early_rip_relative_call_with_target (
+    TargetFunc target_func);
 #endif
 void proxy_func_free (ProxyFunc proxy_func);
 #endif


### PR DESCRIPTION
`FF 15 12 34 56 78` behave differently under x86 and x86_64.

x86:
```
0:  ff 15 12 34 56 78       call   DWORD PTR ds:0x78563412
```
x64:
```
0:  ff 15 12 34 56 78       call   QWORD PTR [rip+0x78563412]        # 0x78563418
```

In x86_64, it's a call to the value of a rip relative address, 
hence should be handled by the rip_relative* routine.