### PR TITLE
Stalker: rename and expose cache flushing routine

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -4466,3 +4466,9 @@ gum_is_exclusive_store_insn (const cs_insn * insn)
       return FALSE;
   }
 }
+
+void
+gum_stalker_flush_caches (GumStalker * self)
+{
+    g_warning ("Invalidation unsupported");
+}

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -281,7 +281,7 @@ static GumExecCtx * gum_stalker_create_exec_ctx (GumStalker * self,
     GumEventSink * sink);
 static void gum_stalker_destroy_exec_ctx (GumStalker * self, GumExecCtx * ctx);
 static GumExecCtx * gum_stalker_get_exec_ctx (GumStalker * self);
-static void gum_stalker_invalidate_caches (GumStalker * self);
+void gum_stalker_flush_caches (GumStalker * self);
 
 static void gum_stalker_thaw (GumStalker * self, gpointer code, gsize size);
 static void gum_stalker_freeze (GumStalker * self, gpointer code, gsize size);
@@ -919,7 +919,7 @@ gum_stalker_add_call_probe (GumStalker * self,
 
   gum_spinlock_release (&self->probe_lock);
 
-  gum_stalker_invalidate_caches (self);
+  gum_stalker_flush_caches (self);
 
   return probe.id;
 }
@@ -971,7 +971,7 @@ gum_stalker_remove_call_probe (GumStalker * self,
 
   gum_spinlock_release (&self->probe_lock);
 
-  gum_stalker_invalidate_caches (self);
+  gum_stalker_flush_caches (self);
 }
 
 static void
@@ -1079,7 +1079,7 @@ gum_stalker_get_exec_ctx (GumStalker * self)
 }
 
 static void
-gum_stalker_invalidate_caches (GumStalker * self)
+gum_stalker_flush_caches (GumStalker * self)
 {
   GSList * cur;
 

--- a/gum/backend-mips/gumstalker-mips.c
+++ b/gum/backend-mips/gumstalker-mips.c
@@ -154,3 +154,9 @@ gum_stalker_iterator_put_callout (GumStalkerIterator * self,
                                   GDestroyNotify data_destroy)
 {
 }
+
+void
+gum_stalker_flush_caches (GumStalker * self)
+{
+    g_warning ("Invalidation unsupported");
+}

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -336,7 +336,7 @@ static GumExecCtx * gum_stalker_create_exec_ctx (GumStalker * self,
     GumEventSink * sink);
 static void gum_stalker_destroy_exec_ctx (GumStalker * self, GumExecCtx * ctx);
 static GumExecCtx * gum_stalker_get_exec_ctx (GumStalker * self);
-static void gum_stalker_invalidate_caches (GumStalker * self);
+void gum_stalker_flush_caches (GumStalker * self);
 
 static void gum_exec_ctx_dispose_callouts (GumExecCtx * ctx);
 static void gum_exec_ctx_free (GumExecCtx * ctx);
@@ -1183,7 +1183,7 @@ gum_stalker_add_call_probe (GumStalker * self,
 
   gum_spinlock_release (&self->probe_lock);
 
-  gum_stalker_invalidate_caches (self);
+  gum_stalker_flush_caches (self);
 
   return probe.id;
 }
@@ -1235,7 +1235,7 @@ gum_stalker_remove_call_probe (GumStalker * self,
 
   gum_spinlock_release (&self->probe_lock);
 
-  gum_stalker_invalidate_caches (self);
+  gum_stalker_flush_caches (self);
 }
 
 static void
@@ -1356,7 +1356,7 @@ gum_stalker_get_exec_ctx (GumStalker * self)
 }
 
 static void
-gum_stalker_invalidate_caches (GumStalker * self)
+gum_stalker_flush_caches (GumStalker * self)
 {
   GSList * cur;
 

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -223,6 +223,8 @@ GUM_API void gum_stalker_deactivate (GumStalker * self);
 GUM_API void gum_stalker_prefetch (GumStalker * self, gconstpointer address,
     gint recycle_count);
 
+GUM_API void gum_stalker_flush_caches (GumStalker * self);
+
 GUM_API GumProbeId gum_stalker_add_call_probe (GumStalker * self,
     gpointer target_address, GumCallProbeCallback callback, gpointer data,
     GDestroyNotify notify);


### PR DESCRIPTION
Rename gum_stalker_invalidate_caches to gum_stalker_flush_caches to make
clear that this will invalidate the complete cache, as opposed to
a single basic block as planned with a future API.

Exposing this API means adding stub functions to the MIPS and ARM32
stalker implementations. On MIPS, Stalker is not supported, so just add
a similar stub implementation there. On ARM32, the invalidation logic
was not ported from ARM64 since it was not needed due to missing call
probe support. There, gum_stalker_flush_caches is also left as a stub
function, pending porting from ARM64.