### PR TITLE
Add regex support to `Memory.scan()` and implement `MatchPattern` object

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -3989,7 +3989,7 @@ GUMJS_DEFINE_FINALIZER (gumjs_match_pattern_finalize)
   if (p == NULL)
     return;
 
-  gum_match_pattern_free (p);
+  gum_match_pattern_unref (p);
 }
 
 static gboolean

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2020-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -302,6 +303,9 @@ static JSValue gumjs_source_map_new (const gchar * json, GumQuickCore * core);
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_source_map_construct)
 GUMJS_DECLARE_FINALIZER (gumjs_source_map_finalize)
 GUMJS_DECLARE_FUNCTION (gumjs_source_map_resolve)
+
+GUMJS_DECLARE_CONSTRUCTOR (gumjs_match_pattern_construct)
+GUMJS_DECLARE_FINALIZER (gumjs_match_pattern_finalize)
 
 static JSValue gum_quick_core_schedule_callback (GumQuickCore * self,
     GumQuickArgs * args, gboolean repeat);
@@ -846,6 +850,12 @@ static const JSCFunctionListEntry gumjs_source_map_entries[] =
   JS_CFUNC_DEF ("_resolve", 0, gumjs_source_map_resolve),
 };
 
+static const JSClassDef gumjs_match_pattern_def =
+{
+  .class_name = "MatchPattern",
+  .finalizer = gumjs_match_pattern_finalize,
+};
+
 void
 _gum_quick_core_init (GumQuickCore * self,
                       GumQuickScript * script,
@@ -1032,6 +1042,14 @@ _gum_quick_core_init (GumQuickCore * self,
   JS_SetPropertyFunctionList (ctx, proto, gumjs_source_map_entries,
       G_N_ELEMENTS (gumjs_source_map_entries));
   JS_DefinePropertyValueStr (ctx, ns, gumjs_source_map_def.class_name, ctor,
+      JS_PROP_C_W_E);
+
+  _gum_quick_create_class (ctx, &gumjs_match_pattern_def, self,
+      &self->match_pattern_class, &proto);
+  ctor = JS_NewCFunction2 (ctx, gumjs_match_pattern_construct,
+      gumjs_match_pattern_def.class_name, 0, JS_CFUNC_constructor, 0);
+  JS_SetConstructor (ctx, ctor, proto);
+  JS_DefinePropertyValueStr (ctx, ns, gumjs_match_pattern_def.class_name, ctor,
       JS_PROP_C_W_E);
 
   JS_FreeValue (ctx, global_obj);
@@ -4038,6 +4056,57 @@ GUMJS_DEFINE_FUNCTION (gumjs_source_map_resolve)
   {
     return JS_NULL;
   }
+}
+
+GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
+{
+  JSValue wrapper;
+  const gchar * pattern_str;
+  JSValue proto;
+  GumMatchPattern * pattern;
+
+  wrapper = JS_NULL;
+
+  if (!_gum_quick_args_parse (args, "s", &pattern_str))
+    goto propogate_exception;
+
+  proto = JS_GetProperty (ctx, new_target,
+      GUM_QUICK_CORE_ATOM (core, prototype));
+  wrapper = JS_NewObjectProtoClass (ctx, proto, core->match_pattern_class);
+  JS_FreeValue (ctx, proto);
+  if (JS_IsException (wrapper))
+    goto propogate_exception;
+
+  pattern = gum_match_pattern_new_from_string (pattern_str);
+  if (pattern == NULL)
+    goto invalid_match_pattern;
+
+  JS_SetOpaque (wrapper, pattern);
+
+  return wrapper;
+
+invalid_match_pattern:
+  {
+    _gum_quick_throw_literal (ctx, "invalid match pattern");
+    goto propogate_exception;
+  }
+propogate_exception:
+  {
+    JS_FreeValue (ctx, wrapper);
+
+    return JS_EXCEPTION;
+  }
+}
+
+GUMJS_DEFINE_FINALIZER (gumjs_match_pattern_finalize)
+{
+  GumMatchPattern * p;
+
+  p = JS_GetOpaque (val, core->match_pattern_class);
+  if (p == NULL)
+    return;
+
+  gum_match_pattern_free (p);
 }
 
 static JSValue

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -3951,14 +3951,14 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
   wrapper = JS_NULL;
 
   if (!_gum_quick_args_parse (args, "s", &pattern_str))
-    goto propogate_exception;
+    goto propagate_exception;
 
   proto = JS_GetProperty (ctx, new_target,
       GUM_QUICK_CORE_ATOM (core, prototype));
   wrapper = JS_NewObjectProtoClass (ctx, proto, core->match_pattern_class);
   JS_FreeValue (ctx, proto);
   if (JS_IsException (wrapper))
-    goto propogate_exception;
+    goto propagate_exception;
 
   pattern = gum_match_pattern_new_from_string (pattern_str);
   if (pattern == NULL)
@@ -3971,9 +3971,9 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
 invalid_match_pattern:
   {
     _gum_quick_throw_literal (ctx, "invalid match pattern");
-    goto propogate_exception;
+    goto propagate_exception;
   }
-propogate_exception:
+propagate_exception:
   {
     JS_FreeValue (ctx, wrapper);
 

--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -115,6 +115,7 @@ struct _GumQuickCore
   JSClassID cpu_context_class;
   JSClassID source_map_class;
   JSValue source_map_ctor;
+  JSClassID match_pattern_class;
 
 #define GUM_DECLARE_ATOM(id) \
     JSAtom G_PASTE (atom_for_, id)

--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -113,9 +113,9 @@ struct _GumQuickCore
   JSClassID native_callback_class;
   JSClassID callback_context_class;
   JSClassID cpu_context_class;
+  JSClassID match_pattern_class;
   JSClassID source_map_class;
   JSValue source_map_ctor;
-  JSClassID match_pattern_class;
 
 #define GUM_DECLARE_ATOM(id) \
     JSAtom G_PASTE (atom_for_, id)

--- a/bindings/gumjs/gumquickcore.h
+++ b/bindings/gumjs/gumquickcore.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -880,7 +880,7 @@ gum_kernel_scan_context_free (GumKernelScanContext * self)
   _gum_quick_core_unpin (core);
   _gum_quick_scope_leave (&scope);
 
-  gum_match_pattern_free (self->pattern);
+  gum_match_pattern_unref (self->pattern);
 
   g_slice_free (GumKernelScanContext, self);
 }
@@ -963,7 +963,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
   gum_kernel_scan (&range, pattern, (GumMemoryScanMatchFunc) gum_append_match,
       &sc);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   return result;
 }

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -947,7 +947,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   pattern_val = args->elements[2];
 
