### PR TITLE
Fix Instruction operands parsing on x86

### DIFF
--- a/bindings/gumjs/gumquickinstruction.c
+++ b/bindings/gumjs/gumquickinstruction.c
@@ -466,10 +466,7 @@ gum_parse_operands (JSContext * ctx,
         break;
       case X86_OP_IMM:
         type = "imm";
-        if (op->size <= 4)
-          val = JS_NewInt64 (ctx, op->imm);
-        else
-          val = _gum_quick_int64_new (ctx, op->imm, core);
+        val = _gum_quick_int64_new (ctx, op->imm, core);
         break;
       case X86_OP_MEM:
         type = "mem";

--- a/bindings/gumjs/gumv8instruction.cpp
+++ b/bindings/gumjs/gumv8instruction.cpp
@@ -449,15 +449,8 @@ gum_parse_operands (const cs_insn * insn,
         break;
       case X86_OP_IMM:
         _gum_v8_object_set_ascii (element, type_key, "imm", core);
-        if (op->size <= 4)
-        {
-          _gum_v8_object_set_int (element, value_key, op->imm, core);
-        }
-        else
-        {
-          _gum_v8_object_set (element, value_key,
+        _gum_v8_object_set (element, value_key,
               _gum_v8_int64_new (op->imm, core), core);
-        }
         break;
       case X86_OP_MEM:
         _gum_v8_object_set_ascii (element, type_key, "mem", core);

--- a/bindings/gumjs/gumv8instruction.cpp
+++ b/bindings/gumjs/gumv8instruction.cpp
@@ -450,7 +450,7 @@ gum_parse_operands (const cs_insn * insn,
       case X86_OP_IMM:
         _gum_v8_object_set_ascii (element, type_key, "imm", core);
         _gum_v8_object_set (element, value_key,
-              _gum_v8_int64_new (op->imm, core), core);
+            _gum_v8_int64_new (op->imm, core), core);
         break;
       case X86_OP_MEM:
         _gum_v8_object_set_ascii (element, type_key, "mem", core);


### PR DESCRIPTION
the `op->imm` field is a 64 bit value in both variants.