### PR TITLE
Extract native libraries on android

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -57,6 +57,9 @@
 /* Define to 1 if OS is macOS. */
 #mesondefine HAVE_MACOS
 
+/* Define to 1 if minizip is available. */
+#mesondefine HAVE_MINIZIP
+
 /* Define to 1 if target is MIPS based. */
 #mesondefine HAVE_MIPS
 

--- a/gum/backend-elf/gumelfmodule.h
+++ b/gum/backend-elf/gumelfmodule.h
@@ -29,6 +29,7 @@ typedef gboolean (* GumElfFoundDynamicEntryFunc) (
 typedef gboolean (* GumElfFoundSectionFunc) (
     const GumElfSectionDetails * details, gpointer user_data);
 
+typedef guint GumElfSource;
 typedef guint GumElfDynamicAddressState;
 typedef GElf_Sxword GumElfDynamicEntryType;
 typedef GElf_Xword GumElfDynamicEntryValue;
@@ -47,8 +48,7 @@ struct _GumElfModule
 
   gpointer file_data;
   gsize file_size;
-  gboolean is_linux_vdso;
-  gboolean is_android_extracted;
+  GumElfSource source;
 
   Elf * elf;
 
@@ -60,6 +60,14 @@ struct _GumElfModule
   GumElfDynamicAddressState dynamic_address_state;
 
   const gchar * dynamic_strings;
+};
+
+enum _GumElfSource
+{
+  GUM_ELF_SOURCE_NONE,
+  GUM_ELF_SOURCE_FILE,
+  GUM_ELF_SOURCE_BLOB,
+  GUM_ELF_SOURCE_VDSO,
 };
 
 enum _GumElfDynamicAddressState

--- a/gum/backend-elf/gumelfmodule.h
+++ b/gum/backend-elf/gumelfmodule.h
@@ -48,6 +48,7 @@ struct _GumElfModule
   gpointer file_data;
   gsize file_size;
   gboolean is_linux_vdso;
+  gboolean is_android_extracted;
 
   Elf * elf;
 

--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,15 @@ else
   have_libdwarf = false
 endif
 
+if host_os == 'android'
+  minizip_dep = dependency('minizip', required: false)
+  if minizip_dep.found()
+    cdata.set('HAVE_MINIZIP', 1)
+    extra_deps += [minizip_dep]
+    extra_requires_private += ['minizip']
+  endif
+endif
+
 tls_provider_dep = dependency('gioopenssl', required: false)
 if tls_provider_dep.found()
   cdata.set('HAVE_GIOOPENSSL', 1)


### PR DESCRIPTION
[Since Android Gradle plugin 3.6.0](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs) `android:extractNativeLibs` is by default set to `false` which causes bundled native libraries (shared objects) to not be extracted to an extra file. Instead, Android extracts and loads them to memory at runtime.

As a consequence, frida cannot find these libraries under the given path and needs to extract them from the APK. Here is an example for such a path:
`/data/app/com.example.hellojni-G-r4G8zOhKSiGhnnvK7F0g==/base.apk!/lib/x86_64/libhello-jni.so`
Notice the apk path before the delimiting exclamation mark and the library path inside the zip after it.

This is related to 
- frida/frida#955
- frida/frida#1471 (though this needs fixing in Vala code)
- and possibly frida/frida#978