-  if (JS_IsString (pattern_val)) {
+  if (JS_IsString (pattern_val))
+  {
     const gchar * match_str;
 
     if (!_gum_quick_string_get (ctx, args->elements[2], &match_str))
@@ -955,9 +956,13 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
     sc.pattern = gum_match_pattern_new_from_string (match_str);
     JS_FreeCString (ctx, match_str);
-  } else if (JS_IsObject (pattern_val)) {
+  }
+  else if (JS_IsObject (pattern_val))
+  {
     sc.pattern = JS_GetOpaque(pattern_val, core->match_pattern_class);
-  } else {
+  }
+  else
+  {
     return _gum_quick_throw_literal (ctx,
         "expected either a pattern string or a MatchPattern object");
   }
@@ -967,7 +972,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   callbacks = args->elements[3];
 
-  if (!JS_IsObject (callbacks)) {
+  if (!JS_IsObject (callbacks))
+  {
     return _gum_quick_throw_literal (ctx,
         "expected an object containing callbacks");
   }
@@ -975,9 +981,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   sc.on_match = JS_GetPropertyStr (ctx, callbacks, "onMatch");
   sc.on_complete = JS_GetPropertyStr (ctx, callbacks, "onComplete");
 
-  if (!JS_IsFunction (ctx, sc.on_match)) {
+  if (!JS_IsFunction (ctx, sc.on_match))
     return _gum_quick_throw_literal (ctx, "expected a callback value");
-  }
 
   sc.on_complete = JS_GetPropertyStr (ctx, callbacks, "onComplete");
   sc.on_error = JS_GetPropertyStr (ctx, callbacks, "onError");

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -1000,7 +1000,7 @@ gum_memory_scan_context_free (GumMemoryScanContext * self)
   _gum_quick_core_unpin (core);
   _gum_quick_scope_leave (&scope);
 
-  gum_match_pattern_free (self->pattern);
+  gum_match_pattern_unref (self->pattern);
 
   g_slice_free (GumMemoryScanContext, self);
 }
@@ -1109,7 +1109,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
         &sc);
   }
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   if (gum_exceptor_catch (core->exceptor, &scope))
   {

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -315,7 +315,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
   {
     if ((size % page_size) != 0)
     {
-      return _gum_quick_native_resource_new (ctx, g_malloc0 (size), g_free, core);
+      return _gum_quick_native_resource_new (ctx, g_malloc0 (size), g_free,
+          core);
     }
     else
     {

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -932,9 +932,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc_utf16_string)
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 {
-  GumMemoryScanContext sc;
   gpointer address;
   gsize size;
+  GumMemoryScanContext sc;
   JSValue callbacks;
 
   if (args->count < 4)

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -146,7 +146,7 @@ static void gum_memory_scan_context_run (GumMemoryScanContext * self);
 static gboolean gum_memory_scan_context_emit_match (GumAddress address,
     gsize size, GumMemoryScanContext * self);
 GUMJS_DECLARE_FUNCTION (gumjs_memory_scan_sync)
-static gboolean gum_memory_scan_args_parse (JSContext * ctx,
+static gboolean gum_parse_memory_scan_args (JSContext * ctx,
     const GumQuickArgs * args, gpointer * address, gsize * size,
     GumMatchPattern ** pattern);
 static gboolean gum_append_match (GumAddress address, gsize size,
@@ -941,7 +941,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   if (args->count < 4)
     return _gum_quick_throw_literal (ctx, "missing argument");
 
-  if (!gum_memory_scan_args_parse (ctx, args, &address, &size, &sc.pattern))
+  if (!gum_parse_memory_scan_args (ctx, args, &address, &size, &sc.pattern))
     return JS_EXCEPTION;
 
   callbacks = args->elements[3];
@@ -1098,7 +1098,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
   if (args->count < 3)
     return _gum_quick_throw_literal (ctx, "missing argument");
 
-  if (!gum_memory_scan_args_parse (ctx, args, &address, &size, &pattern))
+  if (!gum_parse_memory_scan_args (ctx, args, &address, &size, &pattern))
     return JS_EXCEPTION;
 
   range.base_address = GUM_ADDRESS (address);
@@ -1130,7 +1130,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
 }
 
 static gboolean
-gum_memory_scan_args_parse (JSContext * ctx,
+gum_parse_memory_scan_args (JSContext * ctx,
                             const GumQuickArgs * args,
                             gpointer * address,
                             gsize * size,

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -966,7 +966,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   sc.ctx = ctx;
   sc.core = core;
 
-  /* TODO: When to free? */
   JS_DupValue (ctx, sc.on_match);
   JS_DupValue (ctx, sc.on_error);
   JS_DupValue (ctx, sc.on_complete);

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -947,7 +947,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   callbacks = args->elements[3];
   if (!JS_IsObject (callbacks))
     goto invalid_callbacks_object;
-
   sc.on_match = JS_GetPropertyStr (ctx, callbacks, "onMatch");
   if (!JS_IsFunction (ctx, sc.on_match))
     goto missing_callback_value;

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -1168,7 +1168,6 @@ gum_parse_memory_scan_args (JSContext * ctx,
     return FALSE;
 
   pattern_val = args->elements[2];
-
   if (JS_IsString (pattern_val))
   {
     const gchar * match_str;

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3346,7 +3346,7 @@ gum_v8_match_pattern_free (GumV8MatchPattern * self)
 {
   delete self->wrapper;
 
-  gum_match_pattern_free (self->handle);
+  gum_match_pattern_unref (self->handle);
 
   g_slice_free (GumV8MatchPattern, self);
 }

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -1041,6 +1041,9 @@ _gum_v8_core_finalize (GumV8Core * self)
   delete self->source_map;
   self->source_map = nullptr;
 
+  delete self->match_pattern;
+  self->match_pattern = nullptr;
+
   delete self->cpu_context;
   self->cpu_context = nullptr;
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3318,8 +3318,8 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
 
   if (pattern == NULL)
   {
-      _gum_v8_throw (isolate, "invalid match pattern");
-      return;
+    _gum_v8_throw_literal (isolate, "invalid match pattern");
+    return;
   }
 
   wrapper->SetInternalField (0, External::New (isolate, pattern));

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -972,6 +972,9 @@ _gum_v8_core_dispose (GumV8Core * self)
   g_hash_table_unref (self->source_maps);
   self->source_maps = NULL;
 
+  g_hash_table_unref (self->match_patterns);
+  self->match_patterns = NULL;
+
   g_hash_table_unref (self->kernel_resources);
   self->kernel_resources = NULL;
   g_hash_table_unref (self->native_resources);

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3426,7 +3426,8 @@ gum_v8_source_map_on_weak_notify (const WeakCallbackInfo<GumV8SourceMap> & info)
 
 GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
 {
-  if (!info.IsConstructCall()) {
+  if (!info.IsConstructCall())
+  {
     _gum_v8_throw_ascii_literal (isolate,
         "use `new MatchPattern()` to create a new instance");
     return;
@@ -3440,7 +3441,8 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
 
   g_free (pattern_str);
 
-  if (pattern == NULL) {
+  if (pattern == NULL)
+  {
       _gum_v8_throw (isolate, "invalid match pattern");
       return;
   }

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -461,11 +461,6 @@ static const GumV8Property gumjs_callback_context_values[] =
   { NULL, NULL, NULL }
 };
 
-static const GumV8Property gumjs_match_pattern_values[] =
-{
-  { NULL, NULL, NULL }
-};
-
 static const GumV8Function gumjs_source_map_functions[] =
 {
   { "_resolve", gumjs_source_map_resolve },
@@ -743,8 +738,6 @@ _gum_v8_core_init (GumV8Core * self,
 
   auto match_pattern = _gum_v8_create_class ("MatchPattern",
       gumjs_match_pattern_construct, scope, module, isolate);
-  _gum_v8_class_add (match_pattern, gumjs_match_pattern_values, module,
-      isolate);
   self->match_pattern =
       new GumPersistent<FunctionTemplate>::type (isolate, match_pattern);
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3452,10 +3452,9 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
 }
 
 static GumV8MatchPattern *
-gum_v8_match_pattern_new (
-    Local<Object> wrapper,
-    GumMatchPattern * handle,
-    GumV8Core * core)
+gum_v8_match_pattern_new (Local<Object> wrapper,
+                          GumMatchPattern * handle,
+                          GumV8Core * core)
 {
   auto pattern = g_slice_new (GumV8MatchPattern);
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -143,6 +143,12 @@ struct GumV8SourceMap
   GumV8Core * core;
 };
 
+struct GumV8MatchPattern
+{
+  GumPersistent<Object>::type * wrapper;
+  GumMatchPattern * handle;
+};
+
 static gboolean gum_v8_core_handle_crashed_js (GumExceptionDetails * details,
     gpointer user_data);
 
@@ -305,6 +311,11 @@ static void gum_v8_source_map_free (GumV8SourceMap * self);
 static void gum_v8_source_map_on_weak_notify (
     const WeakCallbackInfo<GumV8SourceMap> & info);
 
+GUMJS_DECLARE_CONSTRUCTOR (gumjs_match_pattern_construct)
+static GumV8MatchPattern * gum_v8_match_pattern_new (Local<Object> wrapper,
+    GumMatchPattern * pattern, GumV8Core * core);
+static void gum_v8_match_pattern_free (GumV8MatchPattern * self);
+
 static GumV8ExceptionSink * gum_v8_exception_sink_new (
     Local<Function> callback, Isolate * isolate);
 static void gum_v8_exception_sink_free (GumV8ExceptionSink * sink);
@@ -454,6 +465,11 @@ static const GumV8Function gumjs_source_map_functions[] =
   { "_resolve", gumjs_source_map_resolve },
 
   { NULL, NULL }
+};
+
+static const GumV8Property gumjs_match_pattern_values[] =
+{
+  { NULL, NULL, NULL }
 };
 
 void
@@ -730,6 +746,13 @@ _gum_v8_core_init (GumV8Core * self,
   self->source_map =
       new GumPersistent<FunctionTemplate>::type (isolate, source_map);
 
+  auto match_pattern = _gum_v8_create_class ("MatchPattern",
+      gumjs_match_pattern_construct, scope, module, isolate);
+  _gum_v8_class_add (match_pattern, gumjs_match_pattern_values, module,
+      isolate);
+  self->match_pattern =
+      new GumPersistent<FunctionTemplate>::type (isolate, match_pattern);
+
   gum_exceptor_add (self->exceptor, gum_v8_core_handle_crashed_js, self);
 }
 
@@ -791,6 +814,9 @@ _gum_v8_core_realize (GumV8Core * self)
 
   self->source_maps = g_hash_table_new_full (NULL, NULL, NULL,
       (GDestroyNotify) gum_v8_source_map_free);
+
+  self->match_patterns = g_hash_table_new_full (NULL, NULL, NULL,
+      (GDestroyNotify) gum_v8_match_pattern_free);
 
   Local<Value> zero = Integer::New (isolate, 0);
 
@@ -3396,6 +3422,57 @@ gum_v8_source_map_on_weak_notify (const WeakCallbackInfo<GumV8SourceMap> & info)
   HandleScope handle_scope (info.GetIsolate ());
   auto self = info.GetParameter ();
   g_hash_table_remove (self->core->source_maps, self);
+}
+
+GUMJS_DEFINE_CONSTRUCTOR (gumjs_match_pattern_construct)
+{
+  if (!info.IsConstructCall()) {
+    _gum_v8_throw_ascii_literal (isolate,
+        "use `new MatchPattern()` to create a new instance");
+    return;
+  }
+
+  gchar * pattern_str;
+  if (!_gum_v8_args_parse (args, "s", &pattern_str))
+    return;
+
+  auto pattern = gum_match_pattern_new_from_string (pattern_str);
+
+  g_free (pattern_str);
+
+  if (pattern == NULL) {
+      _gum_v8_throw (isolate, "invalid match pattern");
+      return;
+  }
+
+  wrapper->SetInternalField (0, External::New (isolate, pattern));
+  gum_v8_match_pattern_new (wrapper, pattern, module);
+}
+
+static GumV8MatchPattern *
+gum_v8_match_pattern_new (
+    Local<Object> wrapper,
+    GumMatchPattern * handle,
+    GumV8Core * core)
+{
+  auto pattern = g_slice_new (GumV8MatchPattern);
+
+  pattern->wrapper = new GumPersistent<Object>::type (core->isolate, wrapper);
+  pattern->handle = handle;
+
+  g_hash_table_add (core->match_patterns, pattern);
+
+  return pattern;
+}
+
+static void
+gum_v8_match_pattern_free (GumV8MatchPattern * self)
+{
+  delete self->wrapper;
+
+  gum_match_pattern_free (self->handle);
+
+  g_slice_free (GumV8MatchPattern, self);
 }
 
 static GumV8ExceptionSink *

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -4,6 +4,7 @@
  * Copyright (C) 2015 Marc Hartmayer <hello@hartmayer.com>
  * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -118,7 +118,6 @@ struct GumV8Core
 
   GumPersistent<v8::FunctionTemplate>::type * source_map;
 
-  // TODO: how to finalize / release?
   GumPersistent<v8::FunctionTemplate>::type * match_pattern;
 };
 

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -86,9 +86,9 @@ struct GumV8Core
   GHashTable * native_resources;
   GHashTable * kernel_resources;
 
-  GHashTable * source_maps;
-
   GHashTable * match_patterns;
+
+  GHashTable * source_maps;
 
   GumPersistent<v8::FunctionTemplate>::type * int64;
   GumPersistent<v8::Object>::type * int64_value;
@@ -116,9 +116,9 @@ struct GumV8Core
   GumPersistent<v8::FunctionTemplate>::type * cpu_context;
   GumPersistent<v8::Object>::type * cpu_context_value;
 
-  GumPersistent<v8::FunctionTemplate>::type * source_map;
-
   GumPersistent<v8::FunctionTemplate>::type * match_pattern;
+
+  GumPersistent<v8::FunctionTemplate>::type * source_map;
 };
 
 struct GumV8NativeResource

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -88,6 +88,8 @@ struct GumV8Core
 
   GHashTable * source_maps;
 
+  GHashTable * match_patterns;
+
   GumPersistent<v8::FunctionTemplate>::type * int64;
   GumPersistent<v8::Object>::type * int64_value;
 
@@ -115,6 +117,9 @@ struct GumV8Core
   GumPersistent<v8::Object>::type * cpu_context_value;
 
   GumPersistent<v8::FunctionTemplate>::type * source_map;
+
+  // TODO: how to finalize / release?
+  GumPersistent<v8::FunctionTemplate>::type * match_pattern;
 };
 
 struct GumV8NativeResource

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -776,7 +776,7 @@ gum_kernel_scan_context_free (GumKernelScanContext * self)
 {
   auto core = self->core;
 
-  gum_match_pattern_free (self->pattern);
+  gum_match_pattern_unref (self->pattern);
 
   {
     ScriptScope script_scope (core->script);
@@ -876,7 +876,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
 
   info.GetReturnValue ().Set (ctx.matches);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 }
 
 static gboolean

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -986,7 +986,7 @@ gum_memory_scan_context_free (GumMemoryScanContext * self)
 {
   auto core = self->core;
 
-  gum_match_pattern_free (self->pattern);
+  gum_match_pattern_unref (self->pattern);
 
   {
     ScriptScope script_scope (core->script);
@@ -1107,7 +1107,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
         &ctx);
   }
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   if (gum_exceptor_catch (core->exceptor, &scope))
   {

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -1163,7 +1163,7 @@ gum_parse_memory_scan_args (GumV8Core * core,
   }
   else
   {
-    auto match_pattern = Local<FunctionTemplate>::New (isolate,
+    auto match_pattern = Local<FunctionTemplate>::New (core->isolate,
         *core->match_pattern);
     if (!match_pattern->HasInstance (pattern_val))
     {

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -913,7 +913,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   gpointer address;
   gsize size;
 
-  if (info.Length () < 4) {
+  if (info.Length () < 4)
+  {
     _gum_v8_throw_ascii_literal (isolate, "missing argument");
     return;
   }
@@ -927,26 +928,33 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   auto pattern_val = info[2];
   GumMatchPattern * pattern = NULL;
 
-  if (pattern_val->IsString()) {
+  if (pattern_val->IsString())
+  {
     String::Utf8Value pattern_utf8 (isolate, pattern_val);
     pattern = gum_match_pattern_new_from_string (*pattern_utf8);
-  } else if (pattern_val->IsObject()) {
+  }
+  else if (pattern_val->IsObject())
+  {
     auto pattern_obj = pattern_val.As<Object> ();
     pattern = (GumMatchPattern *)pattern_obj->GetInternalField (0)
         .As<External> ()->Value ();
-  } else {
+  }
+  else
+  {
     _gum_v8_throw_ascii_literal (isolate,
         "expected either a pattern string or a MatchPattern object");
     return;
   }
 
-  if (pattern == nullptr) {
+  if (pattern == nullptr)
+  {
     _gum_v8_throw_ascii_literal (isolate,
         "expected either a pattern string or a MatchPattern object");
     return;
   }
 
-  if (!info[3]->IsObject ()) {
+  if (!info[3]->IsObject ())
+  {
     _gum_v8_throw_ascii_literal (isolate,
         "expected an object containing callbacks");
     return;
@@ -959,7 +967,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   if (!callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
           "onMatch")).ToLocal (&on_match_val) ||
-      !on_match_val->IsFunction ()) {
+      !on_match_val->IsFunction ())
+  {
     _gum_v8_throw_literal (isolate, "expected a callback value");
     return;
   }
@@ -968,13 +977,15 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   if (callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
           "onComplete")).ToLocal (&on_complete_val) &&
-      !on_complete_val.IsEmpty ()) {
+      !on_complete_val.IsEmpty ())
+  {
     on_complete = on_complete_val.As <Function> ();
   }
 
   if (callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
           "onError")).ToLocal (&on_error_val) &&
-      !on_error_val.IsEmpty ()) {
+      !on_error_val.IsEmpty ())
+  {
     on_error = on_error_val.As <Function> ();
   }
 

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -1252,7 +1252,7 @@ _gum_v8_native_pointer_get (Local<Value> value,
 
   if (!success)
   {
-    _gum_v8_throw_ascii_literal (isolate, "expected a NativePointer object");
+    _gum_v8_throw_ascii_literal (isolate, "expected a pointer");
     return FALSE;
   }
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -239,17 +239,17 @@ Object.defineProperties(Memory, {
         throw new Error('expected a callback value');
 
       return new Promise(function (resolve, reject) {
-          Memory._scan(address, size, pattern, {
-            onMatch: callbacks.onMatch,
-            onComplete: () => {
-              callbacks.onComplete?.();
-              resolve();
-            },
-            onError: (reason) => {
-              callbacks.onError?.(reason);
-              reject(new Error(reason));
-            }
-          });
+        Memory._scan(address, size, pattern, {
+          onMatch: callbacks.onMatch,
+          onComplete: () => {
+            callbacks.onComplete?.();
+            resolve();
+          },
+          onError: (reason) => {
+            callbacks.onError?.(reason);
+            reject(new Error(reason));
+          }
+        });
       });
     }
   }

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -226,7 +226,10 @@ Object.defineProperties(Memory, {
       if (!isInt || isLessThanZero)
         throw new Error('expected an unsigned integer');
 
-      if (typeof(pattern) !== 'string' && !(pattern instanceof MatchPattern))
+      if (typeof(pattern) === 'string')
+        /* XXX: test if it's a valid pattern */
+        new MatchPattern(pattern);
+      else if (!(pattern instanceof MatchPattern))
         throw new Error('expected either a pattern string or a MatchPattern object');
 
       if (typeof(callbacks) !== 'object')

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -208,6 +208,40 @@ Object.defineProperties(Memory, {
       Memory._patchCode(address, size, apply);
     }
   },
+  scan: {
+    enumerable: true,
+    value: function (address, size, pattern, callbacks) {
+      const wrappedArgs = arguments;
+
+      return new Promise(function (resolve, reject) {
+        if (wrappedArgs.length < 4) {
+          reject(new Error('missing argument'));
+          return;
+        }
+
+        if (typeof(callbacks) !== 'object') {
+          reject(new Error('expected an object containing callbacks'));
+          return;
+        }
+
+        try {
+          Memory._scan(address, size, pattern, {
+            onMatch: callbacks.onMatch,
+            onComplete: () => {
+              callbacks.onComplete?.();
+              resolve();
+            },
+            onError: (reason) => {
+              callbacks.onError?.(reason);
+              reject(new Error(reason));
+            }
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }
+  }
 });
 
 makeEnumerateApi(Module, 'enumerateImports', 1);

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -219,11 +219,11 @@ Object.defineProperties(Memory, {
 
       Memory._scan(address, size, pattern, {
         onMatch: callbacks.onMatch,
-        onComplete: () => {
+        onComplete() {
           onSuccess();
           callbacks.onComplete?.();
         },
-        onError: (reason) => {
+        onError(reason) {
           onFailure(new Error(reason));
           callbacks.onError?.(reason);
         }

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -482,7 +482,7 @@ gum_kernel_scan_section (const gchar * section_name,
 
   gum_kernel_scan (&range, pattern, func, user_data);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   return TRUE;
 }
@@ -838,7 +838,7 @@ gum_kernel_has_kld (GumAddress address)
   gum_kernel_scan (&range, pattern,
       (GumMemoryScanMatchFunc) gum_kernel_find_first_hit, &found);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   return found;
 }

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -318,15 +318,17 @@ gum_kernel_scan (const GumMemoryRange * range,
 {
   GumKernelScanContext ctx;
   GumAddress cursor, end;
+  guint pattern_size;
   gsize size, max_chunk_size;
 
   ctx.func = func;
   ctx.user_data = user_data;
 
   cursor = range->base_address;
+  pattern_size = gum_match_pattern_get_size (pattern);
   size = range->size;
-  max_chunk_size = MAX (pattern->size * 2, 2048 * 512);
-  end = cursor + size - pattern->size;
+  max_chunk_size = MAX (pattern_size * 2, 2048 * 512);
+  end = cursor + size - pattern_size;
 
   while (cursor <= end)
   {
@@ -353,8 +355,8 @@ gum_kernel_scan (const GumMemoryRange * range,
     if (!ctx.carry_on)
       return;
 
-    cursor += chunk_size - pattern->size + 1;
-    size -= chunk_size - pattern->size + 1;
+    cursor += chunk_size - pattern_size + 1;
+    size -= chunk_size - pattern_size + 1;
   }
 }
 

--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -1358,7 +1358,7 @@ gum_store_dl_mutex_pointer_if_found_in_section (
         details->address + (GUM_ADDRESS (mutex_in_file) - range.base_address));
   }
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   return FALSE;
 }
@@ -1391,7 +1391,7 @@ gum_store_libdl_info_pointer_if_found_in_section (
   {
     pattern = gum_match_pattern_new_from_string ("6c 69 62 64 6c 2e 73 6f 00");
     gum_memory_scan (&range, pattern, gum_store_first_scan_match, libdl_info);
-    gum_match_pattern_free (pattern);
+    gum_match_pattern_unref (pattern);
   }
   else if (strcmp (details->name, ".bss") == 0)
   {
@@ -1471,7 +1471,7 @@ gum_find_function_by_signature (GumAddress address,
     gum_memory_scan (&range, pattern,
         (GumMemoryScanMatchFunc) gum_store_function_signature_match, &ctx);
 
-    gum_match_pattern_free (pattern);
+    gum_match_pattern_unref (pattern);
 
     if (ctx.num_matches == 1)
       return GSIZE_TO_POINTER (ctx.match + s->displacement);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -5570,7 +5570,7 @@ gum_find_thread_exit_implementation (void)
 
   gum_memory_scan (&range, pattern, gum_store_thread_exit_match, &result);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   /* Non-public symbols are all <redacted> on iOS. */
 #ifndef HAVE_IOS

--- a/gum/gummemory-priv.h
+++ b/gum/gummemory-priv.h
@@ -12,12 +12,6 @@
 typedef struct _GumMatchToken GumMatchToken;
 typedef enum _GumMatchType GumMatchType;
 
-struct _GumMatchPattern
-{
-  GPtrArray * tokens;
-  guint size;
-};
-
 enum _GumMatchType
 {
   GUM_MATCH_EXACT,

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -526,18 +526,14 @@ gum_match_pattern_new_from_regex (const gchar * regex_str)
   GumMatchPattern * pattern;
   GRegex * regex;
 
-  pattern = NULL;
-
-  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE,
-      G_REGEX_MATCH_NOTEMPTY, NULL);
-
+  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE, G_REGEX_MATCH_NOTEMPTY,
+      NULL);
   if (regex == NULL)
-    goto beach;
+    return NULL;
 
   pattern = gum_match_pattern_new ();
   pattern->regex = regex;
 
-beach:
   return pattern;
 }
 

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -372,7 +372,8 @@ gum_memory_scan_regex (const GumMemoryRange * range,
 {
   GMatchInfo * info;
 
-  g_regex_match (regex, (const gchar *) range->base_address, 0, &info);
+  g_regex_match_full (regex, (const gchar *) range->base_address, range->size,
+      0, 0, &info, NULL);
 
   while (g_match_info_matches (info))
   {

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -57,8 +57,7 @@ static void gum_memory_scan_raw (const GumMemoryRange * range,
     const GumMatchPattern * pattern, GumMemoryScanMatchFunc func,
     gpointer user_data);
 static void gum_memory_scan_regex (const GumMemoryRange * range,
-    const GumMatchPattern * pattern, GumMemoryScanMatchFunc func,
-    gpointer user_data);
+    const GRegex * regex, GumMemoryScanMatchFunc func, gpointer user_data);
 static GumMatchPattern * gum_match_pattern_new_from_hexstring (
     const gchar * match_combined_str);
 static GumMatchPattern * gum_match_pattern_new_from_regex (
@@ -303,7 +302,7 @@ gum_memory_scan (const GumMemoryRange * range,
   if (pattern->regex == NULL)
     gum_memory_scan_raw (range, pattern, func, user_data);
   else
-    gum_memory_scan_regex (range, pattern, func, user_data);
+    gum_memory_scan_regex (range, pattern->regex, func, user_data);
 }
 
 static void
@@ -367,14 +366,13 @@ gum_memory_scan_raw (const GumMemoryRange * range,
 
 static void
 gum_memory_scan_regex (const GumMemoryRange * range,
-                       const GumMatchPattern * pattern,
+                       const GRegex * regex,
                        GumMemoryScanMatchFunc func,
                        gpointer user_data)
 {
   GMatchInfo * info;
 
-  g_regex_match (pattern->regex, (const gchar *) range->base_address, 0,
-      &info);
+  g_regex_match (regex, (const gchar *) range->base_address, 0, &info);
 
   while (g_match_info_matches (info))
   {

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C)      2021 Abdelrahman Eid <hot3eed@gmail.com>
+ *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -567,8 +567,8 @@ gum_match_pattern_unref (GumMatchPattern * pattern)
   {
     if (pattern->regex != NULL)
       g_regex_unref (pattern->regex);
-    else
-      g_ptr_array_free (pattern->tokens, TRUE);
+
+    g_ptr_array_free (pattern->tokens, TRUE);
 
     g_slice_free (GumMatchPattern, pattern);
   }

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -398,7 +398,7 @@ gum_memory_scan_regex (const GumMemoryRange * range,
 GumMatchPattern *
 gum_match_pattern_new_from_string (const gchar * pattern_str)
 {
-  GumMatchPattern * result = NULL;
+  GumMatchPattern * result;
 
   if (g_str_has_prefix (pattern_str, "/") &&
       g_str_has_suffix (pattern_str, "/"))

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -374,14 +374,17 @@ gum_match_pattern_new_from_string (const gchar * pattern_str)
   GumMatchPattern * result = NULL;
 
   if (g_str_has_prefix (pattern_str, "/") &&
-      g_str_has_suffix (pattern_str, "/")) {
+      g_str_has_suffix (pattern_str, "/"))
+  {
     gchar * regex_str;
 
     regex_str = g_strndup (pattern_str + 1, strlen (pattern_str) - 2);
     result = gum_match_pattern_new_from_regex (regex_str);
 
     g_free (regex_str);
-  } else {
+  }
+  else
+  {
     result = gum_match_pattern_new_from_hexstring (pattern_str);
   }
 
@@ -399,9 +402,8 @@ gum_match_pattern_new_from_regex (const gchar * regex_str)
   regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE,
       G_REGEX_MATCH_NOTEMPTY, NULL);
 
-  if (regex == NULL) {
+  if (regex == NULL)
     goto beach;
-  }
 
   pattern = gum_match_pattern_new ();
   pattern->regex = regex;

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -401,11 +401,8 @@ gum_match_pattern_new_from_string (const gchar * pattern_str)
   if (g_str_has_prefix (pattern_str, "/") &&
       g_str_has_suffix (pattern_str, "/"))
   {
-    gchar * regex_str;
-
-    regex_str = g_strndup (pattern_str + 1, strlen (pattern_str) - 2);
+    gchar * regex_str = g_strndup (pattern_str + 1, strlen (pattern_str) - 2);
     result = gum_match_pattern_new_from_regex (regex_str);
-
     g_free (regex_str);
   }
   else

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -323,9 +323,9 @@ gum_memory_scan_raw (const GumMemoryRange * range,
     mask_data = (guint8 *) needle->masks->data;
   }
 
-  pattern_size = gum_match_pattern_get_size (pattern);
   needle_data = (guint8 *) needle->bytes->data;
   needle_len = needle->bytes->len;
+  pattern_size = gum_match_pattern_get_size (pattern);
 
   cur = GSIZE_TO_POINTER (range->base_address);
   end_address = cur + range->size - (pattern_size - needle->offset) + 1;

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -103,11 +103,12 @@ GUM_API void gum_memory_scan (const GumMemoryRange * range,
     gpointer user_data);
 
 GUM_API GumMatchPattern * gum_match_pattern_new_from_string (
-  const gchar * pattern_str);
+    const gchar * pattern_str);
+GUM_API GumMatchPattern * gum_match_pattern_ref (GumMatchPattern * pattern);
+GUM_API void gum_match_pattern_unref (GumMatchPattern * pattern);
 GUM_API guint gum_match_pattern_get_size (const GumMatchPattern * pattern);
 GUM_API GPtrArray * gum_match_pattern_get_tokens (
     const GumMatchPattern * pattern);
-GUM_API void gum_match_pattern_free (GumMatchPattern * pattern);
 
 GUM_API void gum_ensure_code_readable (gconstpointer address, gsize size);
 

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -103,7 +103,10 @@ GUM_API void gum_memory_scan (const GumMemoryRange * range,
     gpointer user_data);
 
 GUM_API GumMatchPattern * gum_match_pattern_new_from_string (
-    const gchar * match_combined_str);
+  const gchar * pattern_str);
+GUM_API guint gum_match_pattern_get_size (const GumMatchPattern * pattern);
+GUM_API GPtrArray * gum_match_pattern_get_tokens (
+    const GumMatchPattern * pattern);
 GUM_API void gum_match_pattern_free (GumMatchPattern * pattern);
 
 GUM_API void gum_ensure_code_readable (gconstpointer address, gsize size);

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -25,6 +25,7 @@ TESTLIST_BEGIN (memory)
   TESTENTRY (scan_range_finds_three_exact_matches)
   TESTENTRY (scan_range_finds_three_wildcarded_matches)
   TESTENTRY (scan_range_finds_three_masked_matches)
+  TESTENTRY (scan_range_finds_three_regex_matches)
   TESTENTRY (is_memory_readable_handles_mixed_page_protections)
   TESTENTRY (alloc_n_pages_returns_aligned_rw_address)
   TESTENTRY (alloc_n_pages_near_returns_aligned_rw_address_within_range)
@@ -168,13 +169,13 @@ TESTCASE (write_to_invalid_address_should_fail)
 }
 
 #define GUM_PATTERN_NTH_TOKEN(p, n) \
-    ((GumMatchToken *) g_ptr_array_index (p->tokens, n))
+    ((GumMatchToken *) g_ptr_array_index (gum_match_pattern_get_tokens (p), n))
 #define GUM_PATTERN_NTH_TOKEN_NTH_BYTE(p, n, b) \
-    (g_array_index (((GumMatchToken *) g_ptr_array_index (p->tokens, \
-        n))->bytes, guint8, b))
+    (g_array_index (((GumMatchToken *) g_ptr_array_index ( \
+        gum_match_pattern_get_tokens (p), n))->bytes, guint8, b))
 #define GUM_PATTERN_NTH_TOKEN_NTH_MASK(p, n, b) \
-    (g_array_index (((GumMatchToken *) g_ptr_array_index (p->tokens, \
-        n))->masks, guint8, b))
+    (g_array_index (((GumMatchToken *) g_ptr_array_index ( \
+        gum_match_pattern_get_tokens(p), n))->masks, guint8, b))
 
 TESTCASE (match_pattern_from_string_does_proper_validation)
 {
@@ -182,8 +183,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("1337");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 2);
-  g_assert_cmpuint (pattern->tokens->len, ==, 1);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 1);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 2);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 1), ==, 0x37);
@@ -191,8 +192,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("13 37");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 2);
-  g_assert_cmpuint (pattern->tokens->len, ==, 1);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 1);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 2);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 1), ==, 0x37);
@@ -209,8 +210,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("13 ?? 37");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 3);
-  g_assert_cmpuint (pattern->tokens->len, ==, 3);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 3);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 3);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 1);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 1)->bytes->len, ==, 1);
@@ -239,8 +240,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("1337:ff0f");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 2);
-  g_assert_cmpuint (pattern->tokens->len, ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 2);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 1);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 1)->bytes->len, ==, 1);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
@@ -250,8 +251,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("13 37 : ff 0f");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 2);
-  g_assert_cmpuint (pattern->tokens->len, ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 2);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 1);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 1)->bytes->len, ==, 1);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
@@ -261,8 +262,8 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
 
   pattern = gum_match_pattern_new_from_string ("13 ?7");
   g_assert_nonnull (pattern);
-  g_assert_cmpuint (pattern->size, ==, 2);
-  g_assert_cmpuint (pattern->tokens->len, ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 2);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 1);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 1)->bytes->len, ==, 1);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
@@ -373,6 +374,33 @@ TESTCASE (scan_range_finds_three_masked_matches)
 
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
 
