### PR TITLE
objc-api-resolver: Guard against disposed objc classes

### DIFF
--- a/gum/backend-darwin/gumobjcapiresolver.c
+++ b/gum/backend-darwin/gumobjcapiresolver.c
@@ -415,7 +415,8 @@ gum_objc_api_resolver_create_snapshot (GumObjcApiResolver * self)
       GumObjcClassMetadata * klass;
 
       klass = g_hash_table_lookup (class_by_handle, super_handle);
-      klass->subclasses = g_slist_prepend (klass->subclasses, handle);
+      if (klass != NULL)
+        klass->subclasses = g_slist_prepend (klass->subclasses, handle);
     }
   }
 


### PR DESCRIPTION
This change reduces the chances of crashing when any Objective-C class gets disposed during the lifetime of an `ApiResolver` instance of the `objc` type, by detecting and removing dangling class references.