### PR TITLE
Stalker Performance Improvements

### DIFF
--- a/gum/arch-x86/gumx86reader.c
+++ b/gum/arch-x86/gumx86reader.c
@@ -8,7 +8,6 @@
 
 static gpointer try_get_relative_call_or_jump_target (gconstpointer address,
     guint call_or_jump);
-static cs_insn * disassemble_instruction_at (gconstpointer address);
 
 guint
 gum_x86_reader_insn_length (guint8 * code)
@@ -16,7 +15,7 @@ gum_x86_reader_insn_length (guint8 * code)
   guint result;
   cs_insn * insn;
 
-  insn = disassemble_instruction_at (code);
+  insn = gum_x86_reader_disassemble_instruction_at (code);
   if (insn == NULL)
     return 0;
   result = insn->size;
@@ -74,7 +73,7 @@ gum_x86_reader_try_get_indirect_jump_target (gconstpointer address)
   cs_insn * insn;
   cs_x86_op * op;
 
-  insn = disassemble_instruction_at (address);
+  insn = gum_x86_reader_disassemble_instruction_at (address);
   if (insn == NULL)
     return NULL;
 
@@ -105,7 +104,7 @@ try_get_relative_call_or_jump_target (gconstpointer address,
   cs_insn * insn;
   cs_x86_op * op;
 
-  insn = disassemble_instruction_at (address);
+  insn = gum_x86_reader_disassemble_instruction_at (address);
   if (insn == NULL)
     return NULL;
 
@@ -118,8 +117,8 @@ try_get_relative_call_or_jump_target (gconstpointer address,
   return result;
 }
 
-static cs_insn *
-disassemble_instruction_at (gconstpointer address)
+cs_insn *
+gum_x86_reader_disassemble_instruction_at (gconstpointer address)
 {
   csh capstone;
   cs_insn * insn = NULL;

--- a/gum/arch-x86/gumx86reader.h
+++ b/gum/arch-x86/gumx86reader.h
@@ -19,6 +19,7 @@ gboolean gum_x86_reader_insn_is_jcc (const cs_insn * insn);
 gpointer gum_x86_reader_try_get_relative_call_target (gconstpointer address);
 gpointer gum_x86_reader_try_get_relative_jump_target (gconstpointer address);
 gpointer gum_x86_reader_try_get_indirect_jump_target (gconstpointer address);
+cs_insn * gum_x86_reader_disassemble_instruction_at (gconstpointer address);
 
 G_END_DECLS
 

--- a/gum/gumstalker.c
+++ b/gum/gumstalker.c
@@ -247,3 +247,20 @@ gum_stalker_observer_notify_backpatch (GumStalkerObserver * observer,
 
   iface->notify_backpatch (observer, backpatch, size);
 }
+
+void
+gum_stalker_observer_switch_callback (GumStalkerObserver * observer,
+                                      gpointer start_address,
+                                      const cs_insn * from_insn,
+                                      gpointer * target)
+{
+  GumStalkerObserverInterface * iface;
+
+  iface = GUM_STALKER_OBSERVER_GET_IFACE (observer);
+  g_assert (iface != NULL);
+
+  if (iface->switch_callback == NULL)
+    return;
+
+  iface->switch_callback (observer, start_address, from_insn, target);
+}

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -47,9 +47,12 @@ G_DECLARE_INTERFACE (GumStalkerObserver, gum_stalker_observer, GUM,
 typedef struct _GumStalkerIterator GumStalkerIterator;
 typedef struct _GumStalkerOutput GumStalkerOutput;
 typedef struct _GumBackpatch GumBackpatch;
+typedef struct _GumBackpatchInstruction GumBackpatchInstruction;
 typedef void (* GumStalkerIncrementFunc) (GumStalkerObserver * self);
 typedef void (* GumStalkerNotifyBackpatchFunc) (GumStalkerObserver * self,
     const GumBackpatch * backpatch, gsize size);
+typedef void (* GumStalkerSwitchCallbackFunc) (GumStalkerObserver * self,
+    gpointer start_address, const cs_insn * from_insn, gpointer * target);
 typedef union _GumStalkerWriter GumStalkerWriter;
 typedef void (* GumStalkerTransformerCallback) (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
@@ -120,6 +123,8 @@ struct _GumStalkerObserverInterface
   GumStalkerIncrementFunc increment_sysenter_slow_path;
 
   GumStalkerNotifyBackpatchFunc notify_backpatch;
+
+  GumStalkerSwitchCallbackFunc switch_callback;
 };
 
 union _GumStalkerWriter
@@ -357,6 +362,10 @@ GUM_API gboolean gum_stalker_iterator_next (GumStalkerIterator * self,
 GUM_API void gum_stalker_iterator_keep (GumStalkerIterator * self);
 GUM_API void gum_stalker_iterator_put_callout (GumStalkerIterator * self,
     GumStalkerCallout callout, gpointer data, GDestroyNotify data_destroy);
+
+GUM_API void gum_stalker_observer_switch_callback (
+    GumStalkerObserver * observer, gpointer start_address,
+    const cs_insn * from_insn, gpointer * target);
 
 G_END_DECLS
 


### PR DESCRIPTION
- Adjacency/Localtiy
  - Split instrumented code into fast and slow slabs
  - Compilation of adjacent blocks
  - Use NOP slides rather than jumps to branch between adjacent instrumented blocks
  - Move inline cache to the data slab
  - Use linked list to track GumExecBlocks so data slab can also be used for inline caches
- Inline cache
  - Replace shadow stack with inline cache on return
  - Inline cache now uses Most Recently Used
  - Unroll loop when searching inline cache
  - Support backpatching inline cache for RET statements which return to the code slab 
- Perf
  - Reduce branches when backpatching Jcc instructions
  - Optimize generation of NOP padding.
  - Emit UD2 after indirect JMP instructions to stall branch predictor.
- Misc
  - Entry gates are no longer fast call (as they are on the slow path anyway)
  - Add support for switch block callback to the observer (allows fuzzer to control branching and skip coverage generation for direct branches).