### PR TITLE
stalker: Add backpatch query support

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -1208,6 +1208,18 @@ gum_stalker_prefetch_backpatch (GumStalker * self,
 {
 }
 
+gpointer
+gum_stalker_backpatch_get_from (const GumBackpatch * backpatch)
+{
+  return NULL;
+}
+
+gpointer
+gum_stalker_backpatch_get_to (const GumBackpatch * backpatch)
+{
+  return NULL;
+}
+
 void
 gum_stalker_invalidate (GumStalker * self,
                         gconstpointer address)

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -1636,6 +1636,18 @@ gum_stalker_prefetch_backpatch (GumStalker * self,
   }
 }
 
+gpointer
+gum_stalker_backpatch_get_from (const GumBackpatch * backpatch)
+{
+  return backpatch->from;
+}
+
+gpointer
+gum_stalker_backpatch_get_to (const GumBackpatch * backpatch)
+{
+  return backpatch->to;
+}
+
 void
 gum_stalker_invalidate (GumStalker * self,
                         gconstpointer address)

--- a/gum/backend-mips/gumstalker-mips.c
+++ b/gum/backend-mips/gumstalker-mips.c
@@ -136,6 +136,18 @@ gum_stalker_prefetch_backpatch (GumStalker * self,
 {
 }
 
+gpointer
+gum_stalker_backpatch_get_from (const GumBackpatch * backpatch)
+{
+  return NULL;
+}
+
+gpointer
+gum_stalker_backpatch_get_to (const GumBackpatch * backpatch)
+{
+  return NULL;
+}
+
 void
 gum_stalker_invalidate (GumStalker * self,
                         gconstpointer address)

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -1855,6 +1855,18 @@ gum_stalker_prefetch_backpatch (GumStalker * self,
   }
 }
 
+gpointer
+gum_stalker_backpatch_get_from (const GumBackpatch * backpatch)
+{
+  return backpatch->from;
+}
+
+gpointer
+gum_stalker_backpatch_get_to (const GumBackpatch * backpatch)
+{
+  return backpatch->to;
+}
+
 void
 gum_stalker_invalidate (GumStalker * self,
                         gconstpointer address)

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -193,6 +193,11 @@ GUM_API void gum_stalker_prefetch (GumStalker * self, gconstpointer address,
 GUM_API void gum_stalker_prefetch_backpatch (GumStalker * self,
     const GumBackpatch * notification);
 
+GUM_API gpointer gum_stalker_backpatch_get_from (
+    const GumBackpatch * backpatch);
+GUM_API gpointer gum_stalker_backpatch_get_to (
+    const GumBackpatch * backpatch);
+
 GUM_API void gum_stalker_invalidate (GumStalker * self, gconstpointer address);
 GUM_API void gum_stalker_invalidate_for_thread (GumStalker * self,
     GumThreadId thread_id, gconstpointer address);


### PR DESCRIPTION
Expose some information about backpatch prefetches so that the caller can determine whether they relate to blocks which are present in its address space.