### PR TITLE
gumjs: Add Process.operatingSystem

### DIFF
--- a/bindings/gumjs/gumquickprocess.c
+++ b/bindings/gumjs/gumquickprocess.c
@@ -38,6 +38,22 @@
 # define GUM_SCRIPT_PLATFORM "qnx"
 #endif
 
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+# define GUM_SCRIPT_OS "linux"
+#elif defined (HAVE_ANDROID)
+# define GUM_SCRIPT_OS "android"
+#elif defined (HAVE_MACOS)
+# define GUM_SCRIPT_OS "macos"
+#elif defined (HAVE_IOS)
+# define GUM_SCRIPT_OS "ios"
+#elif defined (HAVE_WINDOWS)
+# define GUM_SCRIPT_OS "windows"
+#elif defined (HAVE_FREEBSD)
+# define GUM_SCRIPT_OS "freebsd"
+#elif defined (HAVE_QNX)
+# define GUM_SCRIPT_OS "qnx"
+#endif
+
 typedef struct _GumQuickMatchContext GumQuickMatchContext;
 typedef struct _GumQuickFindModuleByNameContext GumQuickFindModuleByNameContext;
 typedef struct _GumQuickFindRangeByAddressContext
@@ -113,6 +129,7 @@ static const JSCFunctionListEntry gumjs_process_entries[] =
 {
   JS_PROP_STRING_DEF ("arch", GUM_SCRIPT_ARCH, JS_PROP_C_W_E),
   JS_PROP_STRING_DEF ("platform", GUM_SCRIPT_PLATFORM, JS_PROP_C_W_E),
+  JS_PROP_STRING_DEF ("operatingSystem", GUM_SCRIPT_OS, JS_PROP_C_W_E),
   JS_PROP_INT32_DEF ("pointerSize", GLIB_SIZEOF_VOID_P, JS_PROP_C_W_E),
   JS_CFUNC_DEF ("getCurrentDir", 0, gumjs_process_get_current_dir),
   JS_CFUNC_DEF ("getHomeDir", 0, gumjs_process_get_home_dir),

--- a/bindings/gumjs/gumv8process.cpp
+++ b/bindings/gumjs/gumv8process.cpp
@@ -44,6 +44,22 @@
 # define GUM_SCRIPT_PLATFORM "qnx"
 #endif
 
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+# define GUM_SCRIPT_OS "linux"
+#elif defined (HAVE_ANDROID)
+# define GUM_SCRIPT_OS "android"
+#elif defined (HAVE_MACOS)
+# define GUM_SCRIPT_OS "macos"
+#elif defined (HAVE_IOS)
+# define GUM_SCRIPT_OS "ios"
+#elif defined (HAVE_WINDOWS)
+# define GUM_SCRIPT_OS "windows"
+#elif defined (HAVE_FREEBSD)
+# define GUM_SCRIPT_OS "freebsd"
+#elif defined (HAVE_QNX)
+# define GUM_SCRIPT_OS "qnx"
+#endif
+
 using namespace v8;
 
 struct GumV8ExceptionHandler
@@ -129,6 +145,8 @@ _gum_v8_process_init (GumV8Process * self,
       String::NewFromUtf8Literal (isolate, GUM_SCRIPT_ARCH), ReadOnly);
   process->Set (_gum_v8_string_new_ascii (isolate, "platform"),
       String::NewFromUtf8Literal (isolate, GUM_SCRIPT_PLATFORM), ReadOnly);
+  process->Set (_gum_v8_string_new_ascii (isolate, "operatingSystem"),
+      String::NewFromUtf8Literal (isolate, GUM_SCRIPT_OS), ReadOnly);
   process->Set (_gum_v8_string_new_ascii (isolate, "pageSize"),
       Number::New (isolate, gum_query_page_size ()), ReadOnly);
   process->Set (_gum_v8_string_new_ascii (isolate, "pointerSize"),


### PR DESCRIPTION
Hi!
So there was a need to add a property (next to `Process.platform`) to determine the operating system (#192).

I added a (unneeded?) macro `GUM_SCRIPT_OS` which is pretty similar to this [one](https://github.com/frida/frida-gum/blob/4233137e80bc60cb00a0623201273f04f2d9e29c/tests/core/interceptor-fixture.c#L39). The alternative consisted in using the already existing [gum_process_get_native_os](https://github.com/frida/frida-gum/blob/4233137e80bc60cb00a0623201273f04f2d9e29c/gum/gumprocess.c#L46) and then retrieve a string from it, but it didn't look as simple as the macro solution.

Two doubts:

1) Should I have added a default case? (e.g. `"unknown"`)
2) Should I have handled darwin-based operating system which aren't MacOs nor iOS? (`defined (HAVE_DARWIN) && !defined (HAVE_MACOS) && !defined (HAVE_IOS)`)

Cheers