### PR TITLE
Implement `MatchPattern` qualifier and update `Kernel.scan*()`

### DIFF
--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -846,6 +846,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   sc.range.base_address = address;
   sc.range.size = size;
   gum_match_pattern_ref (sc.pattern);
+  sc.result = GUM_QUICK_MATCH_CONTINUE;
   sc.ctx = ctx;
   sc.core = core;
 

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -176,7 +176,7 @@ static const JSCFunctionListEntry gumjs_kernel_entries[] =
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf8String", UTF8_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf16String", UTF16_STRING),
 
-  JS_CFUNC_DEF ("scan", 0, gumjs_kernel_scan),
+  JS_CFUNC_DEF ("_scan", 0, gumjs_kernel_scan),
   JS_CFUNC_DEF ("scanSync", 0, gumjs_kernel_scan_sync),
 };
 

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -840,7 +840,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
 
   sc.pattern = NULL;
 
-  if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError?,onComplete?}",
+  if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError?,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
   {

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -845,6 +845,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
 
   sc.range.base_address = address;
   sc.range.size = size;
+  gum_match_pattern_ref (sc.pattern);
   sc.ctx = ctx;
   sc.core = core;
 
@@ -960,8 +961,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
 
   gum_kernel_scan (&range, pattern, (GumMemoryScanMatchFunc) gum_append_match,
       &sc);
-
-  gum_match_pattern_unref (pattern);
 
   return result;
 }

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -838,7 +838,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   GumAddress address;
   gsize size;
 
-  if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError?,onComplete}",
+  if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
     return JS_EXCEPTION;

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -845,14 +845,17 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
 
   sc.range.base_address = address;
   sc.range.size = size;
+
   gum_match_pattern_ref (sc.pattern);
-  sc.result = GUM_QUICK_MATCH_CONTINUE;
-  sc.ctx = ctx;
-  sc.core = core;
 
   JS_DupValue (ctx, sc.on_match);
   JS_DupValue (ctx, sc.on_error);
   JS_DupValue (ctx, sc.on_complete);
+
+  sc.result = GUM_QUICK_MATCH_CONTINUE;
+
+  sc.ctx = ctx;
+  sc.core = core;
 
   _gum_quick_core_pin (core);
   _gum_quick_core_push_job (core,

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -838,16 +838,10 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   GumAddress address;
   gsize size;
 
-  sc.pattern = NULL;
-
   if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError?,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
-  {
-    if (sc.pattern != NULL)
-      gum_match_pattern_unref (sc.pattern);
     return JS_EXCEPTION;
-  }
 
   sc.range.base_address = address;
   sc.range.size = size;

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -944,14 +944,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
   GumMemoryRange range;
   GumMemoryScanSyncContext sc;
 
-  pattern = NULL;
-
   if (!_gum_quick_args_parse (args, "QZM", &address, &size, &pattern))
-  {
-    if (pattern != NULL)
-      gum_match_pattern_unref (pattern);
     return JS_EXCEPTION;
-  }
 
   range.base_address = address;
   range.size = size;

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -836,20 +836,22 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   GumKernelScanContext sc;
   GumAddress address;
   gsize size;
-  const gchar * match_str;
 
-  if (!_gum_quick_args_parse (args, "QZsF{onMatch,onError?,onComplete}",
-      &address, &size, &match_str, &sc.on_match, &sc.on_error, &sc.on_complete))
+  sc.pattern = NULL;
+
+  if (!_gum_quick_args_parse (args, "QZMF{onMatch,onError?,onComplete?}",
+      &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
+      &sc.on_complete))
+  {
+    if (sc.pattern != NULL)
+      gum_match_pattern_unref (sc.pattern);
     return JS_EXCEPTION;
+  }
+
   sc.range.base_address = address;
   sc.range.size = size;
-  sc.pattern = gum_match_pattern_new_from_string (match_str);
-  sc.result = GUM_QUICK_MATCH_CONTINUE;
   sc.ctx = ctx;
   sc.core = core;
-
-  if (sc.pattern == NULL)
-    return _gum_quick_throw_literal (ctx, "invalid match pattern");
 
   JS_DupValue (ctx, sc.on_match);
   JS_DupValue (ctx, sc.on_error);
@@ -938,20 +940,21 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
   JSValue result;
   GumAddress address;
   gsize size;
-  const gchar * match_str;
-  GumMemoryRange range;
   GumMatchPattern * pattern;
+  GumMemoryRange range;
   GumMemoryScanSyncContext sc;
 
-  if (!_gum_quick_args_parse (args, "QZs", &address, &size, &match_str))
+  pattern = NULL;
+
+  if (!_gum_quick_args_parse (args, "QZM", &address, &size, &pattern))
+  {
+    if (pattern != NULL)
+      gum_match_pattern_unref (pattern);
     return JS_EXCEPTION;
+  }
 
   range.base_address = address;
   range.size = size;
-
-  pattern = gum_match_pattern_new_from_string (match_str);
-  if (pattern == NULL)
-    return _gum_quick_throw_literal (ctx, "invalid match pattern");
 
   result = JS_NewArray (ctx);
 

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2018-2019 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumquickkernel.c
+++ b/bindings/gumjs/gumquickkernel.c
@@ -954,6 +954,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan_sync)
 
   sc.matches = result;
   sc.index = 0;