+  gum_match_pattern_free (pattern);
+}
+
+TESTCASE (scan_range_finds_three_regex_matches)
+{
+  gchar buf[] = "Brainfuck_OR_brainsuckANDbrainluck\nbrainmuck";
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  TestForEachContext ctx;
+
+  range.base_address = GUM_ADDRESS (buf);
+  range.size = sizeof (buf);
+
+  pattern = gum_match_pattern_new_from_string ("/[Bb]rain[fsm]..k/");
+  g_assert_nonnull (pattern);
+
+  ctx.number_of_calls = 0;
+  ctx.value_to_return = TRUE;
+
+  ctx.expected_address[0] = buf + 0;
+  ctx.expected_address[1] = buf + sizeof ("Brainfuck_OR_") - 1;
+  ctx.expected_address[2] = buf +
+      sizeof ("Brainfuck_OR_brainsuckANDbrainluck\n") - 1;
+  ctx.expected_size = 9;
+
+  gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+  g_assert_cmpuint (ctx.number_of_calls, ==, 3);
   gum_match_pattern_free (pattern);
 }
 

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -188,7 +188,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 2);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 1), ==, 0x37);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 37");
   g_assert_nonnull (pattern);
@@ -197,7 +197,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 0)->bytes->len, ==, 2);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 1), ==, 0x37);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("1 37");
   g_assert_null (pattern);
