### PR TITLE
kernel: Get base from all_image_info where supported

### DIFF
--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -705,12 +705,12 @@ gum_kernel_do_find_base_address (void)
   if (base == 0)
   {
     version = gum_kernel_get_version ();
-    if (version >= 16.0) // iOS 10.0+
+    if (version >= 16.0) /* iOS 10.0+ */
     {
       base = gum_kernel_bruteforce_base (
           G_GUINT64_CONSTANT (0xfffffff007004000));
     }
-    else if (version >= 15.0) // iOS 9.0+
+    else if (version >= 15.0) /* iOS 9.0+ */
     {
       base = gum_kernel_bruteforce_base (
           G_GUINT64_CONSTANT (0xffffff8004004000));

--- a/gum/backend-darwin/gumkernel-darwin.c
+++ b/gum/backend-darwin/gumkernel-darwin.c
@@ -9,6 +9,7 @@
 #include "gum-init.h"
 #include "gumdarwin.h"
 #include "gummemory-priv.h"
+#include "gumprocess-darwin-priv.h"
 
 #include <mach/mach.h>
 #include <mach-o/loader.h>
@@ -110,6 +111,7 @@ static float gum_kernel_get_version (void);
 
 #ifdef HAVE_ARM64
 
+static GumAddress gum_kernel_get_base_from_all_image_info (void);
 static GumAddress gum_kernel_bruteforce_base (GumAddress unslid_base);
 static gboolean gum_kernel_is_header (GumAddress address);
 static gboolean gum_kernel_has_kld (GumAddress address);
@@ -698,13 +700,22 @@ gum_kernel_do_find_base_address (void)
   float version;
   GumAddress base = 0;
 
-  version = gum_kernel_get_version ();
-
 #ifdef HAVE_ARM64
-  if (version >= 16.0) /* iOS 10.0+ */
-    base = gum_kernel_bruteforce_base (G_GUINT64_CONSTANT (0xfffffff007004000));
-  else if (version >= 15.0) /* iOS 9.0+ */
-    base = gum_kernel_bruteforce_base (G_GUINT64_CONSTANT (0xffffff8004004000));
+  base = gum_kernel_get_base_from_all_image_info ();
+  if (base == 0)
+  {
+    version = gum_kernel_get_version ();
+    if (version >= 16.0) // iOS 10.0+
+    {
+      base = gum_kernel_bruteforce_base (
+          G_GUINT64_CONSTANT (0xfffffff007004000));
+    }
+    else if (version >= 15.0) // iOS 9.0+
+    {
+      base = gum_kernel_bruteforce_base (
+          G_GUINT64_CONSTANT (0xffffff8004004000));
+    }
+  }
 #endif
 
   return g_slice_dup (GumAddress, &base);
@@ -728,6 +739,32 @@ gum_kernel_get_version (void)
 }
 
 #ifdef HAVE_ARM64
+
+static GumAddress
+gum_kernel_get_base_from_all_image_info (void)
+{
+  mach_port_t task;
+  kern_return_t kr;
+  DyldInfo info_raw;
+  mach_msg_type_number_t info_count = DYLD_INFO_COUNT;
+
+  task = gum_kernel_get_task ();
+  if (task == MACH_PORT_NULL)
+    return 0;
+
+  kr = task_info (task, TASK_DYLD_INFO, (task_info_t) &info_raw, &info_count);
+  if (kr != KERN_SUCCESS)
+    return 0;
+
+  if (info_raw.info_64.all_image_info_addr == 0 &&
+      info_raw.info_64.all_image_info_size == 0)
+  {
+    return 0;
+  }
+
+  return info_raw.info_64.all_image_info_size +
+      G_GUINT64_CONSTANT (0xfffffff007004000);
+}
 
 static gboolean
 gum_kernel_is_debug (void)

--- a/gum/backend-darwin/gumprocess-darwin-priv.h
+++ b/gum/backend-darwin/gumprocess-darwin-priv.h
@@ -1,5 +1,13 @@
+/*
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
 #ifndef __GUM_PROCESS_DARWIN_PRIV_H__
 #define __GUM_PROCESS_DARWIN_PRIV_H__
+
+#include <glib.h>
 
 #define DYLD_INFO_COUNT 5
 #define DYLD_INFO_LEGACY_COUNT 1

--- a/gum/backend-darwin/gumprocess-darwin-priv.h
+++ b/gum/backend-darwin/gumprocess-darwin-priv.h
@@ -1,0 +1,40 @@
+#ifndef __GUM_PROCESS_DARWIN_PRIV_H__
+#define __GUM_PROCESS_DARWIN_PRIV_H__
+
+#define DYLD_INFO_COUNT 5
+#define DYLD_INFO_LEGACY_COUNT 1
+#define DYLD_INFO_32_COUNT 3
+#define DYLD_INFO_64_COUNT 5
+
+typedef union _DyldInfo DyldInfo;
+typedef struct _DyldInfoLegacy DyldInfoLegacy;
+typedef struct _DyldInfo32 DyldInfo32;
+typedef struct _DyldInfo64 DyldInfo64;
+
+struct _DyldInfoLegacy
+{
+  guint32 all_image_info_addr;
+};
+
+struct _DyldInfo32
+{
+  guint32 all_image_info_addr;
+  guint32 all_image_info_size;
+  gint32 all_image_info_format;
+};
+
+struct _DyldInfo64
+{
+  guint64 all_image_info_addr;
+  guint64 all_image_info_size;
+  gint32 all_image_info_format;
+};
+
+union _DyldInfo
+{
+  DyldInfoLegacy info_legacy;
+  DyldInfo32 info_32;
+  DyldInfo64 info_64;
+};
+
+#endif

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -7,11 +7,11 @@
 
 #include "gumprocess-priv.h"
 
-#include "gumprocess-darwin-priv.h"
 #include "gum-init.h"
 #include "gumdarwin.h"
 #include "gumdarwinmodule.h"
 #include "gumleb.h"
+#include "gumprocess-darwin-priv.h"
 
 #include <dlfcn.h>
 #include <errno.h>

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -6,6 +6,7 @@
  */
 
 #include "gumprocess-priv.h"
+#include "gumprocess-darwin-priv.h"
 
 #include "gum-init.h"
 #include "gumdarwin.h"
@@ -27,10 +28,6 @@
 
 #define GUM_PSR_THUMB 0x20
 #define MAX_MACH_HEADER_SIZE (64 * 1024)
-#define DYLD_INFO_COUNT 5
-#define DYLD_INFO_LEGACY_COUNT 1
-#define DYLD_INFO_32_COUNT 3
-#define DYLD_INFO_64_COUNT 5
 #define DYLD_IMAGE_INFO_32_SIZE 12
 #define DYLD_IMAGE_INFO_64_SIZE 24
 #define GUM_THREAD_POLL_STEP 1000
@@ -70,10 +67,6 @@ typedef struct _GumEnumerateModulesSlowContext GumEnumerateModulesSlowContext;
 typedef struct _GumEnumerateMallocRangesContext GumEnumerateMallocRangesContext;
 typedef struct _GumCanonicalizeNameContext GumCanonicalizeNameContext;
 
-typedef union _DyldInfo DyldInfo;
-typedef struct _DyldInfoLegacy DyldInfoLegacy;
-typedef struct _DyldInfo32 DyldInfo32;
-typedef struct _DyldInfo64 DyldInfo64;
 typedef struct _DyldAllImageInfos32 DyldAllImageInfos32;
 typedef struct _DyldAllImageInfos64 DyldAllImageInfos64;
 typedef struct _DyldImageInfo32 DyldImageInfo32;
@@ -134,32 +127,6 @@ struct _GumCanonicalizeNameContext
 {
   const gchar * module_name;
   gchar * module_path;
-};
-
-struct _DyldInfoLegacy
-{
-  guint32 all_image_info_addr;
-};
-
-struct _DyldInfo32
-{
-  guint32 all_image_info_addr;
-  guint32 all_image_info_size;
-  gint32 all_image_info_format;
-};
-
-struct _DyldInfo64
-{
-  guint64 all_image_info_addr;
-  guint64 all_image_info_size;
-  gint32 all_image_info_format;
-};
-
-union _DyldInfo
-{
-  DyldInfoLegacy info_legacy;
-  DyldInfo32 info_32;
-  DyldInfo64 info_64;
 };
 
 struct _DyldAllImageInfos32

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -6,8 +6,8 @@
  */
 
 #include "gumprocess-priv.h"
-#include "gumprocess-darwin-priv.h"
 
+#include "gumprocess-darwin-priv.h"
 #include "gum-init.h"
 #include "gumdarwin.h"
 #include "gumdarwinmodule.h"


### PR DESCRIPTION
Jailbreaks like Unc0ver and checkra1n store the kernel slide in `all_image_info_size`, obtainable via a call to `task_info` on the kernel task port. This change adds support for reconstructing the kernel base address from it.