+
   sc.ctx = ctx;
   sc.core = core;
 

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -941,13 +941,17 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   sc.range.base_address = GUM_ADDRESS (address);
   sc.range.size = size;
-  sc.result = GUM_QUICK_MATCH_CONTINUE;
-  sc.ctx = ctx;
-  sc.core = core;
+
+  gum_match_pattern_ref (sc.pattern);
 
   JS_DupValue (ctx, sc.on_match);
   JS_DupValue (ctx, sc.on_error);
   JS_DupValue (ctx, sc.on_complete);
+
+  sc.result = GUM_QUICK_MATCH_CONTINUE;
+
+  sc.ctx = ctx;
+  sc.core = core;
 
   _gum_quick_core_pin (core);
   _gum_quick_core_push_job (core,
@@ -1084,8 +1088,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
     gum_memory_scan (&range, pattern, (GumMemoryScanMatchFunc) gum_append_match,
         &sc);
   }
-
-  gum_match_pattern_unref (pattern);
 
   if (gum_exceptor_catch (core->exceptor, &scope))
   {

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -936,7 +936,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   sc.pattern = NULL;
 
-  if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError?,onComplete?}",
+  if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError?,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
     goto propagate_exception;

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -934,7 +934,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   gsize size;
   GumMemoryScanContext sc;
 
-  if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError?,onComplete}",
+  if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
     return JS_EXCEPTION;

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -1083,6 +1083,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
 
     sc.matches = result;
     sc.index = 0;
+
     sc.ctx = ctx;
     sc.core = core;
 

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -934,8 +934,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   gsize size;
   GumMemoryScanContext sc;
 
-  sc.pattern = NULL;
-
   if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError?,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
@@ -961,9 +959,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
 propagate_exception:
   {
-    if (sc.pattern != NULL)
-      gum_match_pattern_unref (sc.pattern);
-
     return JS_EXCEPTION;
   }
 }

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -937,7 +937,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   if (!_gum_quick_args_parse (args, "pZMF{onMatch,onError?,onComplete}",
       &address, &size, &sc.pattern, &sc.on_match, &sc.on_error,
       &sc.on_complete))
-    goto propagate_exception;
+    return JS_EXCEPTION;
 
   sc.range.base_address = GUM_ADDRESS (address);
   sc.range.size = size;
@@ -960,11 +960,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
       (GDestroyNotify) gum_memory_scan_context_free);
 
   return JS_UNDEFINED;
-
-propagate_exception:
-  {
-    return JS_EXCEPTION;
-  }
 }
 
 static void

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -1074,6 +1074,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
 
   range.base_address = GUM_ADDRESS (address);
   range.size = size;
+
   result = JS_NewArray (ctx);
 
   if (gum_exceptor_try (core->exceptor, &scope))

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -51,8 +51,6 @@ _gum_quick_args_init (GumQuickArgs * args,
   args->arrays = NULL;
   args->bytes = NULL;
   args->match_patterns = NULL;
-
-  args->parse_success = false;
 }
 
 void
@@ -61,6 +59,9 @@ _gum_quick_args_destroy (GumQuickArgs * args)
   JSContext * ctx = args->ctx;
   GSList * cur, * next;
   GArray * values;
