### PR TITLE
gumjs: Extend the `File` API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           script: |
             gtar -C build/tests -czf /tmp/runner.tar.gz gum-tests data/
             adb push /tmp/runner.tar.gz /data/local/tmp/
-            adb shell "su root sh -c 'set -ex; cd /data/local/tmp; tar xf runner.tar.gz; ./gum-tests'"
+            adb shell "su root sh -c 'set -ex; cd /data/local/tmp; tar xf runner.tar.gz; TMPDIR=/data/local/tmp ./gum-tests'"
 
   android-arm:
     runs-on: ubuntu-latest

--- a/bindings/gumjs/gumquickfile.c
+++ b/bindings/gumjs/gumquickfile.c
@@ -18,8 +18,18 @@ struct _GumFile
   FILE * handle;
 };
 
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_all_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_all_text)
+GUMJS_DECLARE_FUNCTION (gumjs_file_write_all_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_write_all_text)
+
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_file_construct)
 GUMJS_DECLARE_FINALIZER (gumjs_file_finalize)
+GUMJS_DECLARE_FUNCTION (gumjs_file_tell)
+GUMJS_DECLARE_FUNCTION (gumjs_file_seek)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_text)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_line)
 GUMJS_DECLARE_FUNCTION (gumjs_file_write)
 GUMJS_DECLARE_FUNCTION (gumjs_file_flush)
 GUMJS_DECLARE_FUNCTION (gumjs_file_close)
@@ -27,6 +37,9 @@ GUMJS_DECLARE_FUNCTION (gumjs_file_close)
 static GumFile * gum_file_new (FILE * handle);
 static void gum_file_free (GumFile * self);
 static void gum_file_close (GumFile * self);
+static gsize gum_file_query_num_bytes_available (GumFile * self);
+static gboolean gum_file_set_contents (const gchar * filename,
+    const gchar * contents, gssize length, GError ** error);
 
 static const JSClassDef gumjs_file_def =
 {
@@ -34,8 +47,25 @@ static const JSClassDef gumjs_file_def =
   .finalizer = gumjs_file_finalize,
 };
 
