### PR TITLE
x86-relocator: fix JCCs

### DIFF
--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -391,7 +391,8 @@ gchar * g_convert (const gchar * str, gssize len,
 gchar * g_convert_with_iconv (const gchar * str, gssize len, GIConv converter,
     gsize * bytes_read, gsize * bytes_written, GError ** error);
 gchar * g_convert_with_fallback (const gchar * str, gssize len,
-    const gchar * to_codeset, const gchar * from_codeset, const gchar * fallback,
-    gsize * bytes_read, gsize * bytes_written, GError ** error);
+    const gchar * to_codeset, const gchar * from_codeset,
+    const gchar * fallback, gsize * bytes_read, gsize * bytes_written,
+    GError ** error);
 
 #endif

--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -375,7 +375,7 @@ struct _GError
 };
 
 void g_error_free (GError * error);
-void g_clear_error (GError ** err);
+void g_clear_error (GError ** error);
 
 typedef struct _GIConv * GIConv;
 

--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -382,12 +382,12 @@ gsize g_iconv (GIConv converter,
     gchar ** outbuf, gsize * outbytes_left);
 gint g_iconv_close (GIConv converter);
 
-gchar* g_convert (const gchar * str, gssize len,
+gchar * g_convert (const gchar * str, gssize len,
     const gchar * to_codeset, const gchar * from_codeset,
     gsize * bytes_read, gsize * bytes_written, GError ** error);
 gchar * g_convert_with_iconv (const gchar * str, gssize len, GIConv converter,
     gsize * bytes_read, gsize * bytes_written, GError ** error);
-gchar* g_convert_with_fallback (const gchar * str, gssize len,
+gchar * g_convert_with_fallback (const gchar * str, gssize len,
     const gchar * to_codeset, const gchar * from_codeset, const gchar * fallback,
     gsize * bytes_read, gsize * bytes_written, GError ** error);
 

--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -374,7 +374,7 @@ struct _GError
   gchar * message;
 };
 
-typedef struct _GIConv *GIConv;
+typedef struct _GIConv * GIConv;
 
 GIConv g_iconv_open (const gchar * to_codeset, const gchar * from_codeset);
 gsize g_iconv (GIConv converter,

--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -374,6 +374,9 @@ struct _GError
   gchar * message;
 };
 
+void g_error_free (GError * error);
+void g_clear_error (GError ** err);
+
 typedef struct _GIConv * GIConv;
 
 GIConv g_iconv_open (const gchar * to_codeset, const gchar * from_codeset);

--- a/bindings/gumjs/runtime/cmodule/glib.h
+++ b/bindings/gumjs/runtime/cmodule/glib.h
@@ -364,4 +364,31 @@ const gchar * g_checksum_get_string (GChecksum * checksum);
 void g_checksum_get_digest (GChecksum * checksum, guint8 * buffer,
     gsize * digest_len);
 
+typedef guint32 GQuark;
+typedef struct _GError GError;
+
+struct _GError
+{
+  GQuark domain;
+  gint code;
+  gchar * message;
+};
+
+typedef struct _GIConv *GIConv;
+
+GIConv g_iconv_open (const gchar * to_codeset, const gchar * from_codeset);
+gsize g_iconv (GIConv converter,
+    gchar ** inbuf, gsize * inbytes_left,
+    gchar ** outbuf, gsize * outbytes_left);
+gint g_iconv_close (GIConv converter);
+
+gchar* g_convert (const gchar * str, gssize len,
+    const gchar * to_codeset, const gchar * from_codeset,
+    gsize * bytes_read, gsize * bytes_written, GError ** error);
+gchar * g_convert_with_iconv (const gchar * str, gssize len, GIConv converter,
+    gsize * bytes_read, gsize * bytes_written, GError ** error);
+gchar* g_convert_with_fallback (const gchar * str, gssize len,
+    const gchar * to_codeset, const gchar * from_codeset, const gchar * fallback,
+    gsize * bytes_read, gsize * bytes_written, GError ** error);
+
 #endif

--- a/gum/arch-x86/gumx86relocator.c
+++ b/gum/arch-x86/gumx86relocator.c
@@ -543,7 +543,9 @@ gum_x86_relocator_rewrite_conditional_branch (GumX86Relocator * self,
       gum_x86_writer_put_jcc_short_label (ctx->code_writer, ctx->insn->id,
           target, GUM_NO_HINT);
     }
-    else if (ctx->insn->id == X86_INS_JECXZ || ctx->insn->id == X86_INS_JRCXZ)
+    else if (ctx->insn->id == X86_INS_JECXZ || ctx->insn->id == X86_INS_JRCXZ ||
+             !gum_x86_writer_put_jcc_near (ctx->code_writer, ctx->insn->id,
+             target, GUM_NO_HINT))
     {
       gsize unique_id = GPOINTER_TO_SIZE (ctx->code_writer->code) << 1;
       gconstpointer is_true = GSIZE_TO_POINTER (unique_id | 1);
@@ -557,11 +559,6 @@ gum_x86_relocator_rewrite_conditional_branch (GumX86Relocator * self,
       gum_x86_writer_put_jmp_address (ctx->code_writer, GUM_ADDRESS (target));
 
       gum_x86_writer_put_label (ctx->code_writer, is_false);
-    }
-    else
-    {
-      gum_x86_writer_put_jcc_near (ctx->code_writer, ctx->insn->id, target,
-          GUM_NO_HINT);
     }
   }
   else


### PR DESCRIPTION
Switch to jcc_short when jcc_near failed (-+2GB).