### PR TITLE
gumjs: ignore Interceptor context in unrelated NativeCallback invokes

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -18,7 +18,6 @@
 #include "gumquickstalker.h"
 #include "gumsourcemap.h"
 
-#include <ffi.h>
 #include <string.h>
 #ifdef _MSC_VER
 # include <intrin.h>
@@ -37,7 +36,6 @@ typedef guint8 GumQuickExceptionsBehavior;
 typedef guint8 GumQuickCodeTraps;
 typedef guint8 GumQuickReturnValueShape;
 typedef struct _GumQuickFFIFunction GumQuickFFIFunction;
-typedef struct _GumQuickNativeCallback GumQuickNativeCallback;
 typedef struct _GumQuickCallbackContext GumQuickCallbackContext;
 
 struct _GumQuickFlushCallback
@@ -134,20 +132,6 @@ struct _GumQuickFFIFunction
   guint nargs_fixed;
   ffi_abi abi;
   GSList * data;
-};
-
-struct _GumQuickNativeCallback
-{
-  GumQuickNativePointer native_pointer;
-
-  JSValue wrapper;
-  JSValue func;
-  ffi_closure * closure;
-  ffi_cif cif;
-  ffi_type ** atypes;
-  GSList * data;
-
-  GumQuickCore * core;
 };
 
 struct _GumQuickCallbackContext
@@ -3683,7 +3667,7 @@ gum_quick_native_callback_invoke (ffi_cif * cif,
   }
 
   ic = gum_interceptor_get_current_invocation ();
-  if (ic != NULL)
+  if (ic != NULL && self->interceptor_replacement > 0)
   {
     jic = _gum_quick_interceptor_obtain_invocation_context (core->interceptor);
     _gum_quick_invocation_context_reset (jic, ic);

--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -12,6 +12,7 @@
 #include "gumquickscriptbackend-priv.h"
 
 #include <gum/gumexceptor.h>
+#include <ffi.h>
 
 #define GUM_QUICK_CORE_ATOM(core, name) \
     core->G_PASTE (atom_for_, name)
@@ -43,6 +44,7 @@ typedef struct _GumQuickCpuContext GumQuickCpuContext;
 typedef guint GumQuickCpuContextAccess;
 typedef struct _GumQuickNativeResource GumQuickNativeResource;
 typedef struct _GumQuickKernelResource GumQuickKernelResource;
+typedef struct _GumQuickNativeCallback GumQuickNativeCallback;
 
 typedef void (* GumQuickWeakNotify) (gpointer data);
 typedef void (* GumQuickFlushNotify) (GumQuickScript * script);
@@ -238,6 +240,21 @@ struct _GumQuickKernelResource
   GumQuickUInt64 u64;
 
   GumQuickKernelDestroyNotify notify;
+};
+
+struct _GumQuickNativeCallback
+{
+  GumQuickNativePointer native_pointer;
+
+  JSValue wrapper;
+  JSValue func;
+  ffi_closure * closure;
+  ffi_cif cif;
+  ffi_type ** atypes;
+  GSList * data;
+
+  GumQuickCore * core;
+  gint interceptor_replacement;
 };
 
 G_GNUC_INTERNAL void _gum_quick_core_init (GumQuickCore * self,

--- a/bindings/gumjs/gumquickinterceptor.c
+++ b/bindings/gumjs/gumquickinterceptor.c
@@ -642,6 +642,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_replace)
   JSValue replacement_value;
   GumQuickReplaceEntry * entry = NULL;
   GumReplaceReturn replace_ret;
+  GumQuickNativeCallback * c;
 
   self = gumjs_get_parent_module (core);
 
@@ -664,6 +665,10 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_replace)
       replacement_function, replacement_data);
   if (replace_ret != GUM_REPLACE_OK)
     goto unable_to_replace;
+
+  c = JS_GetOpaque (entry->replacement, core->native_callback_class);
+  if (c != NULL)
+    c->interceptor_replacement++;
 
   g_hash_table_insert (self->replacement_by_address, target, entry);
 