@@ -218,7 +218,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 1, 0), ==, 0x42);
   g_assert_cmpuint (GUM_PATTERN_NTH_TOKEN (pattern, 2)->bytes->len, ==, 1);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 2, 0), ==, 0x37);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 ? 37");
   g_assert_null (pattern);
@@ -247,7 +247,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 1, 0), ==, 0x37);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_MASK (pattern, 1, 0), ==, 0x0f);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 37 : ff 0f");
   g_assert_nonnull (pattern);
@@ -258,7 +258,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 1, 0), ==, 0x37);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_MASK (pattern, 1, 0), ==, 0x0f);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 ?7");
   g_assert_nonnull (pattern);
@@ -269,7 +269,7 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 0, 0), ==, 0x13);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_BYTE (pattern, 1, 0), ==, 0x47);
   g_assert_cmphex (GUM_PATTERN_NTH_TOKEN_NTH_MASK (pattern, 1, 0), ==, 0x0f);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 37 : ff");
   g_assert_null (pattern);
@@ -308,7 +308,7 @@ TESTCASE (scan_range_finds_three_exact_matches)
   gum_memory_scan (&range, pattern, match_found_cb, &ctx);
   g_assert_cmpuint (ctx.number_of_calls, ==, 1);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 }
 
 TESTCASE (scan_range_finds_three_wildcarded_matches)