+
+  g_slist_free_full (g_steal_pointer (&args->match_patterns),
+      (GDestroyNotify) gum_match_pattern_unref);
 
   g_slist_free_full (g_steal_pointer (&args->bytes),
       (GDestroyNotify) g_bytes_unref);
@@ -90,17 +91,6 @@ _gum_quick_args_destroy (GumQuickArgs * args)
     }
 
     g_array_free (values, TRUE);
-  }
-
-  GSList * match_patterns = g_steal_pointer (&args->match_patterns);
-  if (!args->parse_success)
-  {
-    g_slist_free_full (match_patterns,
-        (GDestroyNotify) gum_match_pattern_unref);
-  }
-  else
-  {
-    g_slist_free (match_patterns);
   }
 }
 
@@ -600,8 +590,6 @@ _gum_quick_args_parse (GumQuickArgs * self,
   }
 
   va_end (ap);
-
-  self->parse_success = true;
 
   return TRUE;
 

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -92,18 +92,15 @@ _gum_quick_args_destroy (GumQuickArgs * args)
     g_array_free (values, TRUE);
   }
 
-  GSList * match_patterns = args->match_patterns;
-  if (match_patterns != NULL)
+  GSList * match_patterns = g_steal_pointer (&args->match_patterns);
+  if (!args->parse_success)
   {
-    if (!args->parse_success)
-    {
-      g_slist_free_full (match_patterns,
-          (GDestroyNotify) gum_match_pattern_unref);
-    }
-    else
-    {
-      g_slist_free (match_patterns);
-    }
+    g_slist_free_full (match_patterns,
+        (GDestroyNotify) gum_match_pattern_unref);
+  }
+  else
+  {
+    g_slist_free (match_patterns);
   }
 }
 

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -551,6 +551,7 @@ _gum_quick_args_parse (GumQuickArgs * self,
             goto propagate_exception;
 
           pattern = gum_match_pattern_new_from_string (str);
+
           JS_FreeCString (ctx, str);
 
           if (pattern == NULL)

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -556,7 +556,6 @@ _gum_quick_args_parse (GumQuickArgs * self,
 
           if (pattern == NULL)
             goto invalid_pattern;
-
         }
         else if (JS_IsObject (arg))
         {

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -562,13 +562,13 @@ _gum_quick_args_parse (GumQuickArgs * self,
           pattern = JS_GetOpaque (arg, core->match_pattern_class);
           if (pattern == NULL)
             goto expected_pattern;
+
+          gum_match_pattern_ref (pattern);
         }
         else
         {
           goto expected_pattern;
         }
-
-        gum_match_pattern_ref (pattern);
 
         *va_arg (ap, GumMatchPattern **) = pattern;
 

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumquickvalue.h
+++ b/bindings/gumjs/gumquickvalue.h
@@ -26,6 +26,9 @@ struct _GumQuickArgs
   GSList * cstrings;
   GSList * arrays;
   GSList * bytes;
+  GSList * match_patterns;
+
+  bool parse_success;
 };
 
 enum _GumQuickMatchResult

--- a/bindings/gumjs/gumquickvalue.h
+++ b/bindings/gumjs/gumquickvalue.h
@@ -27,8 +27,6 @@ struct _GumQuickArgs
   GSList * arrays;
   GSList * bytes;
   GSList * match_patterns;
-
-  bool parse_success;
 };
 
 enum _GumQuickMatchResult

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -796,13 +796,10 @@ gum_kernel_scan_context_run (GumKernelScanContext * self)
 
   ScriptScope script_scope (core->script);
 
-  if (!self->on_complete->IsEmpty ())
-  {
-    auto on_complete (Local<Function>::New (isolate, *self->on_complete));
-    auto recv = Undefined (isolate);
-    auto result = on_complete->Call (context, recv, 0, nullptr);
-    _gum_v8_ignore_result (result);
-  }
+  auto on_complete (Local<Function>::New (isolate, *self->on_complete));
+  auto recv = Undefined (isolate);
+  auto result = on_complete->Call (context, recv, 0, nullptr);
+  _gum_v8_ignore_result (result);
 }
 
 static gboolean

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -746,7 +746,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
 
   pattern = NULL;
 
