### PR TITLE
gumjs: add quick cmd support

### DIFF
--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -1,6 +1,7 @@
 const Console = require('./console');
 const hexdump = require('./hexdump');
 const MessageDispatcher = require('./message-dispatcher');
+const REPL = require('./repl');
 
 const engine = global;
 let messageDispatcher;
@@ -105,6 +106,10 @@ Object.defineProperties(engine, {
   hexdump: {
     enumerable: true,
     value: hexdump
+  },
+  REPL: {
+    enumerable: true,
+    value: new REPL()
   },
   ObjC: {
     enumerable: true,

--- a/bindings/gumjs/runtime/repl.js
+++ b/bindings/gumjs/runtime/repl.js
@@ -1,0 +1,35 @@
+class REPL {
+  //interface CmdFuncInfo = {
+  //  min_args_cnt: number,
+  //  func: (...args: string[]) => void,
+  //}
+  #cmdDispatcher;
+
+  constructor() {
+    this.#cmdDispatcher = new Map();
+  }
+
+  _doQuickCmd(s) {
+    const args = JSON.parse(decodeURIComponent(s));
+    const cmd = args[0];
+    const func_info = this.#cmdDispatcher.get(cmd)
+    if (func_info !== undefined) {
+      if (args.length - 1 < func_info.min_args_cnt) {
+        throw Error(`${cmd} need at least ${func_info.min_args_cnt} args`);
+      }
+      func_info.func(...args.slice(1));
+    } else {
+      throw Error(`Unknown command ${cmd}`);
+    }
+  }
+
+  setQuickCmd(cmd, min_args_cnt, func) {
+    this.#cmdDispatcher.set(cmd, { min_args_cnt, func });
+  }
+
+  unsetQuickCmd(cmd) {
+    this.#cmdDispatcher.delete(cmd);
+  }
+}
+
+module.exports = REPL;

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -375,6 +375,10 @@ TESTLIST_BEGIN (script)
     TESTENTRY (match_pattern_can_be_constructed_from_string)
   TESTGROUP_END ()
 
+  TESTGROUP_BEGIN ("REPL")
+    TESTENTRY (REPL_can_set_quick_cmd_and_run)
+  TESTGROUP_END ()
+
   TESTGROUP_BEGIN ("Stalker")
 #if defined (HAVE_I386) || defined (HAVE_ARM) || defined (HAVE_ARM64)
     TESTENTRY (execution_can_be_traced)
@@ -3199,6 +3203,35 @@ TESTCASE (match_pattern_can_be_constructed_from_string)
   COMPILE_AND_LOAD_SCRIPT ("new MatchPattern('Some bad pattern');");
   EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: invalid match pattern");
 }
+
+TESTCASE (REPL_can_set_quick_cmd_and_run)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "REPL.setQuickCmd('square', 1, v => send(v*v));"
+
+      "const okCmd1 = ['square', 3];"
+      "REPL._doQuickCmd(encodeURIComponent(JSON.stringify(okCmd1)));"
+
+      "try {"
+          "const errCmd1 = ['square'];"
+          "REPL._doQuickCmd(encodeURIComponent(JSON.stringify(errCmd1)));"
+      "} catch(e) {"
+          "send('arg cnt err');"
+      "}"
+
+      "try {"
+          "const errCmd2 = ['squar'];"
+          "REPL._doQuickCmd(encodeURIComponent(JSON.stringify(errCmd2)));"
+      "} catch(e) {"
+          "send('cmd err');"
+      "}"
+
+  );
+  EXPECT_SEND_MESSAGE_WITH ("9");
+  EXPECT_SEND_MESSAGE_WITH ("\"arg cnt err\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"cmd err\"");
+}
+
 
 TESTCASE (socket_connection_can_be_established)
 {


### PR DESCRIPTION
The feature "quick command" in frida REPL, like:

```
[Local::a.exe ]-> .d 401000 10
           0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0123456789ABCDEF
00401000  55 8b ec 81 c4 fc fe ff ff 8b 45 0c 83 f8 01 75  U.........E....u
```

The quick cmd starts with '.' (same as nodejs REPL), and can be customized dynamically by the javascript loaded.

For example, register a new quick cmd 'u' in `agent.js` :

```js
REPL.register_quick_cmd(
    'u', // the quick cmd
    1, // at least 1 argument
    function disasm(addr, inst_cnt = 10) { ... } // target function
)
```

Which can be used in REPL:

```
[Local::a.exe ]-> .u 401000
00401000    push ebp
00401001    mov ebp, esp
00401003    add esp, 0xfffffefc
00401009    mov eax, dword ptr [ebp + 0xc]
0040100C    cmp eax, 1
0040100F    jne 0x401028
00401011    push dword ptr [0x403864]
00401017    push 1
00401019    push 0x466
0040101E    push dword ptr [ebp + 8]
```