### PR TITLE
gumjs: Fix v8 Interceptor context

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -3537,6 +3537,7 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_native_callback_construct)
   cb->wrapper = wrapper;
   cb->func = func;
   cb->core = core;
+  cb->interceptor_replacement_count = 0;
 
   if (!gum_quick_ffi_type_get (ctx, rtype_value, core, &rtype, &cb->data))
     goto propagate_exception;

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -3537,7 +3537,6 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_native_callback_construct)
   cb->wrapper = wrapper;
   cb->func = func;
   cb->core = core;
-  cb->interceptor_replacement_count = 0;
 
   if (!gum_quick_ffi_type_get (ctx, rtype_value, core, &rtype, &cb->data))
     goto propagate_exception;

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -2906,7 +2906,6 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_native_callback_construct)
 
   callback = g_slice_new0 (GumV8NativeCallback);
   callback->ref_count = 1;
-  callback->interceptor_replacement_count = 0;
   callback->func = new GumPersistent<Function>::type (isolate, func_value);
   callback->core = core;
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -555,7 +555,7 @@ _gum_v8_core_init (GumV8Core * self,
   auto native_callback = _gum_v8_create_class ("NativeCallback",
       gumjs_native_callback_construct, scope, module, isolate);
   native_callback->Inherit (native_pointer);
-  native_callback->InstanceTemplate ()->SetInternalFieldCount (1);
+  native_callback->InstanceTemplate ()->SetInternalFieldCount (2);
   self->native_callback =
       new GumPersistent<FunctionTemplate>::type (isolate, native_callback);
 
@@ -2906,6 +2906,7 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_native_callback_construct)
 
   callback = g_slice_new0 (GumV8NativeCallback);
   callback->ref_count = 1;
+  callback->interceptor_replacement_count = 0;
   callback->func = new GumPersistent<Function>::type (isolate, func_value);
   callback->core = core;
 
@@ -2955,6 +2956,7 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_native_callback_construct)
   }
 
   wrapper->SetInternalField (0, External::New (isolate, func));
+  wrapper->SetInternalField (1, External::New (isolate, callback));
 
   callback->wrapper = new GumPersistent<Object>::type (isolate, wrapper);
   callback->wrapper->SetWeak (callback,

--- a/bindings/gumjs/gumv8interceptor.cpp
+++ b/bindings/gumjs/gumv8interceptor.cpp
@@ -721,7 +721,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_replace)
     if (native_callback->HasInstance (instance))
     {
       auto callback = (GumV8NativeCallback *)
-          instance->GetInternalField (0).As<External> ()->Value ();
+          instance->GetInternalField (1).As<External> ()->Value ();
       callback->interceptor_replacement_count++;
     }
 
@@ -782,7 +782,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_revert)
     if (native_callback->HasInstance (instance))
     {
       auto callback = (GumV8NativeCallback *)
-          instance->GetInternalField (0).As<External> ()->Value ();
+          instance->GetInternalField (1).As<External> ()->Value ();
       callback->interceptor_replacement_count--;
     }
   }


### PR DESCRIPTION
There was a regression in the tests starting from #578
Fixed getting wrong variable (v8), explicitly initializing new variables (qjs, v8)