### PR TITLE
Handle permanent entries on darwin codesegment

### DIFF
--- a/gum/backend-darwin/gumcodesegment-darwin.c
+++ b/gum/backend-darwin/gumcodesegment-darwin.c
@@ -455,6 +455,20 @@ gum_code_segment_try_remap_locally (GumCodeSegment * self,
       VM_FLAGS_OVERWRITE | VM_FLAGS_FIXED, self_task, source_address, TRUE,
       &cur_protection, &max_protection, VM_INHERIT_COPY);
 
+  if (kr == KERN_NO_SPACE)
+  {
+    /* Get rid of permanent map entries in target range. */
+    mach_vm_protect (self_task, address, source_size, FALSE,
+        PROT_READ | PROT_WRITE | VM_PROT_COPY);
+
+    kr = mach_vm_remap (self_task, &address, source_size, 0,
+        VM_FLAGS_OVERWRITE | VM_FLAGS_FIXED, self_task, source_address, TRUE,
+        &cur_protection, &max_protection, VM_INHERIT_COPY);
+
+    mach_vm_protect (self_task, address, source_size, FALSE,
+        PROT_READ | PROT_EXEC);
+  }
+
   return kr == KERN_SUCCESS;
 }
 


### PR DESCRIPTION
Starting from iOS 14.3 on A12+ devices, `mach_vm_remap` can return `KERN_NO_SPACE` when the target vm map entries are marked as “permanent”.

It happens because `PMAP_CS` is enabled in the kernel, and all executable maps coming from the app itself and dyld have it enforced which also implies the maps are immutable (it is actually controlled by the `vm_map_executable_immutable` boot argument, which is `1` by default and can’t normally be changed).

This change detects and works around the issue by calling `mach_vm_protect` with the `VM_PROT_COPY` flag, to instruct the kernel to implicitly remap the target entries by removing the ”permanent” bit.