### PR TITLE
objc-api-resolver: Protect against objc_disposeClassPair via mutex

### DIFF
--- a/gum/backend-darwin/gumobjcapiresolver.c
+++ b/gum/backend-darwin/gumobjcapiresolver.c
@@ -63,8 +63,6 @@ static void gum_objc_api_resolver_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_objc_api_resolver_dispose (GObject * object);
 static void gum_objc_api_resolver_finalize (GObject * object);
-static void gum_objc_api_resolver_ensure_class_by_handle (
-    GumObjcApiResolver * self);
 static void gum_objc_api_resolver_enumerate_matches (GumApiResolver * resolver,
     const gchar * query, GumFoundApiFunc func, gpointer user_data,
     GError ** error);

--- a/gum/backend-darwin/gumobjcapiresolver.c
+++ b/gum/backend-darwin/gumobjcapiresolver.c
@@ -30,7 +30,6 @@ struct _GumObjcApiResolver
 
   gboolean available;
   GHashTable * class_by_handle;
-
   GumObjcDisposeClassPairMonitor * monitor;
 
   gint (* objc_getClassList) (Class * buffer, gint class_count);
@@ -146,11 +145,8 @@ gum_objc_api_resolver_init (GumObjcApiResolver * self)
   GUM_TRY_ASSIGN_OBJC_FUNC (method_getImplementation);
   GUM_TRY_ASSIGN_OBJC_FUNC (sel_getName);
 
-  self->monitor = gum_objc_dispose_class_pair_monitor_obtain ();
-
   self->available = TRUE;
-
-  self->class_by_handle = NULL;
+  self->monitor = gum_objc_dispose_class_pair_monitor_obtain ();
 
 beach:
   if (objc != NULL)

--- a/gum/backend-darwin/gumobjcapiresolver.c
+++ b/gum/backend-darwin/gumobjcapiresolver.c
@@ -7,12 +7,11 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
-#include "guminterceptor.h"
-
 #include "gumobjcapiresolver.h"
+
+#include "guminterceptor.h"
 #include "gumobjcapiresolver-priv.h"
 #include "gumobjcdisposeclasspairmonitor.h"
-
 #include "gumprocess.h"
 
 #include <dlfcn.h>