@@ -341,7 +341,7 @@ TESTCASE (scan_range_finds_three_wildcarded_matches)
 
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 }
 
 TESTCASE (scan_range_finds_three_masked_matches)
@@ -374,7 +374,7 @@ TESTCASE (scan_range_finds_three_masked_matches)
 
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
 
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 }
 
 TESTCASE (scan_range_finds_three_regex_matches)
@@ -401,7 +401,7 @@ TESTCASE (scan_range_finds_three_regex_matches)
 
   gum_memory_scan (&range, pattern, match_found_cb, &ctx);
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
-  gum_match_pattern_free (pattern);
+  gum_match_pattern_unref (pattern);
 }
 
 TESTCASE (is_memory_readable_handles_mixed_page_protections)

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -175,7 +175,7 @@ TESTCASE (write_to_invalid_address_should_fail)
         gum_match_pattern_get_tokens (p), n))->bytes, guint8, b))
 #define GUM_PATTERN_NTH_TOKEN_NTH_MASK(p, n, b) \
     (g_array_index (((GumMatchToken *) g_ptr_array_index ( \
-        gum_match_pattern_get_tokens(p), n))->masks, guint8, b))
+        gum_match_pattern_get_tokens (p), n))->masks, guint8, b))
 
 TESTCASE (match_pattern_from_string_does_proper_validation)
 {

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -400,7 +400,9 @@ TESTCASE (scan_range_finds_three_regex_matches)
   ctx.expected_size = 9;
 
   gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
+
   gum_match_pattern_unref (pattern);
 }
 

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6342,9 +6342,6 @@ TESTCASE (memory_scan_handles_unreadable_memory)
 
 TESTCASE (memory_scan_handles_bad_arguments)
 {
-  COMPILE_AND_LOAD_SCRIPT ("Memory.scan();");
-  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: missing argument");
-
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(0x1337, 7, '13 37', {"
       "  onMatch(address, size) {}, onComplete() {}"
@@ -6372,11 +6369,6 @@ TESTCASE (memory_scan_handles_bad_arguments)
     "});"
   );
   EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: invalid match pattern");
-
-  COMPILE_AND_LOAD_SCRIPT (
-      "Memory.scan(ptr(0x1337), 7, '13 37', 'non-object');");
-  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
-      "Error: expected an object containing callbacks");
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(ptr(0x1337), 7, '13 37', { onComplete() {} });"

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6360,11 +6360,18 @@ TESTCASE (memory_scan_handles_bad_arguments)
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(ptr(0x1337), 7, 0xbadcafe, {"
-        "onMatch(address, size) {},"
-        "onComplete() {}"
+      "  onMatch(address, size) {},"
+      "  onComplete() {}"
       "});");
   EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
       "Error: expected either a pattern string or a MatchPattern object");
+
+  COMPILE_AND_LOAD_SCRIPT (
+    "Memory.scan(ptr(0x1337), 7, 'bad pattern', {"
+    "  onMatch(addres, size) {}"
+    "});"
+  );
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: invalid match pattern");
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(ptr(0x1337), 7, '13 37', 'non-object');");

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6136,6 +6136,7 @@ compare_measurements (gconstpointer element_a,
 TESTCASE (memory_can_be_scanned_with_pattern_string)
 {
   guint8 haystack1[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
+  gchar haystack2[] = "Hello world, hello world, I said.";
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(" GUM_PTR_CONST ", 7, '13 37', {"
@@ -6165,8 +6166,6 @@ TESTCASE (memory_can_be_scanned_with_pattern_string)
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
 
-  gchar haystack2[] = "Hello world, hello world, I said.";
-
   COMPILE_AND_LOAD_SCRIPT (
       "const regex = /[Hh]ello\\sworld/.toString();"
       "Memory.scan(" GUM_PTR_CONST ", 33, regex, {"
@@ -6186,6 +6185,7 @@ TESTCASE (memory_can_be_scanned_with_pattern_string)
 TESTCASE (memory_can_be_scanned_with_match_pattern_object)
 {
   guint8 haystack1[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
+  gchar haystack2[] = "Hello world, hello world, I said.";
 
   COMPILE_AND_LOAD_SCRIPT (
       "const pattern = new MatchPattern('13 37');"
@@ -6216,8 +6216,6 @@ TESTCASE (memory_can_be_scanned_with_match_pattern_object)
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
-
-  gchar haystack2[] = "Hello world, hello world, I said.";
 
   COMPILE_AND_LOAD_SCRIPT (
       "const pattern = new MatchPattern(/[Hh]ello\\sworld/.toString());"
@@ -6268,12 +6266,12 @@ TESTCASE (memory_can_be_scanned_asynchronously)
   guint8 haystack[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
 
   COMPILE_AND_LOAD_SCRIPT (
-      "Promise.resolve(Memory.scan(" GUM_PTR_CONST ", 7, '13 37', {"
+      "Memory.scan(" GUM_PTR_CONST ", 7, '13 37', {"
       "  onMatch(address, size) {"
       "    send('onMatch offset=' + address.sub(" GUM_PTR_CONST ").toInt32()"
       "      + ' size=' + size);"
       "  }"
-      "}))"
+      "})"
       ".catch(e => console.error(e.message))"
       ".then(() => send('DONE'));", haystack, haystack);
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6342,37 +6342,40 @@ TESTCASE (memory_scan_handles_unreadable_memory)
 
 TESTCASE (memory_scan_handles_bad_arguments)
 {
-  COMPILE_AND_LOAD_SCRIPT ("Memory.scan().catch((e) => send(e.message));");
-  EXPECT_SEND_MESSAGE_WITH ("\"missing argument\"");
+  COMPILE_AND_LOAD_SCRIPT ("Memory.scan();");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: missing argument");
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(0x1337, 7, '13 37', {"
-        "onMatch(address, size) {}, onComplete() {}"
-      "}).catch(e => send(e.message));");
-  EXPECT_SEND_MESSAGE_WITH ("\"expected a pointer\"");
+      "  onMatch(address, size) {}, onComplete() {}"
+      "});");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: expected a pointer");
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(ptr(0x1337), -7, '13 37', {"
-        "onMatch(address, size) {}, onComplete() {}"
-      "}).catch(e => send(e.message));");
-  EXPECT_SEND_MESSAGE_WITH ("\"expected an unsigned integer\"");
+      "  onMatch(address, size) {}, onComplete() {}"
+      "});");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
+      "Error: expected an unsigned integer");
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(ptr(0x1337), 7, 0xbadcafe, {"
         "onMatch(address, size) {},"
         "onComplete() {}"
-      "}).catch(e => send(e.message));");
-  EXPECT_SEND_MESSAGE_WITH (
-      "\"expected either a pattern string or a MatchPattern object\"");
+      "});");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
+      "Error: expected either a pattern string or a MatchPattern object");
 
   COMPILE_AND_LOAD_SCRIPT (
-      "Memory.scan(ptr(0x1337), 7, '13 37', 'non-object').catch(e => send(e.message));");
-  EXPECT_SEND_MESSAGE_WITH ("\"expected an object containing callbacks\"");
+      "Memory.scan(ptr(0x1337), 7, '13 37', 'non-object');");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
+      "Error: expected an object containing callbacks");
 
   COMPILE_AND_LOAD_SCRIPT (
-      "Memory.scan(ptr(0x1337), 7, '13 37', { onComplete() {} }).catch(e => send(e.message));"
+      "Memory.scan(ptr(0x1337), 7, '13 37', { onComplete() {} });"
   );
-  EXPECT_SEND_MESSAGE_WITH ("\"expected a callback value\"");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
+      "Error: expected a callback value");
 }
 
 TESTCASE (memory_access_can_be_monitored)

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2015 Marc Hartmayer <hello@hartmayer.com>
  * Copyright (C) 2020-2021 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -148,10 +149,13 @@ TESTLIST_BEGIN (script)
     TESTENTRY (invalid_read_results_in_exception)
     TESTENTRY (invalid_write_results_in_exception)
     TESTENTRY (invalid_read_write_execute_results_in_exception)
-    TESTENTRY (memory_can_be_scanned)
+    TESTENTRY (memory_can_be_scanned_with_pattern_string)
+    TESTENTRY (memory_can_be_scanned_with_match_pattern_object)
     TESTENTRY (memory_can_be_scanned_synchronously)
+    TESTENTRY (memory_can_be_scanned_asynchronously)
     TESTENTRY (memory_scan_should_be_interruptible)
     TESTENTRY (memory_scan_handles_unreadable_memory)
+    TESTENTRY (memory_scan_handles_bad_arguments)
     TESTENTRY (memory_access_can_be_monitored)
     TESTENTRY (memory_access_can_be_monitored_one_range)
   TESTGROUP_END ()
@@ -356,6 +360,10 @@ TESTLIST_BEGIN (script)
     TESTENTRY (inline_sqlite_database_can_be_queried)
     TESTENTRY (external_sqlite_database_can_be_queried)
     TESTENTRY (external_sqlite_database_can_be_opened_with_flags)
+  TESTGROUP_END ()
+
+  TESTGROUP_BEGIN ("MatchPattern")
+    TESTENTRY (match_pattern_can_be_constructed_from_string)
   TESTGROUP_END ()
 
   TESTGROUP_BEGIN ("Stalker")
@@ -2820,6 +2828,18 @@ TESTCASE (external_sqlite_database_can_be_opened_with_flags)
   EXPECT_SEND_MESSAGE_WITH ("\"invalid flags\"");
   EXPECT_SEND_MESSAGE_WITH ("\"can write\"");
   EXPECT_NO_MESSAGES ();
+}
+
+TESTCASE (match_pattern_can_be_constructed_from_string)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "const p = new MatchPattern('13 37 ?? ff');"
+      "send(JSON.stringify(p));"
+  );
+  EXPECT_SEND_MESSAGE_WITH ("\"{}\"");
+
+  COMPILE_AND_LOAD_SCRIPT ("new MatchPattern('Some bad pattern');");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: invalid match pattern");
 }
 
 TESTCASE (socket_connection_can_be_established)
@@ -6113,9 +6133,9 @@ compare_measurements (gconstpointer element_a,
   return 0;
 }
 
-TESTCASE (memory_can_be_scanned)
+TESTCASE (memory_can_be_scanned_with_pattern_string)
 {
-  guint8 haystack[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
+  guint8 haystack1[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
 
   COMPILE_AND_LOAD_SCRIPT (
       "Memory.scan(" GUM_PTR_CONST ", 7, '13 37', {"
@@ -6126,7 +6146,7 @@ TESTCASE (memory_can_be_scanned)
         "onComplete() {"
         "  send('onComplete');"
         "}"
-      "});", haystack, haystack);
+      "});", haystack1, haystack1);
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
@@ -6140,9 +6160,78 @@ TESTCASE (memory_can_be_scanned)
         "onComplete() {"
         "  send('onComplete');"
         "}"
-      "});", haystack, haystack);
+      "});", haystack1, haystack1);
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
+
+  gchar haystack2[] = "Hello world, hello world, I said.";
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const regex = /[Hh]ello\\sworld/.toString();"
+      "Memory.scan(" GUM_PTR_CONST ", 33, regex, {"
+        "onMatch(address, size) {"
+        "  send('onMatch offset=' + address.sub(" GUM_PTR_CONST
+             ").toInt32() + ' size=' + size);"
+        "},"
+        "onComplete() {"
+        "  send('onComplete');"
+        "}"
+      "});", haystack2, haystack2);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=0 size=11\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=13 size=11\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
+}
+
+TESTCASE (memory_can_be_scanned_with_match_pattern_object)
+{
+  guint8 haystack1[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const pattern = new MatchPattern('13 37');"
+      "Memory.scan(" GUM_PTR_CONST ", 7, pattern, {"
+        "onMatch(address, size) {"
+        "  send('onMatch offset=' + address.sub(" GUM_PTR_CONST
+             ").toInt32() + ' size=' + size);"
+        "},"
+        "onComplete() {"
+        "  send('onComplete');"
+        "}"
+      "});", haystack1, haystack1);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const pattern = new MatchPattern('13 37');"
+      "Memory.scan(" GUM_PTR_CONST ", uint64(7), pattern, {"
+        "onMatch(address, size) {"
+        "  send('onMatch offset=' + address.sub(" GUM_PTR_CONST
+             ").toInt32() + ' size=' + size);"
+        "},"
+        "onComplete() {"
+        "  send('onComplete');"
+        "}"
+      "});", haystack1, haystack1);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
+
+  gchar haystack2[] = "Hello world, hello world, I said.";
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const pattern = new MatchPattern(/[Hh]ello\\sworld/.toString());"
+      "Memory.scan(" GUM_PTR_CONST ", 33, pattern, {"
+        "onMatch(address, size) {"
+        "  send('onMatch offset=' + address.sub(" GUM_PTR_CONST
+             ").toInt32() + ' size=' + size);"
+        "},"
+        "onComplete() {"
+        "  send('onComplete');"
+        "}"
+      "});", haystack2, haystack2);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=0 size=11\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=13 size=11\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
 }
 
