### PR TITLE
Added callbacks for stats information

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -5740,3 +5740,9 @@ gum_is_exclusive_store_insn (const cs_insn * insn)
       return FALSE;
   }
 }
+
+void
+gum_stalker_set_stats (GumStalker * self,
+			GumStalkerStats * stats)
+{
+}

--- a/gum/backend-mips/gumstalker-mips.c
+++ b/gum/backend-mips/gumstalker-mips.c
@@ -167,3 +167,9 @@ gum_stalker_iterator_put_callout (GumStalkerIterator * self,
                                   GDestroyNotify data_destroy)
 {
 }
+
+void
+gum_stalker_set_stats (GumStalker * self,
+			GumStalkerStats * stats)
+{
+}

--- a/gum/gumstalker.c
+++ b/gum/gumstalker.c
@@ -33,6 +33,8 @@ static void gum_callback_stalker_transformer_transform_block (
     GumStalkerTransformer * transformer, GumStalkerIterator * iterator,
     GumStalkerOutput * output);
 
+static void gum_stalker_stats_default_init (GumStalkerStatsInterface * iface);
+
 G_DEFINE_INTERFACE (GumStalkerTransformer, gum_stalker_transformer,
     G_TYPE_OBJECT)
 
@@ -49,6 +51,8 @@ G_DEFINE_TYPE_EXTENDED (GumCallbackStalkerTransformer,
                         0,
                         G_IMPLEMENT_INTERFACE (GUM_TYPE_STALKER_TRANSFORMER,
                             gum_callback_stalker_transformer_iface_init))
+
+G_DEFINE_INTERFACE (GumStalkerStats, gum_stalker_stats, G_TYPE_OBJECT)
 
 static void
 gum_stalker_transformer_default_init (GumStalkerTransformerInterface * iface)
@@ -171,3 +175,9 @@ gum_callback_stalker_transformer_transform_block (
 
   self->callback (iterator, output, self->data);
 }
+
+static void
+gum_stalker_stats_default_init (GumStalkerStatsInterface * iface)
+{
+}
+

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -40,6 +40,10 @@ G_DECLARE_FINAL_TYPE (GumCallbackStalkerTransformer,
     gum_callback_stalker_transformer, GUM, CALLBACK_STALKER_TRANSFORMER,
     GObject)
 
+#define GUM_TYPE_STALKER_STATS (gum_stalker_stats_get_type ())
+G_DECLARE_INTERFACE (GumStalkerStats, gum_stalker_stats, GUM, STALKER_STATS,
+    GObject)
+
 typedef struct _GumStalkerIterator GumStalkerIterator;
 typedef struct _GumStalkerOutput GumStalkerOutput;
 typedef union _GumStalkerWriter GumStalkerWriter;
@@ -59,6 +63,56 @@ struct _GumStalkerTransformerInterface
 
   void (* transform_block) (GumStalkerTransformer * self,
       GumStalkerIterator * iterator, GumStalkerOutput * output);
+};
+
+typedef void (* GumStalkerStatsIncrement) (GumStalkerStats * self);
+
+struct _GumStalkerStatsInterface
+{
+  GTypeInterface parent;
+
+  /* Common */
+  GumStalkerStatsIncrement increment_total;
+  GumStalkerStatsIncrement increment_call_imm;
+  GumStalkerStatsIncrement increment_call_reg;
+
+  /* x86 only */
+  GumStalkerStatsIncrement increment_call_mem;
+
+  /* Arm64 only */
+  GumStalkerStatsIncrement increment_excluded_call_reg;
+
+  /* x86 only */
+  GumStalkerStatsIncrement increment_ret_slow_path;
+
+  /* Arm64 only */
+  GumStalkerStatsIncrement increment_ret;
+
+  /* Common */
+  GumStalkerStatsIncrement increment_post_call_invoke;
+  GumStalkerStatsIncrement increment_excluded_call_imm;
+
+  /* Common */
+  GumStalkerStatsIncrement increment_jmp_imm;
+  GumStalkerStatsIncrement increment_jmp_reg;
+
+  /* x86 only */
+  GumStalkerStatsIncrement increment_jmp_mem;
+  GumStalkerStatsIncrement increment_jmp_cond_imm;
+  GumStalkerStatsIncrement increment_jmp_cond_mem;
+  GumStalkerStatsIncrement increment_jmp_cond_reg;
+  GumStalkerStatsIncrement increment_jmp_cond_jcxz;
+
+  /* Arm64 only */
+  GumStalkerStatsIncrement increment_jmp_cond_cc;
+  GumStalkerStatsIncrement increment_jmp_cond_cbz;
+  GumStalkerStatsIncrement increment_jmp_cond_cbnz;
+  GumStalkerStatsIncrement increment_jmp_cond_tbz;
+  GumStalkerStatsIncrement increment_jmp_cond_tbnz;
+
+  /* Common */
+  GumStalkerStatsIncrement increment_jmp_continuation;
+
 };
 
 union _GumStalkerWriter
