### PR TITLE
Changes to make the number of ic entries configurable by #define.

### DIFF
--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -34,6 +34,7 @@
 #define GUM_DATA_SLAB_SIZE_DYNAMIC  (GUM_CODE_SLAB_SIZE_DYNAMIC / 5)
 #define GUM_SCRATCH_SLAB_SIZE       16384
 #define GUM_EXEC_BLOCK_MIN_CAPACITY 1024
+#define GUM_IC_ENTRIES              16
 
 #if GLIB_SIZEOF_VOID_P == 4
 # define GUM_INVALIDATE_TRAMPOLINE_SIZE            16
@@ -80,6 +81,8 @@ typedef struct _GumInstruction GumInstruction;
 typedef struct _GumBranchTarget GumBranchTarget;
 
 typedef guint GumVirtualizationRequirements;
+
+typedef struct _GumIcEntry GumIcEntry;
 
 #ifdef HAVE_WINDOWS
 # if GLIB_SIZEOF_VOID_P == 8
@@ -369,6 +372,12 @@ enum _GumVirtualizationRequirements
 
   GUM_REQUIRE_RELOCATION      = 1 << 0,
   GUM_REQUIRE_SINGLE_STEP     = 1 << 1
+};
+
+struct _GumIcEntry
+{
+  gpointer real_start;
+  gpointer code_start;
 };
 
 static void gum_stalker_dispose (GObject * object);