@@ -6172,6 +6261,36 @@ TESTCASE (memory_can_be_scanned_synchronously)
   EXPECT_SEND_MESSAGE_WITH ("\"match offset=2 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"match offset=5 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"done\"");
+}
+
+TESTCASE (memory_can_be_scanned_asynchronously)
+{
+  guint8 haystack[] = { 0x01, 0x02, 0x13, 0x37, 0x03, 0x13, 0x37 };
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Promise.resolve(Memory.scan(" GUM_PTR_CONST ", 7, '13 37', {"
+      "  onMatch(address, size) {"
+      "    send('onMatch offset=' + address.sub(" GUM_PTR_CONST ").toInt32()"
+      "      + ' size=' + size);"
+      "  }"
+      "})).catch(e => console.error(e.message)).then(() => send('DONE'));", haystack, haystack);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"DONE\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "async function run() {"
+      "  try {"
+      "    await Memory.scan(ptr(0xdead), 7, '13 37', {"
+      "      onMatch(address, size) {}"
+      "    });"
+      "  } catch (e) {"
+      "    send(e.message);"
+      "  }"
+      "}"
+      "run();"
+  );
+  EXPECT_SEND_MESSAGE_WITH ("\"access violation accessing 0xdead\"");
 }
 
 TESTCASE (memory_scan_should_be_interruptible)
@@ -6219,6 +6338,41 @@ TESTCASE (memory_scan_handles_unreadable_memory)
         "send(e.message);"
       "}");
   EXPECT_SEND_MESSAGE_WITH ("\"access violation accessing 0x530\"");
+}
+
+TESTCASE (memory_scan_handles_bad_arguments)
+{
+  COMPILE_AND_LOAD_SCRIPT ("Memory.scan().catch((e) => send(e.message));");
+  EXPECT_SEND_MESSAGE_WITH ("\"missing argument\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Memory.scan(0x1337, 7, '13 37', {"
+        "onMatch(address, size) {}, onComplete() {}"
+      "}).catch(e => send(e.message));");
+  EXPECT_SEND_MESSAGE_WITH ("\"expected a pointer\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Memory.scan(ptr(0x1337), -7, '13 37', {"
+        "onMatch(address, size) {}, onComplete() {}"
+      "}).catch(e => send(e.message));");
+  EXPECT_SEND_MESSAGE_WITH ("\"expected an unsigned integer\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Memory.scan(ptr(0x1337), 7, 0xbadcafe, {"
+        "onMatch(address, size) {},"
+        "onComplete() {}"
+      "}).catch(e => send(e.message));");
+  EXPECT_SEND_MESSAGE_WITH (
+      "\"expected either a pattern string or a MatchPattern object\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Memory.scan(ptr(0x1337), 7, '13 37', 'non-object').catch(e => send(e.message));");
+  EXPECT_SEND_MESSAGE_WITH ("\"expected an object containing callbacks\"");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "Memory.scan(ptr(0x1337), 7, '13 37', { onComplete() {} }).catch(e => send(e.message));"
+  );
+  EXPECT_SEND_MESSAGE_WITH ("\"expected a callback value\"");
 }
 
 TESTCASE (memory_access_can_be_monitored)

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6273,7 +6273,9 @@ TESTCASE (memory_can_be_scanned_asynchronously)
       "    send('onMatch offset=' + address.sub(" GUM_PTR_CONST ").toInt32()"
       "      + ' size=' + size);"
       "  }"