-  if (!_gum_v8_args_parse (args, "QZMF{onMatch,onError?,onComplete?}", &address,
+  if (!_gum_v8_args_parse (args, "QZMF{onMatch,onError?,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
   {
     if (pattern != NULL)
@@ -764,8 +764,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   ctx->on_match = new GumPersistent<Function>::type (isolate, on_match);
   if (!on_error.IsEmpty ())
     ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
-  if (!on_complete.IsEmpty ())
-    ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
+  ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
   ctx->core = core;
 
   _gum_v8_core_pin (core);

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -744,15 +744,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_kernel_scan)
   GumMatchPattern * pattern;
   Local<Function> on_match, on_error, on_complete;
 
-  pattern = NULL;
-
   if (!_gum_v8_args_parse (args, "QZMF{onMatch,onError?,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
-  {
-    if (pattern != NULL)
-      gum_match_pattern_unref (pattern);
     return;
-  }
 
   GumMemoryRange range;
   range.base_address = address;

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -165,7 +165,7 @@ static const GumV8Function gumjs_kernel_functions[] =
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf8String", UTF8_STRING),
   GUMJS_EXPORT_MEMORY_READ_WRITE ("Utf16String", UTF16_STRING),
 
-  { "scan", gumjs_kernel_scan },
+  { "_scan", gumjs_kernel_scan },
   { "scanSync", gumjs_kernel_scan_sync },
 
   { NULL, NULL }

--- a/bindings/gumjs/gumv8kernel.cpp
+++ b/bindings/gumjs/gumv8kernel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -915,15 +915,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   GumMatchPattern * pattern;
   Local<Function> on_match, on_error, on_complete;
 
-  pattern = NULL;
-
   if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError?,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
-  {
-    if (pattern != NULL)
-      gum_match_pattern_unref (pattern);
     return;
-  }
 
   GumMemoryRange range;
   range.base_address = GUM_ADDRESS (address);

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -917,7 +917,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 
   pattern = NULL;
 
-  if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError?,onComplete?}", &address,
+  if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError?,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
   {
     if (pattern != NULL)
@@ -935,8 +935,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   ctx->on_match = new GumPersistent<Function>::type (isolate, on_match);
   if (!on_error.IsEmpty ())
     ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
-  if (!on_complete.IsEmpty ())
-    ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
+  ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
   ctx->core = core;
 
   _gum_v8_core_pin (core);

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -915,7 +915,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   GumMatchPattern * pattern;
   Local<Function> on_match, on_error, on_complete;
 
-  if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError?,onComplete}", &address,
+  if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
     return;
 
@@ -927,8 +927,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   ctx->range = range;
   ctx->pattern = pattern;
   ctx->on_match = new GumPersistent<Function>::type (isolate, on_match);
-  if (!on_error.IsEmpty ())
-    ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
+  ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
   ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
   ctx->core = core;
 

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -914,7 +914,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   gsize size;
   GumMatchPattern * pattern;
   Local<Function> on_match, on_error, on_complete;
-
   if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError,onComplete}", &address,
       &size, &pattern, &on_match, &on_error, &on_complete))
     return;
@@ -941,8 +940,6 @@ gum_memory_scan_context_free (GumMemoryScanContext * self)
 {
   auto core = self->core;
 
-  gum_match_pattern_unref (self->pattern);
-
   {
     ScriptScope script_scope (core->script);
 
@@ -952,6 +949,8 @@ gum_memory_scan_context_free (GumMemoryScanContext * self)
 
     _gum_v8_core_unpin (core);
   }
+
+  gum_match_pattern_unref (self->pattern);
 
   g_slice_free (GumMemoryScanContext, self);
 }

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -142,9 +142,6 @@ static gboolean gum_memory_scan_context_emit_match (GumAddress address,
 GUMJS_DECLARE_FUNCTION (gumjs_memory_scan_sync)
 static gboolean gum_append_match (GumAddress address, gsize size,
     GumMemoryScanSyncContext * ctx);
-static gboolean gum_parse_memory_scan_args (GumV8Core * core,
-    const FunctionCallbackInfo<Value> & info, gpointer * address, gsize * size,
-    GumMatchPattern ** pattern);
 
 GUMJS_DECLARE_FUNCTION (gumjs_memory_access_monitor_enable)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_access_monitor_disable)
@@ -913,56 +910,19 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc_utf16_string)
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
 {
-  if (info.Length () < 4)
-  {
-    _gum_v8_throw_ascii_literal (isolate, "missing argument");
-    return;
-  }
-
   gpointer address;
   gsize size;
   GumMatchPattern * pattern;
-  if (!gum_parse_memory_scan_args (core, info, &address, &size, &pattern))
+  Local<Function> on_match, on_error, on_complete;
+
+  pattern = NULL;
+
+  if (!_gum_v8_args_parse (args, "pZMF{onMatch,onError?,onComplete?}", &address,
+      &size, &pattern, &on_match, &on_error, &on_complete))
+  {
+    if (pattern != NULL)
+      gum_match_pattern_unref (pattern);
     return;
-
-  if (!info[3]->IsObject ())
-  {
-    gum_match_pattern_unref (pattern);
-
-    _gum_v8_throw_ascii_literal (isolate,
-        "expected an object containing callbacks");
-    return;
-  }
-
-  auto callbacks_obj = info[3].As<Object> ();
-  auto context = isolate->GetCurrentContext ();
-  Local<Value> on_match_val, on_complete_val, on_error_val;
-  Local<Function> on_match, on_complete, on_error;
-
-  if (!callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
-          "onMatch")).ToLocal (&on_match_val) ||
-      !on_match_val->IsFunction ())
-  {
-    gum_match_pattern_unref (pattern);
-
-    _gum_v8_throw_literal (isolate, "expected a callback value");
-    return;
-  }
-
-  on_match = on_match_val.As<Function> ();
-
-  if (callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
-          "onComplete")).ToLocal (&on_complete_val) &&
-      on_complete_val->IsFunction ())
-  {
-    on_complete = on_complete_val.As<Function> ();
-  }
-
-  if (callbacks_obj->Get (context, _gum_v8_string_new_ascii (isolate,
-          "onError")).ToLocal (&on_error_val) &&
-      on_error_val->IsFunction ())
-  {
-    on_error = on_error_val.As<Function> ();
   }
 
   GumMemoryRange range;