@@ -720,11 +725,21 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_revert)
 {
   GumQuickInterceptor * self;
   gpointer target;
+  GumQuickReplaceEntry * entry;
+  GumQuickNativeCallback * c;
 
   self = gumjs_get_parent_module (core);
 
   if (!_gum_quick_args_parse (args, "p", &target))
     return JS_EXCEPTION;
+
+  entry = g_hash_table_lookup (self->replacement_by_address, target);
+  if (entry != NULL)
+  {
+    c = JS_GetOpaque (entry->replacement, core->native_callback_class);
+    if (c != NULL)
+      c->interceptor_replacement--;
+  }
 
   g_hash_table_remove (self->replacement_by_address, target);
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -16,7 +16,6 @@
 #include "gumv8scope.h"
 #include "gumv8script-priv.h"
 
-#include <ffi.h>
 #ifdef _MSC_VER
 # include <intrin.h>
 #endif
@@ -123,21 +122,6 @@ struct GumV8NativeFunction
   gboolean is_variadic;
   uint32_t nargs_fixed;
   ffi_abi abi;
-  GSList * data;
-
-  GumV8Core * core;
-};
-
-struct GumV8NativeCallback
-{
-  gint ref_count;
-
-  GumPersistent<Object>::type * wrapper;
-
-  GumPersistent<Function>::type * func;
-  ffi_closure * closure;
-  ffi_cif cif;
-  ffi_type ** atypes;
   GSList * data;
 
   GumV8Core * core;
@@ -572,6 +556,8 @@ _gum_v8_core_init (GumV8Core * self,
       gumjs_native_callback_construct, scope, module, isolate);
   native_callback->Inherit (native_pointer);
   native_callback->InstanceTemplate ()->SetInternalFieldCount (1);
+  self->native_callback =
+      new GumPersistent<FunctionTemplate>::type (isolate, native_callback);
 
   auto cc = _gum_v8_create_class ("CallbackContext", nullptr, scope,
       module, isolate);
@@ -3100,7 +3086,7 @@ gum_v8_native_callback_invoke (ffi_cif * cif,
   GumV8InvocationContext * jic = NULL;
   GumV8CallbackContext * jcc = NULL;
   auto ic = gum_interceptor_get_current_invocation ();
-  if (ic != NULL)
+  if (ic != NULL && self->interceptor_replacement > 0)
   {
     jic = _gum_v8_interceptor_obtain_invocation_context (interceptor);
     _gum_v8_invocation_context_reset (jic, ic);

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -13,6 +13,7 @@
 #include "gumv8script.h"
 #include "gumv8scriptbackend.h"
 
+#include <ffi.h>
 #include <gum/gumexceptor.h>
 #include <gum/gumprocess.h>
 #include <v8/v8.h>
@@ -106,6 +107,7 @@ struct GumV8Core
   GumPersistent<v8::String>::type * value_key;
   GumPersistent<v8::String>::type * system_error_key;
 
+  GumPersistent<v8::FunctionTemplate>::type * native_callback;
   GumPersistent<v8::FunctionTemplate>::type * callback_context;
   GumPersistent<v8::Object>::type * callback_context_value;
 
@@ -139,6 +141,22 @@ struct GumV8ByteArray
   gpointer data;
   gsize size;
   GumV8Core * core;
+};
+
+struct GumV8NativeCallback
+{
+  gint ref_count;
+
+  GumPersistent<v8::Object>::type * wrapper;
+
+  GumPersistent<v8::Function>::type * func;
+  ffi_closure * closure;
+  ffi_cif cif;
+  ffi_type ** atypes;
+  GSList * data;
+
+  GumV8Core * core;
+  gint interceptor_replacement;
 };
 
 G_GNUC_INTERNAL void _gum_v8_core_init (GumV8Core * self,

--- a/bindings/gumjs/gumv8interceptor.cpp
+++ b/bindings/gumjs/gumv8interceptor.cpp
@@ -715,6 +715,16 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_replace)
 
   if (replace_ret == GUM_REPLACE_OK)
   {
+    auto native_callback = Local<FunctionTemplate>::New (isolate,
+      *core->native_callback);
+    auto instance = replacement_function_value.As<Object> ();
+    if (native_callback->HasInstance (instance))
+    {
+      auto callback = (GumV8NativeCallback *)
+          instance->GetInternalField (0).As<External> ()->Value ();
+      callback->interceptor_replacement++;
+    }
+
     g_hash_table_insert (module->replacement_by_address, target, entry);
   }
   else
@@ -760,6 +770,22 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_revert)
   gpointer target;
   if (!_gum_v8_args_parse (args, "p", &target))
     return;
+
+  auto entry = (GumV8ReplaceEntry *)
+      g_hash_table_lookup (module->replacement_by_address, target);
+  if (entry != NULL)
+  {
+    auto native_callback = Local<FunctionTemplate>::New (isolate,
+      *core->native_callback);
+    auto replacement_value (Local<Value>::New (isolate, *entry->replacement));
+    auto instance = replacement_value.As<Object> ();
+    if (native_callback->HasInstance (instance))
+    {
+      auto callback = (GumV8NativeCallback *)
+          instance->GetInternalField (0).As<External> ()->Value ();
+      callback->interceptor_replacement--;
+    }
+  }
 
   g_hash_table_remove (module->replacement_by_address, target);
 }

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -1931,16 +1931,25 @@ TESTCASE (native_callback_should_get_accurate_backtraces_2)
     "    }"
     "  });"
 