-      "})).catch(e => console.error(e.message)).then(() => send('DONE'));", haystack, haystack);
+      "}))"
+      ".catch(e => console.error(e.message))"
+      ".then(() => send('DONE'));", haystack, haystack);
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=2 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=5 size=2\"");
   EXPECT_SEND_MESSAGE_WITH ("\"DONE\"");

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -512,7 +512,7 @@ namespace Gum {
 	}
 
 	[Compact]
-	[CCode (free_function = "gum_match_pattern_free")]
+	[CCode (free_function = "gum_match_pattern_unref")]
 	public class MatchPattern {
 		public MatchPattern.from_string (string match_str);
 	}


### PR DESCRIPTION
In this PR:
* Allow `Memory.scan()` to scan for regex patterns, which is triggered automatically when the `pattern` argument is prefixed and suffixed with `/`, e.g. `/Some\s*Pattern/`. 
* Implement the `MatchPattern` object, whose constructor accepts either: a hexstring, `Memory.scan()`-style; or a regex pattern with the format above. This allows the user of the API to re-use a compiled regex, by keeping a reference to the `MatchPattern` object. 
* Make it return a `Promise<void>` instead of `void`.
* Make the `onComplete` callback optional (since we have the settling of the Promise to indicate that we're finished scanning.) 
* The API remains compatible with the older, callback-style one (except for one edge case, see below.)

Points for discussion:
* Is returning `Promise<void>` instead of `void` considered API-breaking? There's one edge case I can think of where code wouldn't take the expected control flow. If a call to `Memory.scan()` throws an exception before starting the scan, due to bad or missing arguments for example, AND the user of the API is catching this exception, then since we now return a Promise, there will be an unhandled rejection instead of a caught exception. Example:

```javascript
try {
  /* should be awaited so that the rejection is thrown as an exception */
  Memory.scan(ptr, size, pattern, {
    onMatch (address, size) {
      ...
    },
    onError (reason) { 
      /* will execute! */
    }
  });
} catch (e) {
  /* will never execute, happens only before initiating the scan */
} 
```
* To keep `Memory.scanSync()` compatible with `Memory.scan()`, we should make it optionally accept a `MatchPattern` for a `pattern` as well. Does this warrant adding a qualifier for `MatchPattern | string` in `xxx_args_parse()` (for V8 and QJS), or should we add a helper method to do that?
* When should we free [this stuff](https://github.com/frida/frida-gum/pull/591/files#diff-66a4ee2d704657707e96bdde6e84adca21eb81ce98e4ad21fedfb70feca139eeR991)?