### PR TITLE
Add minimal context to NativeCallback

### DIFF
--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -106,9 +106,9 @@ struct _GumQuickCore
   JSClassID native_function_class;
   JSClassID system_function_class;
   JSClassID native_callback_class;
+  JSClassID callback_context_class;
   JSClassID cpu_context_class;
   JSClassID source_map_class;
-  JSClassID callback_context_class;
   JSValue source_map_ctor;
 
 #define GUM_DECLARE_ATOM(id) \

--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -108,6 +108,7 @@ struct _GumQuickCore
   JSClassID native_callback_class;
   JSClassID cpu_context_class;
   JSClassID source_map_class;
+  JSClassID callback_context_class;
   JSValue source_map_ctor;
 
 #define GUM_DECLARE_ATOM(id) \

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -109,6 +109,9 @@ struct GumV8Core
   GumPersistent<v8::FunctionTemplate>::type * cpu_context;
   GumPersistent<v8::Object>::type * cpu_context_value;
 
+  GumPersistent<v8::FunctionTemplate>::type * callback_context;
+  GumPersistent<v8::Object>::type * callback_context_value;
+
   GumPersistent<v8::FunctionTemplate>::type * source_map;
 };
 

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -106,11 +106,11 @@ struct GumV8Core
   GumPersistent<v8::String>::type * value_key;
   GumPersistent<v8::String>::type * system_error_key;
 
-  GumPersistent<v8::FunctionTemplate>::type * cpu_context;
-  GumPersistent<v8::Object>::type * cpu_context_value;
-
   GumPersistent<v8::FunctionTemplate>::type * callback_context;
   GumPersistent<v8::Object>::type * callback_context_value;
+
+  GumPersistent<v8::FunctionTemplate>::type * cpu_context;
+  GumPersistent<v8::Object>::type * cpu_context_value;
 
   GumPersistent<v8::FunctionTemplate>::type * source_map;
 };

--- a/bindings/gumjs/gumv8platform.cpp
+++ b/bindings/gumjs/gumv8platform.cpp
@@ -15,6 +15,8 @@
 #include <gum/gumcodesegment.h>
 #include <gum/gummemory.h>
 
+#include <algorithm>
+
 using namespace v8;
 
 namespace

--- a/bindings/gumjs/gumv8platform.cpp
+++ b/bindings/gumjs/gumv8platform.cpp
@@ -11,11 +11,10 @@
 #include "gumv8script-objc.h"
 #include "gumv8script-runtime.h"
 
+#include <algorithm>
 #include <gum/gumcloak.h>
 #include <gum/gumcodesegment.h>
 #include <gum/gummemory.h>
-
-#include <algorithm>
 
 using namespace v8;
 

--- a/gum/arch-arm/gumarmbacktracer.c
+++ b/gum/arch-arm/gumarmbacktracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -21,8 +22,8 @@ static void gum_arm_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_arm_backtracer_dispose (GObject * object);
 static void gum_arm_backtracer_generate (GumBacktracer * backtracer,
-    const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses, guint limit);
+    const GumCpuContext * cpu_context, GumReturnAddressArray * return_addresses,
+    guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumArmBacktracer,
                         gum_arm_backtracer,

--- a/gum/arch-arm64/gumarm64backtracer.c
+++ b/gum/arch-arm64/gumarm64backtracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -21,8 +22,8 @@ static void gum_arm64_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_arm64_backtracer_dispose (GObject * object);
 static void gum_arm64_backtracer_generate (GumBacktracer * backtracer,
-    const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses, guint limit);
+    const GumCpuContext * cpu_context, GumReturnAddressArray * return_addresses,
+    guint limit);
 
 static gsize gum_strip_item (gsize address);
 

--- a/gum/arch-mips/gummipsbacktracer.c
+++ b/gum/arch-mips/gummipsbacktracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -21,8 +22,8 @@ static void gum_mips_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_mips_backtracer_dispose (GObject * object);
 static void gum_mips_backtracer_generate (GumBacktracer * backtracer,
-    const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses, guint limit);
+    const GumCpuContext * cpu_context, GumReturnAddressArray * return_addresses,
+    guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumMipsBacktracer,
                         gum_mips_backtracer,