@@ -3556,7 +3565,7 @@ gum_exec_block_backpatch_ret (GumExecBlock * block,
 
 static void
 gum_exec_block_backpatch_inline_cache (GumExecBlock * block,
-                                       gpointer * ic_entries)
+                                       GumIcEntry * ic_entries)
 {
   gboolean just_unfollowed;
   GumExecCtx * ctx;
@@ -3569,23 +3578,28 @@ gum_exec_block_backpatch_inline_cache (GumExecBlock * block,
 
   if (gum_exec_ctx_may_now_backpatch (ctx, block))
   {
-    guint offset = (ic_entries[0] == NULL) ? 0 : 2;
-
-    if (ic_entries[offset + 0] == NULL)
+    for (guint idx = 0; idx < GUM_IC_ENTRIES; idx++)
     {
+      if (ic_entries[idx].real_start == block->real_start)
+        return;
+
+      if (ic_entries[idx].real_start != NULL)
+        continue;
+
       GumStalker * stalker = ctx->stalker;
-      const gsize ic_slot_size = 2 * sizeof (gpointer);
 
       gum_spinlock_acquire (&ctx->code_lock);
 
-      gum_stalker_thaw (stalker, ic_entries + offset, ic_slot_size);
+      gum_stalker_thaw (stalker, &ic_entries[idx], sizeof(GumIcEntry));
 
-      ic_entries[offset + 0] = block->real_start;
-      ic_entries[offset + 1] = block->code_start;
+      ic_entries[idx].real_start = block->real_start;
+      ic_entries[idx].code_start = block->code_start;
 
-      gum_stalker_freeze (stalker, ic_entries + offset, ic_slot_size);
+      gum_stalker_freeze (stalker, &ic_entries[idx], sizeof(GumIcEntry));
 
       gum_spinlock_release (&ctx->code_lock);
+
+      return;
     }
   }
 }
@@ -3928,14 +3942,17 @@ gum_exec_block_write_call_invoke_code (GumExecBlock * block,
   const GumAddress call_code_start = cw->pc;
   const GumPrologType opened_prolog = gc->opened_prolog;
   gboolean can_backpatch_statically;
-  gpointer * ic_entries = NULL;
+  GumIcEntry * ic_entries = NULL;
+  gpointer * ic_match = NULL;
   GumExecCtxReplaceCurrentBlockFunc entry_func;
   gconstpointer push_application_retaddr = cw->code + 1;
   gconstpointer perform_stack_push = cw->code + 2;
   gconstpointer look_in_cache = cw->code + 3;
-  gconstpointer try_second = cw->code + 4;
-  gconstpointer resolve_dynamically = cw->code + 5;
-  gconstpointer beach = cw->code + 6;
+  gconstpointer loop = cw->code + 4;
+  gconstpointer try_next = cw->code + 5;
+  gconstpointer resolve_dynamically = cw->code + 6;
+  gconstpointer beach = cw->code + 7;
+
   GumAddress ret_real_address, ret_code_address;
 
   can_backpatch_statically =
@@ -3946,8 +3963,16 @@ gum_exec_block_write_call_invoke_code (GumExecBlock * block,
   if (trust_threshold >= 0 && !can_backpatch_statically)
   {
     gpointer null_ptr = NULL;
-    gpointer ic1_real, ic1_code;
-    gpointer ic2_real, ic2_code;
+    /*
+     * Value stored in the code_start field of the IcEntry when empty, so that
+     * it can be more easily idenified when debugging.
+     */
+    gpointer magic_ptr = (gpointer)0xbaadd00ddeadface;
+    /*
+     * Scratch space used to store the matched code_start field so we can jump
+     * there once we have restored all of the target context.
+     */
+    gpointer match_ptr = (gpointer)0xbaadd00dcafef00d;
 
     if (opened_prolog == GUM_PROLOG_NONE)
     {
@@ -3973,44 +3998,83 @@ gum_exec_block_write_call_invoke_code (GumExecBlock * block,
       gc->accumulated_stack_delta += sizeof (gpointer);
     }
 
-    gum_x86_writer_put_jmp_short_label (cw, look_in_cache);
+    /*
+     * We need to use a near rather than short jump since our inline cache is
+     * larger than the maximum distance of a short jump (-128 to +127).
+     */
+    gum_x86_writer_put_jmp_near_label (cw, look_in_cache);
 
     ic_entries = gum_x86_writer_cur (cw);
-    ic1_real = ic_entries;
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic1_code = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic2_real = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic2_code = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
+
+    /* Write our empty inline cache entries */
+    for (guint idx = 0; idx < GUM_IC_ENTRIES; idx++)
+    {
+        gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
+        gum_x86_writer_put_bytes (cw, (guint8 *) &magic_ptr, sizeof (magic_ptr));
+    }
+
+    /*
+     * Write a token which we can replace with our matched ic entry code_start
+     * so we can use it as scratch space and retrieve and jump to it once we
+     * have restored the target application context.
+     */
+    ic_match = gum_x86_writer_cur (cw);
+    gum_x86_writer_put_bytes (cw, (guint8 *) &match_ptr, sizeof (match_ptr));
 
     gum_x86_writer_put_label (cw, look_in_cache);
 
+    gum_x86_writer_put_push_reg (cw, GUM_REG_XCX);
     gum_exec_ctx_write_push_branch_target_address (block->ctx, target, gc);
 
-    gum_x86_writer_put_mov_reg_near_ptr (cw, GUM_REG_XAX,
-        GUM_ADDRESS (ic1_real));
-    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
-    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, try_second,
-        GUM_NO_HINT);
-    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
-    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
-    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic1_code));
+    gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XCX,
+        GUM_ADDRESS (ic_entries));
+    gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XBX,
+        GUM_ADDRESS (&ic_entries[GUM_IC_ENTRIES]));
 
-    gum_x86_writer_put_label (cw, try_second);
-    gum_x86_writer_put_mov_reg_near_ptr (cw, GUM_REG_XAX,
-        GUM_ADDRESS (ic2_real));
-    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
-    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, resolve_dynamically,
-        GUM_NO_HINT);
-    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
-    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
-    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic2_code));
+    /*
+     * Write our inline assembly which iterates through the IcEntry structures,
+     * attempting to match the real_start member with the target block address.
+     */
+    gum_x86_writer_put_label (cw, loop);
+    gum_x86_writer_put_mov_reg_reg_ptr (cw, GUM_REG_XAX, GUM_REG_XCX);
 