@@ -973,10 +933,10 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan)
   ctx->range = range;
   ctx->pattern = pattern;
   ctx->on_match = new GumPersistent<Function>::type (isolate, on_match);
-  if (!on_complete.IsEmpty ())
-    ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
   if (!on_error.IsEmpty ())
     ctx->on_error = new GumPersistent<Function>::type (isolate, on_error);
+  if (!on_complete.IsEmpty ())
+    ctx->on_complete = new GumPersistent<Function>::type (isolate, on_complete);
   ctx->core = core;
 
   _gum_v8_core_pin (core);
@@ -1090,7 +1050,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_scan_sync)
   gpointer address;
   gsize size;
   GumMatchPattern * pattern;
-  if (!gum_parse_memory_scan_args (core, info, &address, &size, &pattern))
+  if (!_gum_v8_args_parse (args, "pZM", &address, &size, &pattern))
     return;
 
   GumMemoryRange range;
@@ -1133,48 +1093,6 @@ gum_append_match (GumAddress address,
   _gum_v8_object_set_uint (match, "size", size, core);
   ctx->matches->Set (core->isolate->GetCurrentContext (),
       ctx->matches->Length (), match).ToChecked ();
-
-  return TRUE;
-}
-
-static gboolean
-gum_parse_memory_scan_args (GumV8Core * core,
-                            const FunctionCallbackInfo<Value> & info,
-                            gpointer * address,
-                            gsize * size,
-                            GumMatchPattern ** pattern)
-{
-  if (!_gum_v8_native_pointer_get (info[0], address, core))
-    return FALSE;
-
-  if (!_gum_v8_size_get (info[1], size, core))
-    return FALSE;
-
-  auto pattern_val = info[2];
-  if (pattern_val->IsString())
-  {
-    String::Utf8Value pattern_utf8 (core->isolate, pattern_val);
-    *pattern = gum_match_pattern_new_from_string (*pattern_utf8);
-    if (*pattern == NULL)
-    {
-      _gum_v8_throw_ascii_literal (core->isolate, "invalid match pattern");
-      return FALSE;
-    }
-  }
-  else
-  {
-    auto match_pattern = Local<FunctionTemplate>::New (core->isolate,
-        *core->match_pattern);
-    if (!match_pattern->HasInstance (pattern_val))
-    {
-      _gum_v8_throw_ascii_literal (core->isolate,
-          "expected either a pattern string or a MatchPattern object");
-      return FALSE;
-    }
-    *pattern = (GumMatchPattern *) pattern_val.As<Object> ()
-        ->GetInternalField (0).As<External> ()->Value ();
-    *pattern = gum_match_pattern_ref (*pattern);
-  }
 
   return TRUE;
 }

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -1014,6 +1014,7 @@ gum_memory_scan_context_emit_match (GumAddress address,
   auto context = isolate->GetCurrentContext ();
 
   gboolean proceed = TRUE;
+
   auto on_match = Local<Function>::New (isolate, *self->on_match);
   auto recv = Undefined (isolate);
   Local<Value> argv[] = {

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -583,6 +583,44 @@ _gum_v8_args_parse (const GumV8Args * args,
 
         break;
       }
+      case 'M':
+      {
+        GumMatchPattern * pattern;
+
+        if (arg->IsString ())
+        {
+          String::Utf8Value arg_utf8 (isolate, arg);
+
+          pattern = gum_match_pattern_new_from_string (*arg_utf8);
+
+          if (pattern == NULL)
+          {
+            _gum_v8_throw_ascii_literal (isolate,
+                "invalid match pattern");
+            return FALSE;
+          }
+        }
+        else
+        {
+          auto match_pattern = Local<FunctionTemplate>::New (core->isolate,
+              *core->match_pattern);
+
+          if (!match_pattern->HasInstance (arg))
+          {
+            _gum_v8_throw_ascii_literal (isolate,
+                "expected either a pattern string or a MatchPattern object");
+            return FALSE;
+          }
+
+          pattern = (GumMatchPattern *) arg.As<Object> ()
+              ->GetInternalField (0).As<External> ()->Value ();
+        }
+
+        gum_match_pattern_ref (pattern);
+        *va_arg (ap, GumMatchPattern **) = pattern;
+
+        break;
+      }
       default:
         g_assert_not_reached ();
     }

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -615,9 +615,10 @@ _gum_v8_args_parse (const GumV8Args * args,
 
           pattern = (GumMatchPattern *) arg.As<Object> ()
               ->GetInternalField (0).As<External> ()->Value ();
+
+          gum_match_pattern_ref (pattern);
         }
 
-        gum_match_pattern_ref (pattern);
         *va_arg (ap, GumMatchPattern **) = pattern;
 
         break;

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -20,7 +20,8 @@ struct GumV8ArgsParseScope
     : committed (FALSE),
       strings (NULL),
       arrays (NULL),
-      bytes (NULL)
+      bytes (NULL),
+      match_patterns (NULL)
   {
   }
 
@@ -31,11 +32,13 @@ struct GumV8ArgsParseScope
       g_slist_foreach (strings, (GFunc) g_free, NULL);
       g_slist_foreach (arrays, (GFunc) g_array_unref, NULL);
       g_slist_foreach (bytes, (GFunc) g_bytes_unref, NULL);
+      g_slist_foreach (match_patterns, (GFunc) gum_match_pattern_unref, NULL);
     }
 
     g_slist_free (strings);
     g_slist_free (arrays);
     g_slist_free (bytes);