+static const JSCFunctionListEntry gumjs_file_module_entries[] =
+{
+  JS_PROP_INT32_DEF ("SEEK_SET", SEEK_SET, JS_PROP_C_W_E),
+  JS_PROP_INT32_DEF ("SEEK_CUR", SEEK_CUR, JS_PROP_C_W_E),
+  JS_PROP_INT32_DEF ("SEEK_END", SEEK_END, JS_PROP_C_W_E),
+
+  JS_CFUNC_DEF ("readAllBytes", 0, gumjs_file_read_all_bytes),
+  JS_CFUNC_DEF ("readAllText", 0, gumjs_file_read_all_text),
+  JS_CFUNC_DEF ("writeAllBytes", 0, gumjs_file_write_all_bytes),
+  JS_CFUNC_DEF ("writeAllText", 0, gumjs_file_write_all_text),
+};
+
 static const JSCFunctionListEntry gumjs_file_entries[] =
 {
+  JS_CFUNC_DEF ("tell", 0, gumjs_file_tell),
+  JS_CFUNC_DEF ("seek", 0, gumjs_file_seek),
+  JS_CFUNC_DEF ("readBytes", 0, gumjs_file_read_bytes),
+  JS_CFUNC_DEF ("readText", 0, gumjs_file_read_text),
+  JS_CFUNC_DEF ("readLine", 0, gumjs_file_read_line),
   JS_CFUNC_DEF ("write", 0, gumjs_file_write),
   JS_CFUNC_DEF ("flush", 0, gumjs_file_flush),
   JS_CFUNC_DEF ("close", 0, gumjs_file_close),
@@ -58,6 +88,8 @@ _gum_quick_file_init (GumQuickFile * self,
   ctor = JS_NewCFunction2 (ctx, gumjs_file_construct,
       gumjs_file_def.class_name, 0, JS_CFUNC_constructor, 0);
   JS_SetConstructor (ctx, ctor, proto);
+  JS_SetPropertyFunctionList (ctx, ctor, gumjs_file_module_entries,
+      G_N_ELEMENTS (gumjs_file_module_entries));
   JS_SetPropertyFunctionList (ctx, proto, gumjs_file_entries,
       G_N_ELEMENTS (gumjs_file_entries));
   JS_DefinePropertyValueStr (ctx, ns, gumjs_file_def.class_name, ctor,
@@ -78,6 +110,122 @@ static GumQuickFile *
 gumjs_get_parent_module (GumQuickCore * core)
 {
   return _gum_quick_core_load_module_data (core, "file");
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_all_bytes)
+{
+  const gchar * filename;
+  gchar * contents;
+  gsize length;
+  GError * error;
+
+  if (!_gum_quick_args_parse (args, "s", &filename))
+    return JS_EXCEPTION;
+
+  error = NULL;
+  if (!g_file_get_contents (filename, &contents, &length, &error))
+    goto propagate_error;
+
+  return JS_NewArrayBuffer (ctx, (uint8_t *) contents, length,
+      _gum_quick_array_buffer_free, contents, FALSE);
+
+propagate_error:
+  {
+    _gum_quick_throw_literal (ctx, error->message);
+    g_error_free (error);
+
+    return JS_EXCEPTION;
+  }
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_all_text)
+{
+  JSValue result;
+  const gchar * filename;
+  gchar * contents;
+  gsize length;
+  GError * error;
+  const gchar * end;
+
+  if (!_gum_quick_args_parse (args, "s", &filename))
+    return JS_EXCEPTION;
+
+  error = NULL;
+  if (!g_file_get_contents (filename, &contents, &length, &error))
+    goto propagate_error;
+
+  if (g_utf8_validate (contents, length, &end))
+  {
+    result = JS_NewStringLen (ctx, contents, length);
+  }
+  else
+  {
+    result = _gum_quick_throw (ctx, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - contents));
+  }
+
+  g_free (contents);
+
+  return result;
+
+propagate_error:
+  {
+    _gum_quick_throw_literal (ctx, error->message);
+    g_error_free (error);
+
+    return JS_EXCEPTION;
+  }
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_write_all_bytes)
+{
+  const gchar * filename;
+  GBytes * bytes;
+  gconstpointer data;
+  gsize size;
+  GError * error;
+
+  if (!_gum_quick_args_parse (args, "sB", &filename, &bytes))
+    return JS_EXCEPTION;
+
+  data = g_bytes_get_data (bytes, &size);
+
+  error = NULL;
+  if (!gum_file_set_contents (filename, data, size, &error))
+    goto propagate_error;
+
+  return JS_UNDEFINED;
+
+propagate_error:
+  {
+    _gum_quick_throw_literal (ctx, error->message);
+    g_error_free (error);
+
+    return JS_EXCEPTION;
+  }
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_write_all_text)
+{
+  const gchar * filename, * text;
+  GError * error;
+
+  if (!_gum_quick_args_parse (args, "ss", &filename, &text))
+    return JS_EXCEPTION;
+
+  error = NULL;
+  if (!gum_file_set_contents (filename, text, -1, &error))
+    goto propagate_error;
+
+  return JS_UNDEFINED;
+
+propagate_error:
+  {
+    _gum_quick_throw_literal (ctx, error->message);
+    g_error_free (error);
+
+    return JS_EXCEPTION;
+  }
 }
 
 static gboolean
@@ -133,7 +281,7 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_file_construct)
 
 fopen_failed:
   {
-    _gum_quick_throw (ctx, "failed to open file (%s)", g_strerror (errno));
+    _gum_quick_throw_literal (ctx, g_strerror (errno));
     goto propagate_exception;
   }
 propagate_exception:
@@ -153,6 +301,176 @@ GUMJS_DEFINE_FINALIZER (gumjs_file_finalize)
     return;
 
   gum_file_free (f);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_tell)
