### PR TITLE
Provide access to the underlying JavaScript Engine to users of the fr…

### DIFF
--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -159,6 +159,9 @@ static void gum_quick_script_do_post (GumPostData * d);
 static void gum_quick_post_data_free (GumPostData * d);
 
 static GumStalker * gum_quick_script_get_stalker (GumScript * script);
+static void * gum_quick_script_get_context (GumScript * script);
+static gboolean gum_quick_script_parse_args (GumScript * script, int argc,
+    void * argv, gchar * fmt, va_list ap);
 
 static void gum_quick_script_emit (GumQuickScript * self,
     const gchar * message, GBytes * data);
@@ -218,6 +221,8 @@ gum_quick_script_iface_init (gpointer g_iface,
   iface->post = gum_quick_script_post;
 
   iface->get_stalker = gum_quick_script_get_stalker;
+  iface->get_context = gum_quick_script_get_context;
+  iface->parse_args = gum_quick_script_parse_args;
 }
 
 static void
@@ -774,6 +779,33 @@ gum_quick_script_get_stalker (GumScript * script)
   GumQuickScript * self = GUM_QUICK_SCRIPT (script);
 
   return _gum_quick_stalker_get (&self->stalker);
+}
+
+static void *
+gum_quick_script_get_context (GumScript * script)
+{
+  GumQuickScript * self = GUM_QUICK_SCRIPT (script);
+
+  return self->ctx;
+}
+
+static gboolean
+gum_quick_script_parse_args (GumScript * script,
+                             int argc,
+                             void * argv,
+                             gchar * format,
+                             va_list ap)
+{
+  GumQuickScript * self = GUM_QUICK_SCRIPT (script);
+  GumQuickArgs args;
+  gboolean result;
+
+  _gum_quick_args_init (&args, self->ctx, argc, argv, &self->core);
+
+  result = _gum_quick_args_vparse (&args, format, ap);
+  _gum_quick_args_destroy (&args);
+
+  return result;
 }
 
 static void

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -84,15 +84,25 @@ _gum_quick_args_parse (GumQuickArgs * self,
                        const gchar * format,
                        ...)
 {
+  gboolean result;
+  va_list ap;
+  va_start (ap, format);
+  result = _gum_quick_args_vparse (self, format, ap);
+  va_end (ap);
+  return result;
+}
+
+gboolean
+_gum_quick_args_vparse (GumQuickArgs * self,
+                        const gchar * format,
+                        va_list ap)
+{
   JSContext * ctx = self->ctx;
   GumQuickCore * core = self->core;
-  va_list ap;
   int arg_index;
   const gchar * t;
   gboolean is_required;
   const gchar * error_message = NULL;
-
-  va_start (ap, format);
 
   arg_index = 0;
   is_required = TRUE;
@@ -536,8 +546,6 @@ _gum_quick_args_parse (GumQuickArgs * self,
     arg_index++;
   }
 
-  va_end (ap);
-
   return TRUE;
 
 missing_argument:
@@ -577,8 +585,6 @@ expected_function:
   }
 propagate_exception:
   {
-    va_end (ap);
-
     if (error_message != NULL)
       _gum_quick_throw_literal (ctx, error_message);
 

--- a/bindings/gumjs/gumquickvalue.h
+++ b/bindings/gumjs/gumquickvalue.h
@@ -40,6 +40,8 @@ G_GNUC_INTERNAL void _gum_quick_args_init (GumQuickArgs * args,
 G_GNUC_INTERNAL void _gum_quick_args_destroy (GumQuickArgs * args);
 G_GNUC_INTERNAL gboolean _gum_quick_args_parse (GumQuickArgs * self,
     const gchar * format, ...);
+G_GNUC_INTERNAL gboolean _gum_quick_args_vparse (GumQuickArgs * self,
+    const gchar * format, va_list ap);
 G_GNUC_INTERNAL GBytes * _gum_quick_args_steal_bytes (GumQuickArgs * self,
     GBytes * bytes);
 

--- a/bindings/gumjs/gumscript.c
+++ b/bindings/gumjs/gumscript.c
@@ -82,3 +82,24 @@ gum_script_get_stalker (GumScript * self)
 {
   return GUM_SCRIPT_GET_IFACE (self)->get_stalker (self);
 }
+
+void *
+gum_script_get_context (GumScript * self)
+{
+  return GUM_SCRIPT_GET_IFACE (self)->get_context (self);
+}
+
+gboolean
+gum_script_parse_args (GumScript * self,
+                       int argc,
+                       void * argv,
+                       gchar * fmt,
+                       ...)
+{
+  gboolean result;
+  va_list ap;
+  va_start(ap, fmt);
+  result = GUM_SCRIPT_GET_IFACE (self)->parse_args (self, argc, argv, fmt, ap);
+  va_end(ap);
+  return result;
+}

--- a/bindings/gumjs/gumscript.h
+++ b/bindings/gumjs/gumscript.h
@@ -38,6 +38,11 @@ struct _GumScriptInterface
   void (* post) (GumScript * self, const gchar * message, GBytes * data);
 
   GumStalker * (* get_stalker) (GumScript * self);
+
+  void * (*get_context) (GumScript * self);
+
+  gboolean (*parse_args) (GumScript * self, int argc, void * argv, gchar * fmt,
+        va_list ap);
 };
 
 GUM_API void gum_script_load (GumScript * self, GCancellable * cancellable,
@@ -58,6 +63,11 @@ GUM_API void gum_script_post (GumScript * self, const gchar * message,
     GBytes * data);
 
 GUM_API GumStalker * gum_script_get_stalker (GumScript * self);
+
+GUM_API void * gum_script_get_context (GumScript * self);
+
+GUM_API gboolean gum_script_parse_args (GumScript * self, int argc, void * argv,
+    gchar * fmt, ...);
 
 G_END_DECLS
 

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -104,6 +104,9 @@ static void gum_v8_script_do_post (GumPostData * d);
 static void gum_v8_post_data_free (GumPostData * d);
 
 static GumStalker * gum_v8_script_get_stalker (GumScript * script);
+static void * gum_v8_script_get_context (GumScript * script);
+static gboolean gum_v8_script_parse_args (GumScript * script, int argc,
+    void * argv, gchar * format, va_list ap);
 
 static void gum_v8_script_emit (GumV8Script * self, const gchar * message,
     GBytes * data);
@@ -174,6 +177,8 @@ gum_v8_script_iface_init (gpointer g_iface,
   iface->post = gum_v8_script_post;
 
   iface->get_stalker = gum_v8_script_get_stalker;
+  iface->get_context = gum_v8_script_get_context;
+  iface->parse_args = gum_v8_script_parse_args;
 }
 
 static void
@@ -714,6 +719,25 @@ gum_v8_script_get_stalker (GumScript * script)
   auto self = GUM_V8_SCRIPT (script);
 
   return _gum_v8_stalker_get (&self->stalker);
+}
+
+static void *
+gum_v8_script_get_context (GumScript * script)
+{
+  auto self = GUM_V8_SCRIPT (script);
+
+  return self->isolate;
+}
+
+static gboolean
+gum_v8_script_parse_args (GumScript * script,
+                          int argc,
+                          void * argv,
+                          gchar * format,
+                          va_list ap)
+{
+  g_warning ("Unimplemented gum_v8_script_parse_args");
+  return FALSE;
 }
 
 static void


### PR DESCRIPTION
…ida-gumjs DevKit

The frida-gumjs allows the user to embed the JavaScript engine with its supported FRIDA APIs into their application. However, it doesn't allow sufficient access for the user to add their own functionality to the runtime. There are two major issues:
1. There is no access to the Quick JSContext / v8 Isolate which is required to add items to the global namespace
2. The type information for FRIDAs JavaScript types is not exposed. Therefore access to the argument parsing API has also been added so that the user can provide a method which takes a NativePointer for example. In to add an API which can interoperate with that of FRIDA, it must be able to interpret FRIDA's types.