+    /* If real_start != target block, Then continue */
+    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, try_next,
+        GUM_NO_HINT);
+
+    /*
+     * If real_start == NULL, Then break (we have reached the end of the
+     * initialized IcEntry structures.
+     */
+    gum_x86_writer_put_cmp_reg_i32 (cw, GUM_REG_XAX, 0);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JE, resolve_dynamically,
+        GUM_NO_HINT);
+
+    /* We found a match, stash the code_start value in the ic_match */
+    gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, GUM_REG_XCX, GUM_REG_XCX,
+        offsetof(GumIcEntry, code_start));
+    gum_x86_writer_put_mov_near_ptr_reg (cw, GUM_ADDRESS(ic_match), GUM_REG_XCX);
+
+    /* Restore the target context and jump at ic_match */
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XCX);
+    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
+    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic_match));
+
+    /* Increment our position through the IcEntry array*/
+    gum_x86_writer_put_label (cw, try_next);
+    gum_x86_writer_put_add_reg_imm (cw, GUM_REG_XCX, sizeof(GumIcEntry));
+    gum_x86_writer_put_cmp_reg_reg(cw, GUM_REG_XCX, GUM_REG_XBX);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JLE, loop,
+        GUM_LIKELY);
+
+    /* Cache miss, do it the hard way */
     gum_x86_writer_put_label (cw, resolve_dynamically);
     gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XCX);
     gum_exec_block_close_prolog (block, gc);
+
   }
 
   gum_exec_block_open_prolog (block, GUM_PROLOG_MINIMAL, gc);
@@ -4145,10 +4209,12 @@ gum_exec_block_write_jmp_transfer_code (GumExecBlock * block,
   const GumAddress code_start = cw->pc;
   const GumPrologType opened_prolog = gc->opened_prolog;
   gboolean can_backpatch_statically;
-  gpointer * ic_entries = NULL;
+  GumIcEntry * ic_entries = NULL;
+  gpointer * ic_match = NULL;
   gconstpointer look_in_cache = cw->code + 1;
-  gconstpointer try_second = cw->code + 2;
-  gconstpointer resolve_dynamically = cw->code + 3;
+  gconstpointer loop = cw->code + 2;
+  gconstpointer try_next = cw->code + 3;
+  gconstpointer resolve_dynamically = cw->code + 4;
 
   can_backpatch_statically =
       trust_threshold >= 0 &&
@@ -4158,49 +4224,95 @@ gum_exec_block_write_jmp_transfer_code (GumExecBlock * block,
   if (trust_threshold >= 0 && !can_backpatch_statically)
   {
     gpointer null_ptr = NULL;
-    gpointer ic1_real, ic1_code;
-    gpointer ic2_real, ic2_code;
+    /*
+     * Value stored in the code_start field of the IcEntry when empty, so that
+     * it can be more easily idenified when debugging.
+     */
+    gpointer magic_ptr = (gpointer)0xbaadd00ddeadface;
+    /*
+     * Scratch space used to store the matched code_start field so we can jump
+     * there once we have restored all of the target context.
+     */
+    gpointer match_ptr = (gpointer)0xbaadd00dcafef00d;
 
     gum_exec_block_close_prolog (block, gc);
 
-    gum_x86_writer_put_jmp_short_label (cw, look_in_cache);
+    /*
+     * We need to use a near rather than short jump since our inline cache is
+     * larger than the maximum distance of a short jump (-128 to +127).
+     */
+    gum_x86_writer_put_jmp_near_label (cw, look_in_cache);
 
     ic_entries = gum_x86_writer_cur (cw);
-    ic1_real = ic_entries;
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic1_code = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic2_real = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
-    ic2_code = gum_x86_writer_cur (cw);
-    gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
+
+    /* Write our empty inline cache entries */
+    for (guint idx = 0; idx < GUM_IC_ENTRIES; idx++)
+    {
+        gum_x86_writer_put_bytes (cw, (guint8 *) &null_ptr, sizeof (null_ptr));
+        gum_x86_writer_put_bytes (cw, (guint8 *) &magic_ptr, sizeof (magic_ptr));
+    }
+
+    /*
+     * Write a token which we can replace with our matched ic entry code_start
+     * so we can use it as scratch space and retrieve and jump to it once we
+     * have restored the target application context.
+     */
+    ic_match = gum_x86_writer_cur (cw);
+    gum_x86_writer_put_bytes (cw, (guint8 *) &match_ptr, sizeof (match_ptr));
 
     gum_x86_writer_put_label (cw, look_in_cache);
     gum_exec_block_open_prolog (block, GUM_PROLOG_IC, gc);
 
+    gum_x86_writer_put_push_reg (cw, GUM_REG_XCX);
     gum_exec_ctx_write_push_branch_target_address (block->ctx, target, gc);
 
-    gum_x86_writer_put_mov_reg_near_ptr (cw, GUM_REG_XAX,
-        GUM_ADDRESS (ic1_real));
-    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
-    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, try_second,
-        GUM_NO_HINT);
-    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
-    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
-    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic1_code));
+    gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XCX,
+        GUM_ADDRESS (ic_entries));
+    gum_x86_writer_put_mov_reg_address (cw, GUM_REG_XBX,
+        GUM_ADDRESS (&ic_entries[GUM_IC_ENTRIES]));
 