+{
+  GumFile * self;
+
+  if (!gum_file_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  return JS_NewInt64 (ctx, ftell (self->handle));
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_seek)
+{
+  GumFile * self;
+  gssize offset;
+  gint whence;
+  int result;
+
+  if (!gum_file_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  whence = SEEK_SET;
+  if (!_gum_quick_args_parse (args, "z|i", &offset, &whence))
+    return JS_EXCEPTION;
+
+  result = fseek (self->handle, offset, whence);
+  if (result == -1)
+    goto seek_failed;
+
+  return JS_NewInt64 (ctx, result);
+
+seek_failed:
+  {
+    return _gum_quick_throw_literal (ctx, strerror (errno));
+  }
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_bytes)
+{
+  JSValue result;
+  GumFile * self;
+  gsize n;
+  gpointer data;
+  size_t num_bytes_read;
+
+  if (!gum_file_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  n = G_MAXSIZE;
+  if (!_gum_quick_args_parse (args, "|Z", &n))
+    return JS_EXCEPTION;
+
+  if (n == G_MAXSIZE)
+    n = gum_file_query_num_bytes_available (self);
+
+  if (n == 0)
+    return JS_NewArrayBufferCopy (ctx, NULL, 0);
+
+  data = g_malloc (n);
+  result = JS_NewArrayBuffer (ctx, data, n, _gum_quick_array_buffer_free, data,
+      FALSE);
+
+  num_bytes_read = fread (data, 1, n, self->handle);
+
+  if (num_bytes_read < n)
+  {
+    JSValue r;
+
+    r = JS_NewArrayBufferCopy (ctx, data, num_bytes_read);
+    JS_FreeValue (ctx, result);
+    result = r;
+  }
+
+  return result;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_text)
+{
+  JSValue result;
+  GumFile * self;
+  gsize n;
+  gchar * data;
+  size_t num_bytes_read;
+  const gchar * end;
+
+  if (!gum_file_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  n = G_MAXSIZE;
+  if (!_gum_quick_args_parse (args, "|Z", &n))
+    return JS_EXCEPTION;
+
+  if (n == G_MAXSIZE)
+    n = gum_file_query_num_bytes_available (self);
+
+  if (n == 0)
+    return JS_NewString (ctx, "");
+
+  data = g_malloc (n);
+  num_bytes_read = fread (data, 1, n, self->handle);
+
+  if (g_utf8_validate (data, num_bytes_read, &end))
+  {
+    result = JS_NewStringLen (ctx, data, num_bytes_read);
+  }
+  else
+  {
+    result = _gum_quick_throw (ctx, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - data));
+
+    fseek (self->handle, -((long) num_bytes_read), SEEK_CUR);
+  }
+
+  g_free (data);
+
+  return result;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_line)
+{
+  JSValue result;
+  GumFile * self;
+  gsize offset, capacity;
+  GString * buffer;
+  const gchar * end;
+
+  if (!gum_file_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  offset = 0;
+  capacity = 256;
+  buffer = g_string_sized_new (capacity);
+  while (TRUE)
+  {
+    gsize num_bytes_read;
+
+    g_string_set_size (buffer, capacity);
+
+    if (fgets (buffer->str + offset, capacity - offset, self->handle) == NULL)
+      break;
+
+    num_bytes_read = strlen (buffer->str + offset);
+    offset += num_bytes_read;
+
+    if (buffer->str[offset - 1] == '\n')
+      break;
+
+    if (offset == capacity - 1)
+      capacity += 256;
+    else
+      break;
+  }
+  g_string_set_size (buffer, offset);
+
+  if (g_utf8_validate (buffer->str, buffer->len, &end))
+  {
+    result = JS_NewStringLen (ctx, buffer->str, buffer->len);
+  }
+  else
+  {
+    result = _gum_quick_throw (ctx, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - buffer->str));
+
+    fseek (self->handle, -((long) buffer->len), SEEK_CUR);
+  }
+
+  g_string_free (buffer, TRUE);
+
+  return result;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_file_write)
@@ -221,4 +539,34 @@ static void
 gum_file_close (GumFile * self)
 {
   g_clear_pointer (&self->handle, fclose);
+}
+
+static gsize
+gum_file_query_num_bytes_available (GumFile * self)
+{
+  FILE * handle = self->handle;
+  long offset, size;
+
+  offset = ftell (handle);
+
+  fseek (handle, 0, SEEK_END);
+  size = ftell (handle);
+
+  fseek (handle, offset, SEEK_SET);
+
+  return size - offset;
+}
+
+static gboolean
+gum_file_set_contents (const gchar * filename,
+                       const gchar * contents,
+                       gssize length,
+                       GError ** error)
+{
+#if GLIB_CHECK_VERSION (2, 66, 0)
+  return g_file_set_contents_full (filename, contents, length,
+      G_FILE_SET_CONTENTS_NONE, 0666, error);
+#else
+  return g_file_set_contents (filename, contents, length, error);
+#endif
 }

--- a/bindings/gumjs/gumv8file.cpp
+++ b/bindings/gumjs/gumv8file.cpp
@@ -22,7 +22,17 @@ struct GumFile
   GumV8File * module;
 };
 
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_all_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_all_text)
+GUMJS_DECLARE_FUNCTION (gumjs_file_write_all_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_write_all_text)
+
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_file_construct)
+GUMJS_DECLARE_FUNCTION (gumjs_file_tell)
+GUMJS_DECLARE_FUNCTION (gumjs_file_seek)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_bytes)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_text)
+GUMJS_DECLARE_FUNCTION (gumjs_file_read_line)
 GUMJS_DECLARE_FUNCTION (gumjs_file_write)
 GUMJS_DECLARE_FUNCTION (gumjs_file_flush)
 GUMJS_DECLARE_FUNCTION (gumjs_file_close)