--- a/gum/arch-mips/gummipsbacktracer.c
+++ b/gum/arch-mips/gummipsbacktracer.c
@@ -22,7 +22,7 @@ static void gum_mips_backtracer_iface_init (gpointer g_iface,
 static void gum_mips_backtracer_dispose (GObject * object);
 static void gum_mips_backtracer_generate (GumBacktracer * backtracer,
     const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses);
+    GumReturnAddressArray * return_addresses, guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumMipsBacktracer,
                         gum_mips_backtracer,
@@ -75,12 +75,13 @@ gum_mips_backtracer_new (void)
 static void
 gum_mips_backtracer_generate (GumBacktracer * backtracer,
                               const GumCpuContext * cpu_context,
-                              GumReturnAddressArray * return_addresses)
+                              GumReturnAddressArray * return_addresses,
+                              guint limit)
 {
   GumMipsBacktracer * self;
   GumInvocationStack * invocation_stack;
   gsize * start_address;
-  guint skips_pending, i;
+  guint skips_pending, depth, i;
   gsize * p;
 
   self = GUM_MIPS_BACKTRACER (backtracer);
@@ -96,6 +97,8 @@ gum_mips_backtracer_generate (GumBacktracer * backtracer,
     asm ("\tmove %0, $sp" : "=r" (start_address));
     skips_pending = 1;
   }
+
+  depth = MIN (limit, G_N_ELEMENTS (return_addresses->items));
 
   for (i = 0, p = start_address; p < start_address + 2048; p++)
   {
@@ -170,7 +173,7 @@ gum_mips_backtracer_generate (GumBacktracer * backtracer,
       if (skips_pending == 0)
       {
         return_addresses->items[i++] = GSIZE_TO_POINTER (value);
-        if (i == G_N_ELEMENTS (return_addresses->items))
+        if (i == depth)
           break;
       }
       else

--- a/gum/arch-x86/gumx86backtracer.c
+++ b/gum/arch-x86/gumx86backtracer.c
@@ -22,7 +22,7 @@ static void gum_x86_backtracer_iface_init (gpointer g_iface,
 static void gum_x86_backtracer_dispose (GObject * object);
 static void gum_x86_backtracer_generate (GumBacktracer * backtracer,
     const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses);
+    GumReturnAddressArray * return_addresses, guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumX86Backtracer,
                         gum_x86_backtracer,
@@ -78,13 +78,14 @@ gum_x86_backtracer_new (void)
 static void
 gum_x86_backtracer_generate (GumBacktracer * backtracer,
                              const GumCpuContext * cpu_context,
-                             GumReturnAddressArray * return_addresses)
+                             GumReturnAddressArray * return_addresses,
+                             guint limit)
 {
   GumX86Backtracer * self;
   GumInvocationStack * invocation_stack;
   gsize * start_address;
   gsize first_address = 0;
-  guint i;
+  guint depth, i;
   gsize * p;
 
   self = GUM_X86_BACKTRACER (backtracer);
@@ -94,6 +95,8 @@ gum_x86_backtracer_generate (GumBacktracer * backtracer,
     start_address = GSIZE_TO_POINTER (GUM_CPU_CONTEXT_XSP (cpu_context));
   else
     start_address = (gsize *) &backtracer;
+
+  depth = MIN (limit, G_N_ELEMENTS (return_addresses->items));
 
   for (i = 0, p = start_address; p < start_address + 2048; p++)
   {
@@ -143,7 +146,7 @@ gum_x86_backtracer_generate (GumBacktracer * backtracer,
     if (valid)
     {
       return_addresses->items[i++] = GSIZE_TO_POINTER (value);
-      if (i == G_N_ELEMENTS (return_addresses->items))
+      if (i == depth)
         break;
 
       if (first_address == 0)

--- a/gum/arch-x86/gumx86backtracer.c
+++ b/gum/arch-x86/gumx86backtracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -21,8 +22,8 @@ static void gum_x86_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_x86_backtracer_dispose (GObject * object);
 static void gum_x86_backtracer_generate (GumBacktracer * backtracer,
-    const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses, guint limit);
+    const GumCpuContext * cpu_context, GumReturnAddressArray * return_addresses,
+    guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumX86Backtracer,
                         gum_x86_backtracer,

--- a/gum/backend-darwin/gumdarwinbacktracer.c
+++ b/gum/backend-darwin/gumdarwinbacktracer.c
@@ -13,8 +13,12 @@
 # define GUM_FP_IS_ALIGNED(F) ((GPOINTER_TO_SIZE (F) & 0xf) == 8)
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
 # define GUM_FP_IS_ALIGNED(F) ((GPOINTER_TO_SIZE (F) & 0xf) == 0)
+# define GUM_FFI_STACK_SKIP (0xd8 / 8)
 #else
 # define GUM_FP_IS_ALIGNED(F) ((GPOINTER_TO_SIZE (F) & 0x1) == 0)
+# if defined (HAVE_ARM)
+#  define GUM_FFI_STACK_SKIP 1
+# endif
 #endif
 
 struct _GumDarwinBacktracer
@@ -26,7 +30,7 @@ static void gum_darwin_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_darwin_backtracer_generate (GumBacktracer * backtracer,
     const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses);
+    GumReturnAddressArray * return_addresses, guint limit);
 
 static gpointer gum_strip_item (gpointer address);
 
@@ -65,12 +69,17 @@ gum_darwin_backtracer_new (void)
 static void
 gum_darwin_backtracer_generate (GumBacktracer * backtracer,
                                 const GumCpuContext * cpu_context,
-                                GumReturnAddressArray * return_addresses)
+                                GumReturnAddressArray * return_addresses,
+                                guint limit)
 {
   pthread_t thread;
   gpointer stack_top, stack_bottom;
   gpointer * cur;
-  guint start_index, i;
+  guint start_index, n_skip, depth, i;
+  gboolean has_ffi_frames;
+#if defined (HAVE_ARM)
+  gpointer * ffi_next = NULL;
+#endif
   GumInvocationStack * invocation_stack;
 
   thread = pthread_self ();
@@ -85,29 +94,44 @@ gum_darwin_backtracer_generate (GumBacktracer * backtracer,
 
     return_addresses->items[0] = *((GumReturnAddress *) GSIZE_TO_POINTER (
         GUM_CPU_CONTEXT_XSP (cpu_context)));
+    has_ffi_frames = GUM_CPU_CONTEXT_XIP (cpu_context) == 0;
 #elif defined (HAVE_ARM)
     cur = GSIZE_TO_POINTER (cpu_context->r[7]);
 
     return_addresses->items[0] = GSIZE_TO_POINTER (cpu_context->lr);
+    has_ffi_frames = cpu_context->pc == 0;
 #elif defined (HAVE_ARM64)
     cur = GSIZE_TO_POINTER (cpu_context->fp);
 
     return_addresses->items[0] = GSIZE_TO_POINTER (cpu_context->lr);
+    has_ffi_frames = cpu_context->pc == 0;
 #else
 # error Unsupported architecture
 #endif
-    return_addresses->items[0] = gum_strip_item (return_addresses->items[0]);
-    start_index = 1;
+    if (has_ffi_frames)
+    {
+      n_skip = 2;
+      start_index = 0;
+    }
+    else
+    {
+      return_addresses->items[0] = gum_strip_item (return_addresses->items[0]);
+      n_skip = 0;
+      start_index = 1;
+    }
   }
   else
   {
     cur = __builtin_frame_address (0);
-
+    has_ffi_frames = FALSE;
+    n_skip = 0;
     start_index = 0;
   }
 
+  depth = MIN (limit, G_N_ELEMENTS (return_addresses->items));
+
   for (i = start_index;
-      i < G_N_ELEMENTS (return_addresses->items) &&
+      i < depth &&
       cur >= (gpointer *) stack_bottom &&
       cur <= (gpointer *) stack_top &&
       GUM_FP_IS_ALIGNED (cur);
@@ -124,7 +148,29 @@ gum_darwin_backtracer_generate (GumBacktracer * backtracer,
     next = *cur;
     if (next <= cur)
       break;
+
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+    if (has_ffi_frames && n_skip == 1)
+      next = cur + GUM_FFI_STACK_SKIP + 1;
+#elif defined (HAVE_ARM)
+    if (has_ffi_frames && n_skip == 1)
+    {
+      ffi_next = next;
+      next = cur + GUM_FFI_STACK_SKIP + 1;
+    }
+    else if (n_skip == 0 && ffi_next != NULL)
+    {
+      next = ffi_next;
+      ffi_next = NULL;
+    }
+#endif
+
     cur = next;
+    if (n_skip > 0)
+    {
+      n_skip--;
+      i--;
+    }
   }
   return_addresses->len = i;
 

--- a/gum/backend-libunwind/gumunwbacktracer.c
+++ b/gum/backend-libunwind/gumunwbacktracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -19,8 +20,8 @@ struct _GumUnwBacktracer
 static void gum_unw_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_unw_backtracer_generate (GumBacktracer * backtracer,
-    const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses);
+    const GumCpuContext * cpu_context, GumReturnAddressArray * return_addresses,
+    guint limit);
 
 static void gum_cpu_context_to_unw (const GumCpuContext * ctx,
     unw_context_t * uc);

--- a/gum/backend-libunwind/gumunwbacktracer.c
+++ b/gum/backend-libunwind/gumunwbacktracer.c
@@ -60,11 +60,12 @@ gum_unw_backtracer_new (void)
 static void
 gum_unw_backtracer_generate (GumBacktracer * backtracer,
                              const GumCpuContext * cpu_context,
-                             GumReturnAddressArray * return_addresses)
+                             GumReturnAddressArray * return_addresses,
+                             guint limit)
 {
   unw_context_t context;
   unw_cursor_t cursor;
-  guint start_index, i;
+  guint start_index, depth, i;
   GumInvocationStack * invocation_stack;
 
   if (cpu_context != NULL)
@@ -100,9 +101,11 @@ gum_unw_backtracer_generate (GumBacktracer * backtracer,
 #pragma GCC diagnostic pop
   }
 
+  depth = MIN (limit, G_N_ELEMENTS (return_addresses->items));
+
   unw_init_local (&cursor, &context);
   for (i = start_index;
-      i < G_N_ELEMENTS (return_addresses->items) && unw_step (&cursor) > 0;
+      i < depth && unw_step (&cursor) > 0;
       i++)
   {
     unw_word_t pc;

--- a/gum/gumbacktracer.c
+++ b/gum/gumbacktracer.c
@@ -72,9 +72,20 @@ gum_backtracer_generate (GumBacktracer * self,
                          const GumCpuContext * cpu_context,
                          GumReturnAddressArray * return_addresses)
 {
+  gum_backtracer_generate_with_limit (self, cpu_context, return_addresses,
+      GUM_MAX_BACKTRACE_DEPTH);
+}
+
+void
+gum_backtracer_generate_with_limit (GumBacktracer * self,
+                                    const GumCpuContext * cpu_context,
+                                    GumReturnAddressArray * return_addresses,
+                                    guint limit)
+{
   GumBacktracerInterface * iface = GUM_BACKTRACER_GET_IFACE (self);
 
   g_assert (iface->generate != NULL);
 
-  iface->generate (self, cpu_context, return_addresses);
+  iface->generate (self, cpu_context, return_addresses,
+      limit);
 }

--- a/gum/gumbacktracer.c
+++ b/gum/gumbacktracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/gum/gumbacktracer.h
+++ b/gum/gumbacktracer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/gum/gumbacktracer.h
+++ b/gum/gumbacktracer.h
@@ -21,7 +21,7 @@ struct _GumBacktracerInterface
   GTypeInterface parent;
 
   void (* generate) (GumBacktracer * self, const GumCpuContext * cpu_context,
-      GumReturnAddressArray * return_addresses);
+      GumReturnAddressArray * return_addresses, guint limit);
 };
 
 GUM_API GumBacktracer * gum_backtracer_make_accurate (void);
@@ -30,6 +30,9 @@ GUM_API GumBacktracer * gum_backtracer_make_fuzzy (void);
 GUM_API void gum_backtracer_generate (GumBacktracer * self,
     const GumCpuContext * cpu_context,
     GumReturnAddressArray * return_addresses);
+GUM_API void gum_backtracer_generate_with_limit (GumBacktracer * self,
+    const GumCpuContext * cpu_context,
+    GumReturnAddressArray * return_addresses, guint limit);
 
 G_END_DECLS
 

--- a/libs/gum/heap/gumallocationtracker.c
+++ b/libs/gum/heap/gumallocationtracker.c
@@ -355,7 +355,7 @@ gum_allocation_tracker_on_malloc_full (GumAllocationTracker * self,
     if (do_backtrace)
     {
       self->backtracer_iface->generate (self->backtracer_instance, cpu_context,
-          &return_addresses);
+          &return_addresses, GUM_MAX_BACKTRACE_DEPTH);
     }
     else
     {

--- a/libs/gum/heap/gumboundschecker.c
+++ b/libs/gum/heap/gumboundschecker.c
@@ -497,7 +497,8 @@ gum_bounds_checker_try_alloc (GumBoundsChecker * self,
 
     g_assert (block.guard_size / 2 >= sizeof (GumReturnAddressArray));
     self->backtracer_iface->generate (self->backtracer_instance,
-        ctx->cpu_context, BLOCK_ALLOC_RETADDRS (&block));
+        ctx->cpu_context, BLOCK_ALLOC_RETADDRS (&block),
+        GUM_MAX_BACKTRACE_DEPTH);
 
     BLOCK_FREE_RETADDRS (&block)->len = 0;
 
@@ -526,7 +527,8 @@ gum_bounds_checker_try_free (GumBoundsChecker * self,
 
     g_assert (block.guard_size / 2 >= sizeof (GumReturnAddressArray));
     self->backtracer_iface->generate (self->backtracer_instance,
-        ctx->cpu_context, BLOCK_FREE_RETADDRS (&block));
+        ctx->cpu_context, BLOCK_FREE_RETADDRS (&block),
+        GUM_MAX_BACKTRACE_DEPTH);
 
     gum_mprotect (block.guard, block.guard_size, GUM_PAGE_NO_ACCESS);
   }
@@ -579,7 +581,7 @@ gum_bounds_checker_on_exception (GumExceptionDetails * details,
   if (self->backtracer_instance != NULL)
   {
     self->backtracer_iface->generate (self->backtracer_instance, NULL,
-        &accessed_at);
+        &accessed_at, GUM_MAX_BACKTRACE_DEPTH);
   }
 
   if (accessed_at.len > 0)

--- a/libs/gum/heap/gumcobjecttracker.c
+++ b/libs/gum/heap/gumcobjecttracker.c
@@ -484,7 +484,8 @@ on_constructor_enter_handler (GumCObjectTracker * self,
   if (self->backtracer_instance != NULL)
   {
     self->backtracer_iface->generate (self->backtracer_instance,
-        invocation_context->cpu_context, &cobject->return_addresses);
+        invocation_context->cpu_context, &cobject->return_addresses,
+        GUM_MAX_BACKTRACE_DEPTH);
   }
 
   thread_context->data = cobject;

--- a/tests/gumjs/script-fixture.c
+++ b/tests/gumjs/script-fixture.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2013 Karl Trygve Kalleberg <karltk@boblycat.org>
- * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -22,9 +22,10 @@
 #include <string.h>
 #include <gio/gio.h>
 #ifdef HAVE_WINDOWS
-#ifndef WIN32_LEAN_AND_MEAN
-# define WIN32_LEAN_AND_MEAN
-#endif
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <intrin.h>
 # include <tchar.h>
 # include <windows.h>
 # include <winsock2.h>

--- a/tests/stubs/fakebacktracer.c
+++ b/tests/stubs/fakebacktracer.c
@@ -11,7 +11,7 @@ static void gum_fake_backtracer_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_fake_backtracer_generate (GumBacktracer * backtracer,
     const GumCpuContext * cpu_context,
-    GumReturnAddressArray * return_addresses);
+    GumReturnAddressArray * return_addresses, guint limit);
 
 G_DEFINE_TYPE_EXTENDED (GumFakeBacktracer,
                         gum_fake_backtracer,
@@ -55,11 +55,13 @@ gum_fake_backtracer_new (const GumReturnAddress * ret_addrs,
 static void
 gum_fake_backtracer_generate (GumBacktracer * backtracer,
                               const GumCpuContext * cpu_context,
-                              GumReturnAddressArray * return_addresses)
+                              GumReturnAddressArray * return_addresses,
+                              guint limit)
 {
   GumFakeBacktracer * self = GUM_FAKE_BACKTRACER (backtracer);
+  guint depth = MIN (limit, self->num_ret_addrs);
 
   memcpy (return_addresses->items, self->ret_addrs,
-      self->num_ret_addrs * sizeof (GumReturnAddress));
-  return_addresses->len = self->num_ret_addrs;
+      depth * sizeof (GumReturnAddress));
+  return_addresses->len = depth;
 }

--- a/tests/stubs/fakebacktracer.c
+++ b/tests/stubs/fakebacktracer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */


### PR DESCRIPTION
With this change, the `NativeCallback` js function is passed an instance of `CallbackContext` as the `this` argument.

This is an object with the `context` and `returnAddress` properties which, similarly to their counterparts found in `InvocationContext` for the `Interceptor` case, provide respectively a (minimal) CPU context and the address of the caller code.

The CPU context is minimal, in that it contains only what's needed to generate accurate backtraces, and it's read-only.

The primary use case for this addition is to provide a means for generating accurate meaningful backtraces from the context of swizzled ObjC methods (by using the `ObjC.implement()` api).

For this reason, this change also extends the Darwin (and Windows) accurate backtracer to take this case into account and properly skip the libffi stack frames. Tests are added to make sure backtraces produced this way are exaclty the same as those produced when using the Interceptor.

Since `CallbackContext` is using the backtrace to derive the `returnAddress` value, the backtracer interface has also been extended to allow for an extra `limit` parameter which can be used to shorten the depth of the backtrace below the maximum allowed in cases like this when not all the result is needed.

This is exposed through a new `gum_backtracer_generate_with_limit ()` api, while the existing `gum_backtracer_generate ()` still works as before, by implicitly using `GUM_MAX_BACKTRACE_DEPTH` as the value for `limit` under the hood.