-    gum_x86_writer_put_label (cw, try_second);
-    gum_x86_writer_put_mov_reg_near_ptr (cw, GUM_REG_XAX,
-        GUM_ADDRESS (ic2_real));
-    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
-    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, resolve_dynamically,
-        GUM_NO_HINT);
-    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
-    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
-    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic2_code));
+    /*
+     * Write our inline assembly which iterates through the IcEntry structures,
+     * attempting to match the real_start member with the target block address.
+     */
+    gum_x86_writer_put_label (cw, loop);
+    gum_x86_writer_put_mov_reg_reg_ptr (cw, GUM_REG_XAX, GUM_REG_XCX);
 
+    /* If real_start != target block, Then continue */
+    gum_x86_writer_put_cmp_reg_offset_ptr_reg (cw, GUM_REG_XSP, 0, GUM_REG_XAX);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JNE, try_next,
+        GUM_NO_HINT);
+
+    /*
+     * If real_start == NULL, Then break (we have reached the end of the
+     * initialized IcEntry structures.
+     */
+    gum_x86_writer_put_cmp_reg_i32 (cw, GUM_REG_XAX, 0);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JE, resolve_dynamically,
+        GUM_NO_HINT);
+
+    /* We found a match, stash the code_start value in the ic_match */
+    gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, GUM_REG_XCX, GUM_REG_XCX,
+        offsetof(GumIcEntry, code_start));
+    gum_x86_writer_put_mov_near_ptr_reg (cw, GUM_ADDRESS(ic_match), GUM_REG_XCX);
+
+    /* Restore the target context and jump at ic_match */
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XCX);
+    gum_exec_ctx_write_epilog (block->ctx, GUM_PROLOG_IC, cw);
+    gum_x86_writer_put_jmp_near_ptr (cw, GUM_ADDRESS (ic_match));
+
+    /* Increment our position through the IcEntry array*/
+    gum_x86_writer_put_label (cw, try_next);
+    gum_x86_writer_put_add_reg_imm (cw, GUM_REG_XCX, sizeof(GumIcEntry));
+    gum_x86_writer_put_cmp_reg_reg(cw, GUM_REG_XCX, GUM_REG_XBX);
+    gum_x86_writer_put_jcc_short_label (cw, X86_INS_JLE, loop,
+        GUM_NO_HINT);
+
+    /* Cache miss, do it the hard way */
     gum_x86_writer_put_label (cw, resolve_dynamically);
     gum_x86_writer_put_pop_reg (cw, GUM_REG_XAX);
+    gum_x86_writer_put_pop_reg (cw, GUM_REG_XCX);
     gum_exec_block_close_prolog (block, gc);
   }
 


### PR DESCRIPTION
Logging of stats information showed that even when prefetching of backpatches was enabled the target application was still making a large number of call back into the engine. Further examination showed that switch statements in particular can quickly saturate the cache of `ic_entries`. This patch changes the number of IC entries to be configurable by a #define and increases the number of entries to 16.