### PR TITLE
Add CI and clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+AlignAfterOpenBracket: DontAlign
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+BreakBeforeBraces: Allman
+ColumnLimit: 80
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 2
+PointerAlignment: Middle
+SortIncludes: false
+SpaceAfterCStyleCast: true
+SpaceBeforeParens: Always
+UseTab: Never
+...

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+gum/dlmalloc.c
+gum/valgrind.h

--- a/.clang-format-include
+++ b/.clang-format-include
@@ -1,0 +1,5 @@
+bindings/**/*
+gum/**/*
+libs/**/*
+tests/**/*
+tools/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout frida-gum
+        uses: actions/checkout@v2
+      - name: Dependencies
+        run: >
+          sudo apt-get install -y \
+            build-essential \
+            clang-format-11 \
+            curl \
+            git \
+            gobject-introspection \
+            lib32stdc++-9-dev \
+            libc6-dev-i386 \
+            libdwarf-dev \
+            libelf-dev \
+            libgirepository1.0-dev \
+            libglib2.0-dev \
+            libjson-glib-dev \
+            libsoup2.4-dev \
+            libsqlite3-dev \
+            libunwind-dev \
+            ninja-build \
+            nodejs \
+            npm \
+            python3-dev \
+            python3-pip && \
+          pip3 install meson==0.60.2
+      - run: cd bindings/gumjs && npm i
+      - run: meson build
+      - run: ninja -C build clang-format-check
+      - run: ninja -C build


### PR DESCRIPTION
This CI will run on master commits or pull requests to master.

It adds a clang-format configuration, but does not format the codebase. You must run `ninja -C build clang-format` first, and then uncomment the `ninja -C build clang-format-check` line.

---

Future follow-up improvements:

* Put all apt-get dependencies in a Docker build image and run inside that container
* Use ccache and cache the build folder for fast incremental build times
* Run tests on CI (requires fixing broken tests on Ubuntu when not building with the monorepo toolchain)
* Upload artifacts to GitHub (e.g. GIR)
