### PR TITLE
Enumerate darwin imports from chained fixups

### DIFF
--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1970,11 +1970,12 @@ gum_resolve_export (const char * module_name,
 {
   GumEnumerateImportsContext * ctx = user_data;
   GumDarwinModule * module;
-  GumExportDetails exp;
 
   module = gum_darwin_module_resolver_find_module (ctx->resolver, module_name);
   if (module != NULL)
   {
+    GumExportDetails exp;
+
     if (gum_darwin_module_resolver_find_export_by_mangled_name (ctx->resolver,
         module, symbol_name, &exp))
     {

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -342,6 +342,8 @@ static gboolean gum_emit_modules_in_range (const GumMemoryRange * range,
     GumEnumerateModulesSlowContext * ctx);
 static gboolean gum_emit_import (const GumImportDetails * details,
     gpointer user_data);
+static GumAddress gum_resolve_export (const char * module_name,
+    const char * symbol_name, gpointer user_data);
 static gboolean gum_emit_export (const GumDarwinExportDetails * details,
     gpointer user_data);
 static gboolean gum_emit_symbol (const GumDarwinSymbolDetails * details,
@@ -1903,7 +1905,10 @@ gum_darwin_enumerate_imports (mach_port_t task,
 
   module = gum_darwin_module_resolver_find_module (ctx.resolver, module_name);
   if (module != NULL)
-    gum_darwin_module_enumerate_imports (module, gum_emit_import, &ctx);
+  {
+    gum_darwin_module_enumerate_imports (module, gum_emit_import,
+        gum_resolve_export, &ctx);
+  }
 
   g_clear_object (&ctx.module_map);
   g_object_unref (ctx.resolver);
@@ -1956,6 +1961,28 @@ gum_emit_import (const GumImportDetails * details,
   }
 
   return ctx->func (&d, ctx->user_data);
+}
+
+static GumAddress
+gum_resolve_export (const char * module_name,
+                    const char * symbol_name,
+                    gpointer user_data)
+{
+  GumEnumerateImportsContext * ctx = user_data;
+  GumDarwinModule * module;
+  GumExportDetails exp;
+
+  module = gum_darwin_module_resolver_find_module (ctx->resolver, module_name);
+  if (module != NULL)
+  {
+    if (gum_darwin_module_resolver_find_export_by_mangled_name (ctx->resolver,
+        module, symbol_name, &exp))
+    {
+      return exp.address;
+    }
+  }
+
+  return 0;
 }
 
 void

--- a/gum/gumdarwinmodule.h
+++ b/gum/gumdarwinmodule.h
@@ -385,7 +385,7 @@ GUM_API GumAddress gum_darwin_module_resolve_symbol_address (
 GUM_API gboolean gum_darwin_module_get_lacks_exports_for_reexports (
     GumDarwinModule * self);
 GUM_API void gum_darwin_module_enumerate_imports (GumDarwinModule * self,
-    GumFoundImportFunc func, gpointer user_data);
+    GumFoundImportFunc func, GumResolveExportFunc resolver, gpointer user_data);
 GUM_API void gum_darwin_module_enumerate_exports (GumDarwinModule * self,
     GumFoundDarwinExportFunc func, gpointer user_data);
 GUM_API void gum_darwin_module_enumerate_symbols (GumDarwinModule * self,

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -160,6 +160,8 @@ typedef gboolean (* GumFoundRangeFunc) (const GumRangeDetails * details,
     gpointer user_data);
 typedef gboolean (* GumFoundMallocRangeFunc) (
     const GumMallocRangeDetails * details, gpointer user_data);
+typedef GumAddress (* GumResolveExportFunc) (const char * module_name,
+    const char * symbol_name, gpointer user_data);
 
 GUM_API GumOS gum_process_get_native_os (void);
 GUM_API GumCodeSigningPolicy gum_process_get_code_signing_policy (void);


### PR DESCRIPTION
In latest arm64e executables there are no binding opcodes, while usually the same information can be reconstructed by walking the metadata indexed by the LC_DYLD_CHAINED_FIXUPS command and stored in linkedit.

The problem in doing so on images which have already been loaded in memory by dyld is that the actual chains are lost because the bitfields in the slots have already been replaced by the actual pointers.

This change reconstructs the correct slots by scanning the pages of the segments which are pointed to by the fixups metadata and looking for pointers to resolved imports.