### PR TITLE
Fixing the case of SymWalk being sensitive about XIP.

### DIFF
--- a/gum/backend-dbghelp/gumdbghelpbacktracer.c
+++ b/gum/backend-dbghelp/gumdbghelpbacktracer.c
@@ -84,9 +84,9 @@ gum_dbghelp_backtracer_generate (GumBacktracer * backtracer,
   gboolean has_ffi_frames = FALSE;
   guint skip_count = 0;
   HANDLE current_process, current_thread;
+  GumInvocationStack * invocation_stack;
   guint depth, i;
   BOOL success;
-  GumInvocationStack * invocation_stack;
 
   self = GUM_DBGHELP_BACKTRACER (backtracer);
   dbghelp = self->dbghelp;
@@ -165,7 +165,7 @@ gum_dbghelp_backtracer_generate (GumBacktracer * backtracer,
   current_process = GetCurrentProcess ();
   current_thread = GetCurrentThread ();
 
-  invocation_stack = gum_interceptor_get_current_stack();
+  invocation_stack = gum_interceptor_get_current_stack ();
 
   dbghelp->Lock ();
 
@@ -227,12 +227,9 @@ gum_dbghelp_backtracer_generate (GumBacktracer * backtracer,
   if (return_addresses->len >= 2)
   {
     for (i = 1; i != return_addresses->len; i++)
-    {
-      return_addresses->items[i - 1] = gum_invocation_stack_translate(
-          invocation_stack, return_addresses->items[i]);
-    }
+      return_addresses->items[i - 1] = return_addresses->items[i];
   }
 
-  if (return_addresses->len)
-      return_addresses->len--;
+  if (return_addresses->len >= 1)
+    return_addresses->len--;
 }


### PR DESCRIPTION
Steps to reproduce the problem that this patch fixes:

1) Run notepad in Frida (x64).
2) Attach hook on combase!CoCreateInstance that prints backtrace onEnter (also load symbols for all modules..).

See truncated or invalid backtraces.

This patch also fixes the case when there are multiple hooks in a cascade, e.g. CreateFileInternal & CreateFileW. See the StackWalk loop.

The problem is that the code tries to skip the first frame by using the return address from the top of stack. SymWalk does not like this -- there is mismatch between XSP and XIP. StackWalk is sensitive about RIP, especially on x64.

It was tested with both 32-bit & 64-bit builds on Windows 10.



