### PR TITLE
Map "bool" to JS boolean instead of number

### DIFF
--- a/bindings/gumjs/gumffi.c
+++ b/bindings/gumjs/gumffi.c
@@ -67,6 +67,8 @@ GUM_DEFINE_FFI_TYPE (ssize_t, gint16, FFI_TYPE_SINT16)
 # error "size_t detection missing"
 #endif
 
+GUM_DEFINE_FFI_TYPE (bool, gboolean, FFI_TYPE_SINT8)
+
 static const GumFFITypeMapping gum_ffi_type_mappings[] =
 {
   { "void", &ffi_type_void },
@@ -89,7 +91,7 @@ static const GumFFITypeMapping gum_ffi_type_mappings[] =
   { "uint32", &ffi_type_uint32 },
   { "int64", &ffi_type_sint64 },
   { "uint64", &ffi_type_uint64 },
-  { "bool", &ffi_type_schar }
+  { "bool", &gum_ffi_type_bool }
 };
 
 static const GumFFIABIMapping gum_ffi_abi_mappings[] =

--- a/bindings/gumjs/gumffi.h
+++ b/bindings/gumjs/gumffi.h
@@ -37,6 +37,7 @@ union _GumFFIValue
   guint32 v_uint32;
   gint64 v_sint64;
   guint64 v_uint64;
+  gboolean v_boolean;
 };
 
 #else
@@ -116,6 +117,7 @@ union _GumFFIValue
       guchar v_uchar;
       gint8 v_sint8;
       guint8 v_uint8;
+      gboolean v_boolean;
     };
   };
 # else
@@ -155,6 +157,7 @@ union _GumFFIValue
       guchar v_uchar;
       gint8 v_sint8;
       guint8 v_uint8;
+      gboolean v_boolean;
     };
   };
 # endif
@@ -166,6 +169,7 @@ union _GumFFIValue
 
 extern ffi_type gum_ffi_type_size_t;
 extern ffi_type gum_ffi_type_ssize_t;
+extern ffi_type gum_ffi_type_bool;
 
 G_GNUC_INTERNAL gboolean gum_ffi_try_get_type_by_name (const gchar * name,
     ffi_type ** type);

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -4394,6 +4394,14 @@ gum_quick_value_to_ffi (JSContext * ctx,
       return FALSE;
     val->v_double = d;
   }
+  else if (type == &gum_ffi_type_bool)
+  {
+    gboolean b;
+
+    if (!_gum_quick_boolean_get (ctx, sval, &b))
+      return FALSE;
+    val->v_boolean = b;
+  }
   else if (type->type == FFI_TYPE_STRUCT)
   {
     ffi_type ** const field_types = type->elements, ** t;
@@ -4545,6 +4553,10 @@ gum_quick_value_from_ffi (JSContext * ctx,
   else if (type == &ffi_type_double)
   {
     return JS_NewFloat64 (ctx, val->v_double);
+  }
+  else if (type == &gum_ffi_type_bool)
+  {
+    return JS_NewBool (ctx, val->v_boolean);
   }
   else if (type->type == FFI_TYPE_STRUCT)
   {

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3682,6 +3682,12 @@ gum_v8_value_to_ffi_type (GumV8Core * core,
       goto error_expected_number;
     value->v_double = svalue->NumberValue (context).ToChecked ();
   }
+  else if (type == &gum_ffi_type_bool)
+  {
+    if (!svalue->IsBoolean ())
+      goto error_expected_boolean;
+    value->v_boolean = svalue->BooleanValue (isolate);
+  }
   else if (type->type == FFI_TYPE_STRUCT)
   {
     if (!svalue->IsArray ())
@@ -3740,6 +3746,11 @@ gum_v8_value_to_ffi_type (GumV8Core * core,
 error_expected_number:
   {
     _gum_v8_throw_ascii_literal (isolate, "expected number");
+    return FALSE;
+  }
+error_expected_boolean:
+  {
+    _gum_v8_throw_ascii_literal (isolate, "expected boolean");
     return FALSE;
   }
 error_unsupported_type:
@@ -3848,6 +3859,10 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
   else if (type == &ffi_type_double)
   {
     *svalue = Number::New (isolate, value->v_double);
+  }
+  else if (type == &gum_ffi_type_bool)
+  {
+    *svalue = Boolean::New (isolate, value->v_boolean);
   }
   else if (type->type == FFI_TYPE_STRUCT)
   {


### PR DESCRIPTION
The title says it all; `"bool"` will now require a boolean value instead of a number. I hope I didn't miss something!

(Update to [frida-gum typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/frida-gum/index.d.ts#L1716) is also needed)