@@ -252,6 +306,8 @@ GUM_API void gum_stalker_iterator_put_callout (GumStalkerIterator * self,
 
 GUM_API void gum_stalker_set_counters_enabled (gboolean enabled);
 GUM_API void gum_stalker_dump_counters (void);
+
+GUM_API void gum_stalker_set_stats (GumStalker * self, GumStalkerStats * stats);
 
 G_END_DECLS
 

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -73,8 +73,18 @@ TESTLIST_BEGIN (stalker)
 
 #ifdef HAVE_LINUX
   TESTENTRY (prefetch)
+  TESTENTRY (stats)
 #endif
 TESTLIST_END ()
+
+#ifdef HAVE_LINUX
+struct _GumTestStalkerStats
+{
+  GObject parent;
+
+  guint64 total;
+};
+#endif
 
 static void insert_extra_add_after_sub (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
@@ -120,6 +130,27 @@ static void prefetch_read_blocks (int fd, GHashTable * table);
 
 static GHashTable * prefetch_compiled = NULL;
 static GHashTable * prefetch_executed = NULL;
+
+#define GUM_TYPE_TEST_STALKER_STATS \
+    (gum_test_stalker_stats_get_type ())
+G_DECLARE_FINAL_TYPE (GumTestStalkerStats,
+    gum_test_stalker_stats, GUM, TEST_STALKER_STATS,
+    GObject)
+
+static void gum_test_stalker_stats_iface_init (gpointer g_iface,
+    gpointer iface_data);
+static void gum_test_stalker_stats_class_init(
+    GumTestStalkerStatsClass * klass);
+static void gum_test_stalker_stats_init (GumTestStalkerStats * self);
+static void gum_test_stalker_stats_increment_total (GumStalkerStats * stats);
+
+G_DEFINE_TYPE_EXTENDED (GumTestStalkerStats,
+                        gum_test_stalker_stats,
+                        G_TYPE_OBJECT,
+                        0,
+                        G_IMPLEMENT_INTERFACE (GUM_TYPE_STALKER_STATS,
+                            gum_test_stalker_stats_iface_init))
+
 #endif
 
 static const guint32 flat_code[] = {
@@ -2162,6 +2193,63 @@ prefetch_read_blocks (int fd,
   {
     g_hash_table_add (table, block_address);
   }
+}
+
+static void
+gum_test_stalker_stats_iface_init (gpointer g_iface,
+                                   gpointer iface_data)
+{
+  GumStalkerStatsInterface * iface = g_iface;
+  iface->increment_total = gum_test_stalker_stats_increment_total;
+}
+
+static void
+gum_test_stalker_stats_class_init (GumTestStalkerStatsClass * klass)
+{
+}
+
+static void
+gum_test_stalker_stats_init (GumTestStalkerStats * self)
+{
+  self->total = 0;
+}
+
+static void
+gum_test_stalker_stats_increment_total (GumStalkerStats * stats)
+{
+  GumTestStalkerStats * test_stats = GUM_TEST_STALKER_STATS (stats);
+  test_stats->total++;
+}
+
+TESTCASE (stats)
+{
+  GumTestStalkerStats * test_stats;
+  GumStalkerStats * stats;
+  guint sum = 0;
+  test_stats = g_object_new (GUM_TYPE_TEST_STALKER_STATS, NULL);
+
+  stats = GUM_STALKER_STATS (test_stats);
+
+  gum_stalker_follow_me (fixture->stalker, fixture->transformer,
+      GUM_EVENT_SINK (fixture->sink));
+  gum_stalker_deactivate (fixture->stalker);
+
+  gum_stalker_set_stats (fixture->stalker, stats);
+
+  gum_stalker_activate (fixture->stalker, prefetch_activation_target);
+  prefetch_activation_target ();
+
+  for (guint idx = 0; idx < 10; idx++)
+    sum += idx;
+
+  gum_stalker_unfollow_me (fixture->stalker);
+
+  if (g_test_verbose ())
+    g_print("total: %" G_GINT64_MODIFIER "u\n", test_stats->total);
+
+  g_assert_cmpuint (sum, == , 45);
+  g_assert_cmpuint (test_stats->total, != , 0);
+
 }
 
 #endif

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -95,8 +95,19 @@ TESTLIST_BEGIN (stalker)
 
 #ifdef HAVE_LINUX
   TESTENTRY (prefetch)
+  TESTENTRY (stats)
 #endif
+
 TESTLIST_END ()
+
+#ifdef HAVE_LINUX
+struct _GumTestStalkerStats
+{
+  GObject parent;
+
+  guint64 total;
+};
+#endif
 
 static gpointer run_stalked_briefly (gpointer data);
 static gpointer run_stalked_into_termination (gpointer data);
@@ -140,6 +151,27 @@ static void prefetch_read_blocks (int fd, GHashTable * table);
 
 static GHashTable * prefetch_compiled = NULL;
 static GHashTable * prefetch_executed = NULL;
+
+#define GUM_TYPE_TEST_STALKER_STATS \
+    (gum_test_stalker_stats_get_type ())
+G_DECLARE_FINAL_TYPE (GumTestStalkerStats,
+    gum_test_stalker_stats, GUM, TEST_STALKER_STATS,
+    GObject)
+
+static void gum_test_stalker_stats_iface_init (gpointer g_iface,
+    gpointer iface_data);
+static void gum_test_stalker_stats_class_init(
+    GumTestStalkerStatsClass * klass);
+static void gum_test_stalker_stats_init (GumTestStalkerStats * self);
+static void gum_test_stalker_stats_increment_total (GumStalkerStats * stats);
+
+G_DEFINE_TYPE_EXTENDED (GumTestStalkerStats,
+                        gum_test_stalker_stats,
+                        G_TYPE_OBJECT,
+                        0,
+                        G_IMPLEMENT_INTERFACE (GUM_TYPE_STALKER_STATS,
+                            gum_test_stalker_stats_iface_init))
+
 #endif
 
 static const guint8 flat_code[] = {
@@ -2841,6 +2873,63 @@ prefetch_read_blocks (int fd,
   {
     g_hash_table_add (table, block_address);
   }
+}
+
+static void
+gum_test_stalker_stats_iface_init (gpointer g_iface,
+                                   gpointer iface_data)
+{
+  GumStalkerStatsInterface * iface = g_iface;
+  iface->increment_total = gum_test_stalker_stats_increment_total;
+}
+
+static void
+gum_test_stalker_stats_class_init (GumTestStalkerStatsClass * klass)
+{
+}
+
+static void
+gum_test_stalker_stats_init (GumTestStalkerStats * self)
+{
+  self->total = 0;
+}
+
+static void
+gum_test_stalker_stats_increment_total (GumStalkerStats * stats)
+{
+  GumTestStalkerStats * test_stats = GUM_TEST_STALKER_STATS (stats);
+  test_stats->total++;
+}
+
+TESTCASE (stats)
+{
+  GumTestStalkerStats * test_stats;
+  GumStalkerStats * stats;
+  guint sum = 0;
+  test_stats = g_object_new (GUM_TYPE_TEST_STALKER_STATS, NULL);
+
+  stats = GUM_STALKER_STATS (test_stats);
+
+  gum_stalker_follow_me (fixture->stalker, fixture->transformer,
+      GUM_EVENT_SINK (fixture->sink));
+  gum_stalker_deactivate (fixture->stalker);
+
+  gum_stalker_set_stats (fixture->stalker, stats);
+
+  gum_stalker_activate (fixture->stalker, prefetch_activation_target);
+  prefetch_activation_target ();
+
+  for (guint idx = 0; idx < 10; idx++)
+    sum += idx;
+
+  gum_stalker_unfollow_me (fixture->stalker);
+
+  if (g_test_verbose ())
+    g_print("total: %" G_GINT64_MODIFIER "u\n", test_stats->total);
+
+  g_assert_cmpuint (sum, == , 45);
+  g_assert_cmpuint (test_stats->total, != , 0);
+
 }
 
 #endif


### PR DESCRIPTION
When fuzzing the stats information is lost each time a new child is forked. Since the parent doesn't run the target code (only prefetches it) it will not generate any transitions for the code under test.

This patch simply adds a handful of weak methods which are called each time stalker handles a transition.