+    g_slist_free (match_patterns);
   }
 
   void
@@ -64,10 +67,17 @@ struct GumV8ArgsParseScope
     bytes = g_slist_prepend (bytes, b);
   }
 
+  void
+  add (GumMatchPattern * p)
+  {
+    match_patterns = g_slist_prepend (match_patterns, p);
+  }
+
   gboolean committed;
   GSList * strings;
   GSList * arrays;
   GSList * bytes;
+  GSList * match_patterns;
 };
 
 struct GumCpuContextWrapper
@@ -618,6 +628,8 @@ _gum_v8_args_parse (const GumV8Args * args,
 
           gum_match_pattern_ref (pattern);
         }
+
+        scope.add(pattern);
 
         *va_arg (ap, GumMatchPattern **) = pattern;
 

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -603,11 +603,9 @@ _gum_v8_args_parse (const GumV8Args * args,
           String::Utf8Value arg_utf8 (isolate, arg);
 
           pattern = gum_match_pattern_new_from_string (*arg_utf8);
-
           if (pattern == NULL)
           {
-            _gum_v8_throw_ascii_literal (isolate,
-                "invalid match pattern");
+            _gum_v8_throw_ascii_literal (isolate, "invalid match pattern");
             return FALSE;
           }
         }
@@ -615,7 +613,6 @@ _gum_v8_args_parse (const GumV8Args * args,
         {
           auto match_pattern = Local<FunctionTemplate>::New (core->isolate,
               *core->match_pattern);
-
           if (!match_pattern->HasInstance (arg))
           {
             _gum_v8_throw_ascii_literal (isolate,
@@ -629,7 +626,7 @@ _gum_v8_args_parse (const GumV8Args * args,
           gum_match_pattern_ref (pattern);
         }
 
-        scope.add(pattern);
+        scope.add (pattern);
 
         *va_arg (ap, GumMatchPattern **) = pattern;
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -183,6 +183,27 @@ makeEnumerateApi(Kernel, 'enumerateModules', 0);
 makeEnumerateRanges(Kernel);
 makeEnumerateApi(Kernel, 'enumerateModuleRanges', 2);
 
+Object.defineProperties(Kernel, {
+  scan: {
+    enumerable: true,
+    value: function (address, size, pattern, callbacks) {
+      return new Promise((resolve, reject) => {
+        Kernel._scan(address, size, pattern, {
+          onMatch: callbacks.onMatch,
+          onError(reason) {
+            reject(new Error(reason));
+            callbacks.onError?.();
+          },
+          onComplete() {
+            resolve();
+            callbacks.onComplete?.();
+          }
+        });
+      });
+    }
+  }
+});
+
 Object.defineProperties(Memory, {
   alloc: {
     enumerable: true,

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -187,29 +187,27 @@ Object.defineProperties(Kernel, {
   scan: {
     enumerable: true,
     value: function (address, size, pattern, callbacks) {
-      return new Promise((resolve, reject) => {
-        let onSuccess;
-        let onFailure;
+      let onSuccess;
+      let onFailure;
 
-        const request = new Promise((resolve, reject) => {
-          onSuccess = resolve;
-          onFailure = reject;
-        });
-
-        Kernel._scan(address, size, pattern, {
-          onMatch: callbacks.onMatch,
-          onError(reason) {
-            onFailure(new Error(reason));
-            callbacks.onError?.();
-          },
-          onComplete() {
-            onSuccess();
-            callbacks.onComplete?.();
-          }
-        });
-
-        return request;
+      const request = new Promise((resolve, reject) => {
+        onSuccess = resolve;
+        onFailure = reject;
       });
+
+      Kernel._scan(address, size, pattern, {
+        onMatch: callbacks.onMatch,
+        onError(reason) {
+          onFailure(new Error(reason));
+          callbacks.onError?.();
+        },
+        onComplete() {
+          onSuccess();
+          callbacks.onComplete?.();
+        }
+      });
+
+      return request;
     }
   }
 });

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -187,9 +187,7 @@ Object.defineProperties(Kernel, {
   scan: {
     enumerable: true,
     value: function (address, size, pattern, callbacks) {
-      let onSuccess;
-      let onFailure;
-
+      let onSuccess, onFailure;
       const request = new Promise((resolve, reject) => {
         onSuccess = resolve;
         onFailure = reject;
@@ -248,13 +246,13 @@ Object.defineProperties(Memory, {
 
       Memory._scan(address, size, pattern, {
         onMatch: callbacks.onMatch,
-        onComplete() {
-          onSuccess();
-          callbacks.onComplete?.();
-        },
         onError(reason) {
           onFailure(new Error(reason));
           callbacks.onError?.(reason);
+        },
+        onComplete() {
+          onSuccess();
+          callbacks.onComplete?.();
         }
       });
 

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -188,17 +188,27 @@ Object.defineProperties(Kernel, {
     enumerable: true,
     value: function (address, size, pattern, callbacks) {
       return new Promise((resolve, reject) => {
+        let onSuccess;
+        let onFailure;
+
+        const request = new Promise((resolve, reject) => {
+          onSuccess = resolve;
+          onFailure = reject;
+        });
+
         Kernel._scan(address, size, pattern, {
           onMatch: callbacks.onMatch,
           onError(reason) {
-            reject(new Error(reason));
+            onFailure(new Error(reason));
             callbacks.onError?.();
           },
           onComplete() {
-            resolve();
+            onSuccess();
             callbacks.onComplete?.();
           }
         });
+
+        return request;
       });
     }
   }

--- a/tests/gumjs/kscript.c
+++ b/tests/gumjs/kscript.c
@@ -151,15 +151,15 @@ TESTCASE (byte_array_can_be_written)
 
 TESTCASE (memory_can_be_asynchronously_scanned)
 {
-  COMPILE_AND_LOAD_SCRIPT(
-      "var buffer = Kernel.alloc(12);"
+  COMPILE_AND_LOAD_SCRIPT (
+      "const buffer = Kernel.alloc(12);"
       /* ASCII for 'hello world' */
       "Kernel.writeByteArray(buffer, [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77,"
         "0x6f, 0x72, 0x6c, 0x64]);"
       "Kernel"
       "  .scan(buffer, 11, '/world/', {"
       "    onMatch(address, size) {"
-      "      send(address == buffer + 6);"
+      "      send(address.equals(buffer.add(6)));"
       "      send(size);"
       "    },"
       "    onError(reason) {"
@@ -175,13 +175,12 @@ TESTCASE (memory_can_be_asynchronously_scanned)
 TESTCASE (memory_can_be_synchronously_scanned)
 {
   COMPILE_AND_LOAD_SCRIPT (
-      "var buffer = Kernel.alloc(12);"
+      "const buffer = Kernel.alloc(12);"
       "Kernel.writeByteArray(buffer, [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77,"
         "0x6f, 0x72, 0x6c, 0x64]);"
-      "var match = Kernel.scanSync(buffer, 11, '/hello/')[0];"
-      /* XXX: for some reason (match.address == compare) evaluates to false */
-      "send(new UInt64(match.address).compare(buffer));"
+      "const match = Kernel.scanSync(buffer, 11, '/hello/')[0];"
+      "send(match.address.equals(buffer));"
       "send(match.size);");
-  EXPECT_SEND_MESSAGE_WITH ("0");
+  EXPECT_SEND_MESSAGE_WITH ("true");
   EXPECT_SEND_MESSAGE_WITH ("5");
 }

--- a/tests/gumjs/kscript.c
+++ b/tests/gumjs/kscript.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -17,6 +18,8 @@ TESTLIST_BEGIN (kscript)
   TESTENTRY (module_ranges_can_be_enumerated_legacy_style)
   TESTENTRY (byte_array_can_be_read)
   TESTENTRY (byte_array_can_be_written)
+  TESTENTRY (memory_can_be_asynchronously_scanned)
+  TESTENTRY (memory_can_be_synchronously_scanned)
 TESTLIST_END ()
 
 TESTCASE (api_availability_can_be_queried)
@@ -146,3 +149,39 @@ TESTCASE (byte_array_can_be_written)
   EXPECT_NO_MESSAGES ();
 }
 
+TESTCASE (memory_can_be_asynchronously_scanned)
+{
+  COMPILE_AND_LOAD_SCRIPT(
+      "var buffer = Kernel.alloc(12);"
+      /* ASCII for 'hello world' */
+      "Kernel.writeByteArray(buffer, [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77,"
+        "0x6f, 0x72, 0x6c, 0x64]);"
+      "Kernel"
+      "  .scan(buffer, 11, '/world/', {"
+      "    onMatch(address, size) {"
+      "      send(address == buffer + 6);"
+      "      send(size);"
+      "    },"
+      "    onError(reason) {"
+      "      console.error(reason);"
+      "    }"
+      "  })"
+      "  .then(() => send('DONE'));");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+  EXPECT_SEND_MESSAGE_WITH ("5");
+  EXPECT_SEND_MESSAGE_WITH ("\"DONE\"");
+}
+
+TESTCASE (memory_can_be_synchronously_scanned)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "var buffer = Kernel.alloc(12);"
+      "Kernel.writeByteArray(buffer, [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77,"
+        "0x6f, 0x72, 0x6c, 0x64]);"
+      "var match = Kernel.scanSync(buffer, 11, '/hello/')[0];"
+      /* XXX: for some reason (match.address == compare) evaluates to false */
+      "send(new UInt64(match.address).compare(buffer));"
+      "send(match.size);");
+  EXPECT_SEND_MESSAGE_WITH ("0");
+  EXPECT_SEND_MESSAGE_WITH ("5");
+}


### PR DESCRIPTION
This makes the `Kernel.scan*()` API fully compatible with `Memory.scan*()`, which was [just updated](https://github.com/frida/frida-gum/pull/591) to add regex support.

TODO:

- [x] Return a `Promise` from `Kernel.scan()`.
- [x] Add tests