+    "  const interceptHere = detector['- matchesInString:options:range:'];"
+    "  Interceptor.attach(interceptHere.implementation, {"
+    "    onEnter() { }"
+    "  });"
+
     "  detector.matchesInString_options_range_(testString, 0, range);"
 
     "  const origImpl = method.implementation;"
     "  method.implementation = ObjC.implement(method,"
     "    function (handle, selector, ...args) {"
     "      if (sample === null) {"
-    "        sample = Thread.backtrace(this.context, Backtracer.ACCURATE);"
-    "        sampleRet = this.returnAddress;"
-    "        send('returnAddress ' +"
-    "            (sample[0].equals(sampleRet) ? 'ok' : 'error'));"
+    "        if (!this.context.pc.isNull()) {"
+    "          send('returnAddress error');"
+    "        } else {"
+    "          sample = Thread.backtrace(this.context, Backtracer.ACCURATE);"
+    "          sampleRet = this.returnAddress;"
+    "          send('returnAddress ' +"
+    "              (sample[0].equals(sampleRet) ? 'ok' : 'error'));"
+    "        }"
     "      }"
     "      return origImpl(handle, selector, ...args);"
     "    });"
@@ -5898,7 +5907,8 @@ TESTCASE (replaced_function_should_have_invocation_context)
 {
   COMPILE_AND_LOAD_SCRIPT (
       "Interceptor.replace(" GUM_PTR_CONST ", new NativeCallback(function () {"
-      "  send(this.returnAddress instanceof NativePointer);"
+      "  send(this.returnAddress instanceof NativePointer &&"
+      "     !this.context.pc.isNull());"
       "  return 0;"
       "}, 'int', ['int']));",
       target_function_int);


### PR DESCRIPTION
In this way invalid Interceptor contexts from higher up the call stack will be safely ignored in favor of the minimal but correct callback context.

NativeCallback instances invoked as part of `Interceptor.replace()` will continue to behave as usual and get the full context from the Interceptor's thread storage.

The new caveat is that when using the same NativeCallback instance both for `Interceptor.replace()` and an Interceptor-unrelated scenario (for example `ObjC.implement()`), AND both scenarios are invoked as part of the same call stack so that the Interceptor case happens earlier, the Interceptor context will "win" in the second invocation too and there will contain possibly invalid values. To overcome this issue, it is now possible to just use two different NativeCallback instances (which can share the same javascript function body, if needed).