@@ -32,10 +42,28 @@ static GumFile * gum_file_new (Local<Object> wrapper, FILE * handle,
 static void gum_file_free (GumFile * file);
 static gboolean gum_file_check_open (GumFile * self, Isolate * isolate);
 static void gum_file_close (GumFile * self);
+static gsize gum_file_query_num_bytes_available (GumFile * self);
+static gboolean gum_file_set_contents (const gchar * filename,
+    const gchar * contents, gssize length, GError ** error);
 static void gum_file_on_weak_notify (const WeakCallbackInfo<GumFile> & info);
+
+static const GumV8Function gumjs_file_module_functions[] =
+{
+  { "readAllBytes", gumjs_file_read_all_bytes },
+  { "readAllText", gumjs_file_read_all_text },
+  { "writeAllBytes", gumjs_file_write_all_bytes },
+  { "writeAllText", gumjs_file_write_all_text },
+
+  { NULL, NULL }
+};
 
 static const GumV8Function gumjs_file_functions[] =
 {
+  { "tell", gumjs_file_tell },
+  { "seek", gumjs_file_seek },
+  { "readBytes", gumjs_file_read_bytes },
+  { "readText", gumjs_file_read_text },
+  { "readLine", gumjs_file_read_line },
   { "write", gumjs_file_write },
   { "flush", gumjs_file_flush },
   { "close", gumjs_file_close },
@@ -56,6 +84,13 @@ _gum_v8_file_init (GumV8File * self,
 
   auto file = _gum_v8_create_class ("File", gumjs_file_construct, scope,
       module, isolate);
+  file->Set (_gum_v8_string_new_ascii (isolate, "SEEK_SET"),
+      Integer::New (isolate, SEEK_SET), ReadOnly);
+  file->Set (_gum_v8_string_new_ascii (isolate, "SEEK_CUR"),
+      Integer::New (isolate, SEEK_CUR), ReadOnly);
+  file->Set (_gum_v8_string_new_ascii (isolate, "SEEK_END"),
+      Integer::New (isolate, SEEK_END), ReadOnly);
+  _gum_v8_class_add_static (file, gumjs_file_module_functions, module, isolate);
   _gum_v8_class_add (file, gumjs_file_functions, module, isolate);
 }
 
@@ -78,6 +113,113 @@ _gum_v8_file_finalize (GumV8File * self)
 {
 }
 
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_all_bytes)
+{
+  gchar * filename;
+  if (!_gum_v8_args_parse (args, "s", &filename))
+    return;
+
+  gchar * contents;
+  gsize length;
+  GError * error = NULL;
+  gboolean success = g_file_get_contents (filename, &contents, &length, &error);
+
+  g_free (filename);
+
+  if (!success)
+  {
+    _gum_v8_throw_literal (isolate, error->message);
+    g_error_free (error);
+    return;
+  }
+
+  auto result = ArrayBuffer::New (isolate, length);
+  auto store = result.As<ArrayBuffer> ()->GetBackingStore ();
+  memcpy (store->Data (), contents, length);
+  info.GetReturnValue ().Set (result);
+
+  g_free (contents);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_read_all_text)
+{
+  gchar * filename;
+  if (!_gum_v8_args_parse (args, "s", &filename))
+    return;
+
+  gchar * contents;
+  gsize length;
+  GError * error = NULL;
+  gboolean success = g_file_get_contents (filename, &contents, &length, &error);
+
+  g_free (filename);
+
+  if (!success)
+  {
+    _gum_v8_throw_literal (isolate, error->message);
+    g_error_free (error);
+    return;
+  }
+
+  const gchar * end;
+  if (g_utf8_validate (contents, length, &end))
+  {
+    info.GetReturnValue ().Set (
+        String::NewFromUtf8 (isolate, contents, NewStringType::kNormal, length)
+        .ToLocalChecked ());
+  }
+  else
+  {
+    _gum_v8_throw (isolate, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - contents));
+  }
+
+  g_free (contents);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_write_all_bytes)
+{
+  gchar * filename;
+  GBytes * bytes;
+  if (!_gum_v8_args_parse (args, "sB", &filename, &bytes))
+    return;
+
+  gsize size;
+  gconstpointer data = g_bytes_get_data (bytes, &size);
+
+  GError * error = NULL;
+  gboolean success = gum_file_set_contents (filename, (const gchar *) data,
+      size, &error);
+
+  g_bytes_unref (bytes);
+  g_free (filename);
+
+  if (!success)
+  {
+    _gum_v8_throw_literal (isolate, error->message);
+    g_error_free (error);
+  }
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_file_write_all_text)
+{
+  gchar * filename, * text;
+  if (!_gum_v8_args_parse (args, "ss", &filename, &text))
+    return;
+
+  GError * error = NULL;
+  gboolean success = gum_file_set_contents (filename, text, -1, &error);
+
+  g_free (text);
+  g_free (filename);
+
+  if (!success)
+  {
+    _gum_v8_throw_literal (isolate, error->message);
+    g_error_free (error);
+  }
+}
+
 GUMJS_DEFINE_CONSTRUCTOR (gumjs_file_construct)
 {
   if (!info.IsConstructCall ())
@@ -98,12 +240,159 @@ GUMJS_DEFINE_CONSTRUCTOR (gumjs_file_construct)
 
   if (handle == NULL)
   {
-    _gum_v8_throw (isolate, "failed to open file (%s)", g_strerror (errno));
+    _gum_v8_throw_literal (isolate, g_strerror (errno));
     return;
   }
 
   auto file = gum_file_new (wrapper, handle, module);
   wrapper->SetAlignedPointerInInternalField (0, file);
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_file_tell, GumFile)
+{
+  if (!gum_file_check_open (self, isolate))
+    return;
+
+  info.GetReturnValue ().Set ((double) ftell (self->handle));
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_file_seek, GumFile)
+{
+  if (!gum_file_check_open (self, isolate))
+    return;
+
+  gssize offset;
+  gint whence = SEEK_SET;
+  if (!_gum_v8_args_parse (args, "z|i", &offset, &whence))
+    return;
+
+  int result = fseek (self->handle, offset, whence);
+  if (result == -1)
+  {
+    _gum_v8_throw_literal (isolate, strerror (errno));
+    return;
+  }
+
+  info.GetReturnValue ().Set (result);
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_file_read_bytes, GumFile)
+{
+  if (!gum_file_check_open (self, isolate))
+    return;
+
+  gsize n = G_MAXSIZE;
+  if (!_gum_v8_args_parse (args, "|Z", &n))
+    return;
+
+  if (n == G_MAXSIZE)
+    n = gum_file_query_num_bytes_available (self);
+
+  if (n == 0)
+  {
+    info.GetReturnValue ().Set (ArrayBuffer::New (isolate, 0));
+    return;
+  }
+
+  auto result = ArrayBuffer::New (isolate, n);
+  auto store = result.As<ArrayBuffer> ()->GetBackingStore ();
+
+  size_t num_bytes_read = fread (store->Data (), 1, n, self->handle);
+
+  if (num_bytes_read < n)
+  {
+    auto r = ArrayBuffer::New (isolate, num_bytes_read);
+    auto s = r.As<ArrayBuffer> ()->GetBackingStore ();
+    memcpy (s->Data (), store->Data (), num_bytes_read);
+    result = r;
+  }
+
+  info.GetReturnValue ().Set (result);
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_file_read_text, GumFile)
+{
+  if (!gum_file_check_open (self, isolate))
+    return;
+
+  gsize n = G_MAXSIZE;
+  if (!_gum_v8_args_parse (args, "|Z", &n))
+    return;
+
+  if (n == G_MAXSIZE)
+    n = gum_file_query_num_bytes_available (self);
+
+  if (n == 0)
+  {
+    info.GetReturnValue ().Set (ArrayBuffer::New (isolate, 0));
+    return;
+  }
+
+  gchar * data = (gchar *) g_malloc (n);
+  size_t num_bytes_read = fread (data, 1, n, self->handle);
+
+  const gchar * end;
+  if (g_utf8_validate (data, num_bytes_read, &end))
+  {
+    info.GetReturnValue ().Set (
+        String::NewFromUtf8 (isolate, data, NewStringType::kNormal,
+          (int) num_bytes_read).ToLocalChecked ());
+  }
+  else
+  {
+    _gum_v8_throw (isolate, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - data));
+
+    fseek (self->handle, -((long) num_bytes_read), SEEK_CUR);
+  }
+
+  g_free (data);
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_file_read_line, GumFile)
+{
+  if (!gum_file_check_open (self, isolate))
+    return;
+
+  gsize offset = 0;
+  gsize capacity = 256;
+  GString * buffer = g_string_sized_new (capacity);
+  while (TRUE)
+  {
+    g_string_set_size (buffer, capacity);
+
+    if (fgets (buffer->str + offset, capacity - offset, self->handle) == NULL)
+      break;
+
+    gsize num_bytes_read = strlen (buffer->str + offset);
+    offset += num_bytes_read;
+
+    if (buffer->str[offset - 1] == '\n')
+      break;
+
+    if (offset == capacity - 1)
+      capacity += 256;
+    else
+      break;
+  }
+  g_string_set_size (buffer, offset);
+
+  const gchar * end;
+  if (g_utf8_validate (buffer->str, buffer->len, &end))
+  {
+    info.GetReturnValue ().Set (
+        String::NewFromUtf8 (isolate, buffer->str, NewStringType::kNormal,
+          buffer->len).ToLocalChecked ());
+  }
+  else
+  {
+    _gum_v8_throw (isolate, "can't decode byte 0x%02x in position %u",
+        (guint8) *end, (guint) (end - buffer->str));
+
+    fseek (self->handle, -((long) buffer->len), SEEK_CUR);
+  }
+
+  g_string_free (buffer, TRUE);
 }
 
 GUMJS_DEFINE_CLASS_METHOD (gumjs_file_write, GumFile)
