### PR TITLE
Fix x86 relocator to just patch offset for RIP relative instructions …

### DIFF
--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -582,6 +582,8 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   GumX86Writer * cw = ctx->code_writer;
   guint mod, reg, rm;
   gboolean is_rip_relative;
+  GumAddress address;
+  gssize offset;
   GumCpuReg cpu_regs[7] = {
     GUM_REG_RAX, GUM_REG_RCX, GUM_REG_RDX, GUM_REG_RBX, GUM_REG_RBP,
     GUM_REG_RSI, GUM_REG_RDI
@@ -591,8 +593,6 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
     X86_REG_RSI, X86_REG_RDI
   };
   gint rip_reg_index, i;
-  GumAddress  address;
-  gssize offset;
   GumCpuReg other_reg, rip_reg;
   GumAbiType target_abi = self->output->target_abi;
   guint8 code[16];
@@ -608,13 +608,13 @@ gum_x86_relocator_rewrite_if_rip_relative (GumX86Relocator * self,
   if (!is_rip_relative)
     return FALSE;
 
-  address = GUM_ADDRESS(insn->address + insn->size + x86->disp);
-  offset = address - (GUM_ADDRESS(cw->code) + insn->size);
+  address = GUM_ADDRESS (insn->address + insn->size + x86->disp);
+  offset = address - (GUM_ADDRESS (cw->code) + insn->size);
 
   if (offset >= G_MININT32 && offset <= G_MAXINT32)
   {
     gum_memcpy (code, ctx->start, ctx->len);
-    *((gint *) (&code[ctx->len - sizeof (gint)])) = (gint) offset;
+    *((gint32 *) &code[ctx->len - sizeof (gint32)]) = (gint32) offset;
     gum_x86_writer_put_bytes (cw, code, ctx->len);
     return TRUE;
   }


### PR DESCRIPTION
…where possible