--- a/gum/backend-darwin/gumobjcapiresolver.c
+++ b/gum/backend-darwin/gumobjcapiresolver.c
@@ -390,7 +390,7 @@ gum_objc_api_resolver_find_method_by_address (GumApiResolver * resolver,
   g_rec_mutex_lock (&self->monitor->mutex);
 
   class_count = self->objc_getClassList (NULL, 0);
-  classes = g_malloc (class_count * sizeof (Class));
+  classes = g_new (Class, class_count);
   self->objc_getClassList (classes, class_count);
 
   for (class_index = 0;

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -10,6 +10,7 @@
 
 static void gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
     gpointer iface_data);
+static void gum_objc_dispose_class_pair_monitor_dispose (GObject * object);
 static void gum_objc_dispose_class_pair_monitor_finalize (GObject * object);
 static void the_monitor_weak_notify (gpointer data,
     GObject * where_the_object_was);
@@ -100,6 +101,7 @@ gum_objc_dispose_class_pair_monitor_class_init (
 {
   GObjectClass * object_class = G_OBJECT_CLASS (klass);
 
+  object_class->dispose = gum_objc_dispose_class_pair_monitor_dispose;
   object_class->finalize = gum_objc_dispose_class_pair_monitor_finalize;
 }
 
@@ -121,7 +123,7 @@ gum_objc_dispose_class_pair_monitor_init (
 }
 
 static void
-gum_objc_dispose_class_pair_monitor_finalize (GObject * object)
+gum_objc_dispose_class_pair_monitor_dispose (GObject * object)
 {
   GumObjcDisposeClassPairMonitor * self =
       GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (object);
@@ -130,7 +132,21 @@ gum_objc_dispose_class_pair_monitor_finalize (GObject * object)
   gum_interceptor_detach (self->interceptor, GUM_INVOCATION_LISTENER (self));
   g_rec_mutex_unlock (&self->mutex);
 
+  g_clear_object (&self->interceptor);
+
+  G_OBJECT_CLASS (
+      gum_objc_dispose_class_pair_monitor_parent_class)->dispose (object);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_finalize (GObject * object)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (object);
+
   g_rec_mutex_clear (&self->mutex);
-  g_object_unref (self->interceptor);
+
+  G_OBJECT_CLASS (
+      gum_objc_dispose_class_pair_monitor_parent_class)->finalize (object);
 }
 

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gumobjcdisposeclasspairmonitor.h"
+
+#include <gum/guminvocationlistener.h>
+
+static void gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
+    gpointer iface_data);
+static void gum_objc_dispose_class_pair_monitor_finalize (GObject * object);
+static void the_monitor_weak_notify (gpointer data,
+    GObject * where_the_object_was);
+
+G_DEFINE_TYPE_EXTENDED (GumObjcDisposeClassPairMonitor,
+                        gum_objc_dispose_class_pair_monitor,
+                        G_TYPE_OBJECT,
+                        0,
+                        G_IMPLEMENT_INTERFACE (GUM_TYPE_INVOCATION_LISTENER,
+                            gum_objc_dispose_class_pair_monitor_iface_init))
+
+static GMutex _gum_obj_dispose_class_pair_monitor_lock;
+static GumObjcDisposeClassPairMonitor * _the_monitor = NULL;
+
+GumObjcDisposeClassPairMonitor *
+gum_objc_dispose_class_pair_monitor_obtain (void)
+{
+  GumObjcDisposeClassPairMonitor * monitor;
+
+  g_mutex_lock (&_gum_obj_dispose_class_pair_monitor_lock);
+
+  if (_the_monitor != NULL)
+  {
+    monitor = GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (
+        g_object_ref (_the_monitor));
+  }
+  else
+  {
+    _the_monitor = g_object_new (GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR,
+        NULL);
+    g_object_weak_ref (G_OBJECT (_the_monitor),
+        the_monitor_weak_notify, NULL);
+
+    monitor = _the_monitor;
+  }
+
+  g_mutex_unlock (&_gum_obj_dispose_class_pair_monitor_lock);
+
+  return monitor;
+}
+
+static void
+the_monitor_weak_notify (gpointer data,
+                         GObject * where_the_object_was)
+{
+  g_mutex_lock (&_gum_obj_dispose_class_pair_monitor_lock);
+
+  g_assert (_the_monitor == (GumObjcDisposeClassPairMonitor *)
+      where_the_object_was);
+  _the_monitor = NULL;
+
+  g_mutex_unlock (&_gum_obj_dispose_class_pair_monitor_lock);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_on_enter (GumInvocationListener * listener,
+                                               GumInvocationContext * context)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
+
+  g_rec_mutex_lock (&self->mutex);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
+                                               GumInvocationContext * context)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
+
+  g_rec_mutex_unlock (&self->mutex);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
+                                                 gpointer iface_data)
+{
+  GumInvocationListenerInterface * iface = g_iface;
+
+  iface->on_enter = gum_objc_dispose_class_pair_monitor_on_enter;
+  iface->on_leave = gum_objc_dispose_class_pair_monitor_on_leave;
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_class_init (
+    GumObjcDisposeClassPairMonitorClass * klass)
+{
+  GObjectClass * object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = gum_objc_dispose_class_pair_monitor_finalize;
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_init (
+    GumObjcDisposeClassPairMonitor * self)
+{
+  gpointer objc_disposeClassPair;
+
+  g_rec_mutex_init (&self->mutex);
+
+  objc_disposeClassPair = GSIZE_TO_POINTER (gum_module_find_export_by_name (
+      "/usr/lib/libobjc.A.dylib", "objc_disposeClassPair"));
+
+  g_assert (objc_disposeClassPair != NULL);
+
+  self->interceptor = gum_interceptor_obtain ();
+  gum_interceptor_attach (self->interceptor, objc_disposeClassPair,
+      GUM_INVOCATION_LISTENER (self), NULL);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_finalize (GObject * object)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (object);
+
+  g_rec_mutex_lock (&self->mutex);
+  gum_interceptor_detach (self->interceptor, GUM_INVOCATION_LISTENER (self));
+  g_rec_mutex_unlock (&self->mutex);
+
+  g_rec_mutex_clear (&self->mutex);
+  g_object_unref (self->interceptor);
+}
+

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -113,7 +113,6 @@ gum_objc_dispose_class_pair_monitor_init (
 
   objc_disposeClassPair = GSIZE_TO_POINTER (gum_module_find_export_by_name (
       "/usr/lib/libobjc.A.dylib", "objc_disposeClassPair"));
-
   g_assert (objc_disposeClassPair != NULL);
 
   self->interceptor = gum_interceptor_obtain ();

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -12,8 +12,11 @@ static void gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
     gpointer iface_data);
 static void gum_objc_dispose_class_pair_monitor_dispose (GObject * object);
 static void gum_objc_dispose_class_pair_monitor_finalize (GObject * object);
-static void the_monitor_weak_notify (gpointer data,
-    GObject * where_the_object_was);
+static void gum_on_weak_notify (gpointer data, GObject * where_the_object_was);
+static void gum_objc_dispose_class_pair_monitor_on_enter (
+    GumInvocationListener * listener, GumInvocationContext * context);
+static void gum_objc_dispose_class_pair_monitor_on_leave (
+    GumInvocationListener * listener, GumInvocationContext * context);
 
 G_DEFINE_TYPE_EXTENDED (GumObjcDisposeClassPairMonitor,
                         gum_objc_dispose_class_pair_monitor,
@@ -25,64 +28,14 @@ G_DEFINE_TYPE_EXTENDED (GumObjcDisposeClassPairMonitor,
 static GMutex _gum_objc_dispose_class_pair_monitor_lock;
 static GumObjcDisposeClassPairMonitor * _the_monitor = NULL;
 
-GumObjcDisposeClassPairMonitor *
-gum_objc_dispose_class_pair_monitor_obtain (void)
-{
-  GumObjcDisposeClassPairMonitor * monitor;
-
-  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
-
-  if (_the_monitor != NULL)
-  {
-    monitor = GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (
-        g_object_ref (_the_monitor));
-  }
-  else
-  {
-    _the_monitor = g_object_new (GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR,
-        NULL);
-    g_object_weak_ref (G_OBJECT (_the_monitor),
-        the_monitor_weak_notify, NULL);
-
-    monitor = _the_monitor;
-  }
-
-  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
-
-  return monitor;
-}
-
 static void
-the_monitor_weak_notify (gpointer data,
-                         GObject * where_the_object_was)
+gum_objc_dispose_class_pair_monitor_class_init (
+    GumObjcDisposeClassPairMonitorClass * klass)
 {
-  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
+  GObjectClass * object_class = G_OBJECT_CLASS (klass);
 
-  g_assert (_the_monitor == (GumObjcDisposeClassPairMonitor *)
-      where_the_object_was);
-  _the_monitor = NULL;
-
-  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
-}
-
-static void
-gum_objc_dispose_class_pair_monitor_on_enter (GumInvocationListener * listener,
-                                              GumInvocationContext * context)
-{
-  GumObjcDisposeClassPairMonitor * self =
-      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
-
-  g_rec_mutex_lock (&self->mutex);
-}
-
-static void
-gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
-                                              GumInvocationContext * context)
-{
-  GumObjcDisposeClassPairMonitor * self =
-      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
-
-  g_rec_mutex_unlock (&self->mutex);
+  object_class->dispose = gum_objc_dispose_class_pair_monitor_dispose;
+  object_class->finalize = gum_objc_dispose_class_pair_monitor_finalize;
 }
 
 static void
@@ -96,29 +49,18 @@ gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
 }
 
 static void
-gum_objc_dispose_class_pair_monitor_class_init (
-    GumObjcDisposeClassPairMonitorClass * klass)
+gum_objc_dispose_class_pair_monitor_init (GumObjcDisposeClassPairMonitor * self)
 {
-  GObjectClass * object_class = G_OBJECT_CLASS (klass);
-
-  object_class->dispose = gum_objc_dispose_class_pair_monitor_dispose;
-  object_class->finalize = gum_objc_dispose_class_pair_monitor_finalize;
-}
-
-static void
-gum_objc_dispose_class_pair_monitor_init (
-    GumObjcDisposeClassPairMonitor * self)
-{
-  gpointer objc_disposeClassPair;
+  gpointer dispose_impl;
 
   g_rec_mutex_init (&self->mutex);
 
-  objc_disposeClassPair = GSIZE_TO_POINTER (gum_module_find_export_by_name (
+  dispose_impl = GSIZE_TO_POINTER (gum_module_find_export_by_name (
       "/usr/lib/libobjc.A.dylib", "objc_disposeClassPair"));
-  g_assert (objc_disposeClassPair != NULL);
+  g_assert (dispose_impl != NULL);
 
   self->interceptor = gum_interceptor_obtain ();
-  gum_interceptor_attach (self->interceptor, objc_disposeClassPair,
+  gum_interceptor_attach (self->interceptor, dispose_impl,
       GUM_INVOCATION_LISTENER (self), NULL);
 }
 
@@ -148,5 +90,63 @@ gum_objc_dispose_class_pair_monitor_finalize (GObject * object)
 
   G_OBJECT_CLASS (
       gum_objc_dispose_class_pair_monitor_parent_class)->finalize (object);
+}
+
+GumObjcDisposeClassPairMonitor *
+gum_objc_dispose_class_pair_monitor_obtain (void)
+{
+  GumObjcDisposeClassPairMonitor * monitor;
+
+  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
+
+  if (_the_monitor != NULL)
+  {
+    monitor = GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (g_object_ref (_the_monitor));
+  }
+  else
+  {
+    _the_monitor = g_object_new (GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR,
+        NULL);
+    g_object_weak_ref (G_OBJECT (_the_monitor), gum_on_weak_notify, NULL);
+
+    monitor = _the_monitor;
+  }
+
+  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
+
+  return monitor;
+}
+
+static void
+gum_on_weak_notify (gpointer data,
+                    GObject * where_the_object_was)
+{
+  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
+
+  g_assert (_the_monitor == (GumObjcDisposeClassPairMonitor *)
+      where_the_object_was);
+  _the_monitor = NULL;
+
+  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_on_enter (GumInvocationListener * listener,
+                                              GumInvocationContext * context)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
+
+  g_rec_mutex_lock (&self->mutex);
+}
+
+static void
+gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
+                                              GumInvocationContext * context)
+{
+  GumObjcDisposeClassPairMonitor * self =
+      GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
+
+  g_rec_mutex_unlock (&self->mutex);
 }
 

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE_EXTENDED (GumObjcDisposeClassPairMonitor,
                         G_IMPLEMENT_INTERFACE (GUM_TYPE_INVOCATION_LISTENER,
                             gum_objc_dispose_class_pair_monitor_iface_init))
 
-static GMutex _gum_obj_dispose_class_pair_monitor_lock;
+static GMutex _gum_objc_dispose_class_pair_monitor_lock;
 static GumObjcDisposeClassPairMonitor * _the_monitor = NULL;
 
 GumObjcDisposeClassPairMonitor *
@@ -29,7 +29,7 @@ gum_objc_dispose_class_pair_monitor_obtain (void)
 {
   GumObjcDisposeClassPairMonitor * monitor;
 
-  g_mutex_lock (&_gum_obj_dispose_class_pair_monitor_lock);
+  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
 
   if (_the_monitor != NULL)
   {
@@ -46,7 +46,7 @@ gum_objc_dispose_class_pair_monitor_obtain (void)
     monitor = _the_monitor;
   }
 
-  g_mutex_unlock (&_gum_obj_dispose_class_pair_monitor_lock);
+  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
 
   return monitor;
 }
@@ -55,13 +55,13 @@ static void
 the_monitor_weak_notify (gpointer data,
                          GObject * where_the_object_was)
 {
-  g_mutex_lock (&_gum_obj_dispose_class_pair_monitor_lock);
+  g_mutex_lock (&_gum_objc_dispose_class_pair_monitor_lock);
 
   g_assert (_the_monitor == (GumObjcDisposeClassPairMonitor *)
       where_the_object_was);
   _the_monitor = NULL;
 
-  g_mutex_unlock (&_gum_obj_dispose_class_pair_monitor_lock);
+  g_mutex_unlock (&_gum_objc_dispose_class_pair_monitor_lock);
 }
 
 static void

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -70,11 +70,15 @@ gum_objc_dispose_class_pair_monitor_dispose (GObject * object)
   GumObjcDisposeClassPairMonitor * self =
       GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (object);
 
-  g_rec_mutex_lock (&self->mutex);
-  gum_interceptor_detach (self->interceptor, GUM_INVOCATION_LISTENER (self));
-  g_rec_mutex_unlock (&self->mutex);
+  if (self->interceptor != NULL)
+  {
+    g_rec_mutex_lock (&self->mutex);
+    gum_interceptor_detach (self->interceptor, GUM_INVOCATION_LISTENER (self));
+    g_rec_mutex_unlock (&self->mutex);
 
-  g_clear_object (&self->interceptor);
+    g_object_unref (self->interceptor);
+    self->interceptor = NULL;
+  }
 
   G_OBJECT_CLASS (
       gum_objc_dispose_class_pair_monitor_parent_class)->dispose (object);

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -66,7 +66,7 @@ the_monitor_weak_notify (gpointer data,
 
 static void
 gum_objc_dispose_class_pair_monitor_on_enter (GumInvocationListener * listener,
-                                               GumInvocationContext * context)
+                                              GumInvocationContext * context)
 {
   GumObjcDisposeClassPairMonitor * self =
       GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
@@ -76,7 +76,7 @@ gum_objc_dispose_class_pair_monitor_on_enter (GumInvocationListener * listener,
 
 static void
 gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
-                                               GumInvocationContext * context)
+                                              GumInvocationContext * context)
 {
   GumObjcDisposeClassPairMonitor * self =
       GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR (listener);
@@ -86,7 +86,7 @@ gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
 
 static void
 gum_objc_dispose_class_pair_monitor_iface_init (gpointer g_iface,
-                                                 gpointer iface_data)
+                                                gpointer iface_data)
 {
   GumInvocationListenerInterface * iface = g_iface;
 

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.c
@@ -153,4 +153,3 @@ gum_objc_dispose_class_pair_monitor_on_leave (GumInvocationListener * listener,
 
   g_rec_mutex_unlock (&self->mutex);
 }
-

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#ifndef __GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR_H__
+#define __GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR_H__
+
+#include <glib-object.h>
+#include <gum/guminterceptor.h>
+
+G_BEGIN_DECLS
+
+#define GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR \
+  (gum_objc_dispose_class_pair_monitor_get_type ())
+G_DECLARE_FINAL_TYPE (GumObjcDisposeClassPairMonitor,
+    gum_objc_dispose_class_pair_monitor,
+    GUM, OBJC_DISPOSE_CLASS_PAIR_MONITOR, GObject)
+
+struct _GumObjcDisposeClassPairMonitor
+{
+  GObject parent;
+  GRecMutex mutex;
+  GumInterceptor * interceptor;
+};
+
+GumObjcDisposeClassPairMonitor *
+    gum_objc_dispose_class_pair_monitor_obtain (void);
+
+G_END_DECLS
+
+#endif

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
@@ -12,7 +12,7 @@
 G_BEGIN_DECLS
 
 #define GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR \
-  (gum_objc_dispose_class_pair_monitor_get_type ())
+    (gum_objc_dispose_class_pair_monitor_get_type ())
 G_DECLARE_FINAL_TYPE (GumObjcDisposeClassPairMonitor,
     gum_objc_dispose_class_pair_monitor, GUM, OBJC_DISPOSE_CLASS_PAIR_MONITOR,
     GObject)

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
@@ -7,7 +7,6 @@
 #ifndef __GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR_H__
 #define __GUM_OBJC_DISPOSE_CLASS_PAIR_MONITOR_H__
 
-#include <glib-object.h>
 #include <gum/guminterceptor.h>
 
 G_BEGIN_DECLS
@@ -15,8 +14,8 @@ G_BEGIN_DECLS
 #define GUM_TYPE_OBJC_DISPOSE_CLASS_PAIR_MONITOR \
   (gum_objc_dispose_class_pair_monitor_get_type ())
 G_DECLARE_FINAL_TYPE (GumObjcDisposeClassPairMonitor,
-    gum_objc_dispose_class_pair_monitor,
-    GUM, OBJC_DISPOSE_CLASS_PAIR_MONITOR, GObject)
+    gum_objc_dispose_class_pair_monitor, GUM, OBJC_DISPOSE_CLASS_PAIR_MONITOR,
+    GObject)
 
 struct _GumObjcDisposeClassPairMonitor
 {

--- a/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
+++ b/gum/backend-darwin/gumobjcdisposeclasspairmonitor.h
@@ -25,7 +25,7 @@ struct _GumObjcDisposeClassPairMonitor
   GumInterceptor * interceptor;
 };
 
-GumObjcDisposeClassPairMonitor *
+G_GNUC_INTERNAL GumObjcDisposeClassPairMonitor *
     gum_objc_dispose_class_pair_monitor_obtain (void);
 
 G_END_DECLS

--- a/gum/meson.build
+++ b/gum/meson.build
@@ -114,6 +114,8 @@ if host_os_family == 'darwin'
   gum_sources += [
     'backend-darwin/gumobjcapiresolver.c',
     'backend-darwin/gumobjcapiresolver.h',
+    'backend-darwin/gumobjcdisposeclasspairmonitor.c',
+    'backend-darwin/gumobjcdisposeclasspairmonitor.h',
     'backend-darwin/gumdarwinbacktracer.c',
     'backend-darwin/gumsymbolutil-darwin.c',
     'backend-darwin/gumdarwinsymbolicator.c',


### PR DESCRIPTION
`GumObjcDisposeClassPairMonitor` uses the `Interceptor` to attach to `objc_disposeClassPair` so that on enter it locks a mutex, releasing it on leave.

This mutex is then used to protect the creation of the initial snapshot of Objective-C classes, and a cache-less reimplementation of `gum_objc_api_resolver_find_method_by_address`.

The monitor instance is shared across all concurrent usages, via the "obtain" semantics.