@@ -183,6 +472,35 @@ static void
 gum_file_close (GumFile * self)
 {
   g_clear_pointer (&self->handle, fclose);
+}
+
+static gsize
+gum_file_query_num_bytes_available (GumFile * self)
+{
+  FILE * handle = self->handle;
+
+  long offset = ftell (handle);
+
+  fseek (handle, 0, SEEK_END);
+  long size = ftell (handle);
+
+  fseek (handle, offset, SEEK_SET);
+
+  return size - offset;
+}
+
+static gboolean
+gum_file_set_contents (const gchar * filename,
+                       const gchar * contents,
+                       gssize length,
+                       GError ** error)
+{
+#if GLIB_CHECK_VERSION (2, 66, 0)
+  return g_file_set_contents_full (filename, contents, length,
+      G_FILE_SET_CONTENTS_NONE, 0666, error);
+#else
+  return g_file_set_contents (filename, contents, length, error);
+#endif
 }
 
 static void


### PR DESCRIPTION
Introducing some high-level static methods:
- readAllBytes(filePath: string): ArrayBuffer
- readAllText(filePath: string): string
- writeAllBytes(filePath: string, bytes: ArrayBuffer | number[]): void
- writeAllText(filePath: string, text: string): void

And some instance methods:
- tell(): number
- seek(offset: number, whence?: number): number
- readBytes(n?: number): ArrayBuffer
- readText(n?: number): string
- readLine(): string

With three new constants for `seek()`:
- File.SEEK_SET
- File.SEEK_CUR
- File.SEEK_END