### PR TITLE
Stalker/x86: Also emit call probe on jmp insns

### DIFF
--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -3079,6 +3079,12 @@ gum_exec_block_virtualize_branch_insn (GumExecBlock * block,
           is_false, GUM_NO_HINT);
     }
 
+    if (insn->ci->id == X86_INS_JMP)
+    {
+      if (ctx->stalker->any_probes_attached)
+        gum_exec_block_write_call_probe_code (block, &target, gc);
+    }
+
     if (target.is_indirect)
     {
       regular_entry_func = GUM_ENTRYGATE (jmp_mem);


### PR DESCRIPTION
Call probes do not work on imported functions called through the GOT, as
these are indirect jumps with the target taken from the PLT.

Also considering direct jumps as candidates for call probes additionally
allows for call probes to be triggered when called as tail-calls.

This has a performance impact at compile-time on the stalker, but should
have no performance impact at run-time.