### PR TITLE
gumjs: Move V8 backend to one Isolate per script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             -Doptimization=s \
             -Dgumpp=enabled \
             -Dgumjs=enabled \
+            --force-fallback-for=glib \
             build
           meson compile -C build
       - name: Test

--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -164,6 +164,12 @@ static void gum_quick_script_post (GumScript * script, const gchar * message,
 static void gum_quick_script_do_post (GumPostData * d);
 static void gum_quick_post_data_free (GumPostData * d);
 
+static void gum_quick_script_set_debug_message_handler (GumScript * backend,
+    GumScriptDebugMessageHandler handler, gpointer data,
+    GDestroyNotify data_destroy);
+static void gum_quick_script_post_debug_message (GumScript * backend,
+    const gchar * message);
+
 static GumStalker * gum_quick_script_get_stalker (GumScript * script);
 
 static void gum_quick_script_emit (GumQuickScript * self,
@@ -222,6 +228,9 @@ gum_quick_script_iface_init (gpointer g_iface,
 
   iface->set_message_handler = gum_quick_script_set_message_handler;
   iface->post = gum_quick_script_post;
+
+  iface->set_debug_message_handler = gum_quick_script_set_debug_message_handler;
+  iface->post_debug_message = gum_quick_script_post_debug_message;
 
   iface->get_stalker = gum_quick_script_get_stalker;
 }
@@ -778,6 +787,23 @@ gum_quick_post_data_free (GumPostData * d)
   g_slice_free (GumPostData, d);
 }
 
+static void
+gum_quick_script_set_debug_message_handler (
+    GumScript * backend,
+    GumScriptDebugMessageHandler handler,
+    gpointer data,
+    GDestroyNotify data_destroy)
+{
+  if (data_destroy != NULL)
+    data_destroy (data);
+}
+
+static void
+gum_quick_script_post_debug_message (GumScript * backend,
+                                     const gchar * message)
+{
+}
+
 static GumStalker *
 gum_quick_script_get_stalker (GumScript * script)
 {
@@ -815,10 +841,7 @@ gum_quick_script_do_emit (GumEmitData * d)
   GumQuickScript * self = d->script;
 
   if (self->message_handler != NULL)
-  {
-    self->message_handler (GUM_SCRIPT (self), d->message, d->data,
-        self->message_handler_data);
-  }
+    self->message_handler (d->message, d->data, self->message_handler_data);
 
   return FALSE;
 }

--- a/bindings/gumjs/gumquickscriptbackend.c
+++ b/bindings/gumjs/gumquickscriptbackend.c
@@ -115,12 +115,6 @@ static void gum_compile_script_task_run (GumScriptTask * task,
     GCancellable * cancellable);
 static void gum_compile_script_data_free (GumCompileScriptData * d);
 
-static void gum_quick_script_backend_set_debug_message_handler (
-    GumScriptBackend * backend, GumScriptBackendDebugMessageHandler handler,
-    gpointer data, GDestroyNotify data_destroy);
-static void gum_quick_script_backend_post_debug_message (
-    GumScriptBackend * backend, const gchar * message);
-
 static void gum_quick_script_backend_with_lock_held (GumScriptBackend * backend,
     GumScriptBackendLockedFunc func, gpointer user_data);
 static gboolean gum_quick_script_backend_is_locked (GumScriptBackend * backend);
@@ -174,10 +168,6 @@ gum_quick_script_backend_iface_init (gpointer g_iface,
   iface->compile = gum_quick_script_backend_compile;
   iface->compile_finish = gum_quick_script_backend_compile_finish;
   iface->compile_sync = gum_quick_script_backend_compile_sync;
-
-  iface->set_debug_message_handler =
-      gum_quick_script_backend_set_debug_message_handler;
-  iface->post_debug_message = gum_quick_script_backend_post_debug_message;
 
   iface->with_lock_held = gum_quick_script_backend_with_lock_held;
   iface->is_locked = gum_quick_script_backend_is_locked;
@@ -998,23 +988,6 @@ gum_compile_script_data_free (GumCompileScriptData * d)
   g_free (d->source);
 
   g_slice_free (GumCompileScriptData, d);
-}
-
-static void
-gum_quick_script_backend_set_debug_message_handler (
-    GumScriptBackend * backend,
-    GumScriptBackendDebugMessageHandler handler,
-    gpointer data,
-    GDestroyNotify data_destroy)
-{
-  if (data_destroy != NULL)
-    data_destroy (data);
-}
-
-static void
-gum_quick_script_backend_post_debug_message (GumScriptBackend * backend,
-                                             const gchar * message)
-{
 }
 
 static void

--- a/bindings/gumjs/gumscript.c
+++ b/bindings/gumjs/gumscript.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -75,6 +75,23 @@ gum_script_post (GumScript * self,
                  GBytes * data)
 {
   GUM_SCRIPT_GET_IFACE (self)->post (self, message, data);
+}
+
+void
+gum_script_set_debug_message_handler (GumScript * self,
+                                      GumScriptDebugMessageHandler handler,
+                                      gpointer data,
+                                      GDestroyNotify data_destroy)
+{
+  GUM_SCRIPT_GET_IFACE (self)->set_debug_message_handler (self, handler, data,
+      data_destroy);
+}
+
+void
+gum_script_post_debug_message (GumScript * self,
+                               const gchar * message)
+{
+  GUM_SCRIPT_GET_IFACE (self)->post_debug_message (self, message);
 }
 
 GumStalker *

--- a/bindings/gumjs/gumscript.h
+++ b/bindings/gumjs/gumscript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2010-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -16,8 +16,10 @@ G_BEGIN_DECLS
 #define GUM_TYPE_SCRIPT (gum_script_get_type ())
 G_DECLARE_INTERFACE (GumScript, gum_script, GUM, SCRIPT, GObject)
 
-typedef void (* GumScriptMessageHandler) (GumScript * script,
-    const gchar * message, GBytes * data, gpointer user_data);
+typedef void (* GumScriptMessageHandler) (const gchar * message, GBytes * data,
+    gpointer user_data);
+typedef void (* GumScriptDebugMessageHandler) (const gchar * message,
+    gpointer user_data);
 
 struct _GumScriptInterface
 {
@@ -36,6 +38,11 @@ struct _GumScriptInterface
       GumScriptMessageHandler handler, gpointer data,
       GDestroyNotify data_destroy);
   void (* post) (GumScript * self, const gchar * message, GBytes * data);
+
+  void (* set_debug_message_handler) (GumScript * self,
+      GumScriptDebugMessageHandler handler, gpointer data,
+      GDestroyNotify data_destroy);
+  void (* post_debug_message) (GumScript * self, const gchar * message);
 
   GumStalker * (* get_stalker) (GumScript * self);
 };
@@ -56,6 +63,12 @@ GUM_API void gum_script_set_message_handler (GumScript * self,
     GDestroyNotify data_destroy);
 GUM_API void gum_script_post (GumScript * self, const gchar * message,
     GBytes * data);
+
+GUM_API void gum_script_set_debug_message_handler (GumScript * self,
+    GumScriptDebugMessageHandler handler, gpointer data,
+    GDestroyNotify data_destroy);
+GUM_API void gum_script_post_debug_message (GumScript * self,
+    const gchar * message);
 
 GUM_API GumStalker * gum_script_get_stalker (GumScript * self);
 

--- a/bindings/gumjs/gumscriptbackend.c
+++ b/bindings/gumjs/gumscriptbackend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -231,24 +231,6 @@ gum_script_backend_compile_sync (GumScriptBackend * self,
 {
   return GUM_SCRIPT_BACKEND_GET_IFACE (self)->compile_sync (self, name, source,
       cancellable, error);
-}
-
-void
-gum_script_backend_set_debug_message_handler (
-    GumScriptBackend * self,
-    GumScriptBackendDebugMessageHandler handler,
-    gpointer data,
-    GDestroyNotify data_destroy)
-{
-  GUM_SCRIPT_BACKEND_GET_IFACE (self)->set_debug_message_handler (self, handler,
-      data, data_destroy);
-}
-
-void
-gum_script_backend_post_debug_message (GumScriptBackend * self,
-                                       const gchar * message)
-{
-  GUM_SCRIPT_BACKEND_GET_IFACE (self)->post_debug_message (self, message);
 }
 
 void

--- a/bindings/gumjs/gumscriptbackend.h
+++ b/bindings/gumjs/gumscriptbackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2010-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -18,8 +18,6 @@ G_BEGIN_DECLS
 G_DECLARE_INTERFACE (GumScriptBackend, gum_script_backend, GUM, SCRIPT_BACKEND,
     GObject)
 
-typedef void (* GumScriptBackendDebugMessageHandler) (const gchar * message,
-    gpointer user_data);
 typedef void (* GumScriptBackendLockedFunc) (gpointer user_data);
 
 struct _GumScriptBackendInterface
@@ -49,11 +47,6 @@ struct _GumScriptBackendInterface
       GError ** error);
   GBytes * (* compile_sync) (GumScriptBackend * self, const gchar * name,
       const gchar * source, GCancellable * cancellable, GError ** error);
-
-  void (* set_debug_message_handler) (GumScriptBackend * self,
-      GumScriptBackendDebugMessageHandler handler, gpointer data,
-      GDestroyNotify data_destroy);
-  void (* post_debug_message) (GumScriptBackend * self, const gchar * message);
 
   void (* with_lock_held) (GumScriptBackend * self,
       GumScriptBackendLockedFunc func, gpointer user_data);
@@ -89,12 +82,6 @@ GUM_API GBytes * gum_script_backend_compile_finish (GumScriptBackend * self,
 GUM_API GBytes * gum_script_backend_compile_sync (GumScriptBackend * self,
     const gchar * name, const gchar * source, GCancellable * cancellable,
     GError ** error);
-
-GUM_API void gum_script_backend_set_debug_message_handler (
-    GumScriptBackend * self, GumScriptBackendDebugMessageHandler handler,
-    gpointer data, GDestroyNotify data_destroy);
-GUM_API void gum_script_backend_post_debug_message (GumScriptBackend * self,
-    const gchar * message);
 
 GUM_API void gum_script_backend_with_lock_held (GumScriptBackend * self,
     GumScriptBackendLockedFunc func, gpointer user_data);

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -16,6 +16,15 @@
 #include "gumv8macros.h"
 #include "gumv8scope.h"
 #include "gumv8script-priv.h"
+#ifdef HAVE_OBJC_BRIDGE
+# include "gumv8script-objc.h"
+#endif
+#ifdef HAVE_SWIFT_BRIDGE
+# include "gumv8script-swift.h"
+#endif
+#ifdef HAVE_JAVA_BRIDGE
+# include "gumv8script-java.h"
+#endif
 
 #ifdef _MSC_VER
 # include <intrin.h>
@@ -1638,10 +1647,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_frida_objc_load)
   bool loaded = false;
 
 #ifdef HAVE_OBJC_BRIDGE
-  auto platform = (GumV8Platform *) gum_v8_script_backend_get_platform (
-      core->script->backend);
-
-  gum_v8_bundle_run (platform->GetObjCBundle ());
+  auto bundle = gum_v8_bundle_new (isolate, gumjs_objc_modules);
+  gum_v8_bundle_run (bundle);
+  gum_v8_bundle_free (bundle);
 
   loaded = true;
 #endif
@@ -1654,10 +1662,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_frida_swift_load)
   bool loaded = false;
 
 #ifdef HAVE_SWIFT_BRIDGE
-  auto platform = (GumV8Platform *) gum_v8_script_backend_get_platform (
-      core->script->backend);
-
-  gum_v8_bundle_run (platform->GetSwiftBundle ());
+  auto bundle = gum_v8_bundle_new (isolate, gumjs_swift_modules);
+  gum_v8_bundle_run (bundle);
+  gum_v8_bundle_free (bundle);
 
   loaded = true;
 #endif
@@ -1670,10 +1677,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_frida_java_load)
   bool loaded = false;
 
 #ifdef HAVE_JAVA_BRIDGE
-  auto platform = (GumV8Platform *) gum_v8_script_backend_get_platform (
-      core->script->backend);
-
-  gum_v8_bundle_run (platform->GetJavaBundle ());
+  auto bundle = gum_v8_bundle_new (isolate, gumjs_java_modules);
+  gum_v8_bundle_run (bundle);
+  gum_v8_bundle_free (bundle);
 
   loaded = true;
 #endif
@@ -1737,9 +1743,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_script_find_source_map)
     }
     else
     {
-      auto platform = (GumV8Platform *) gum_v8_script_backend_get_platform (
-          core->script->backend);
-
       if (strcmp (name, "/_frida.js") == 0)
       {
         json = core->runtime_source_map;
@@ -1747,19 +1750,19 @@ GUMJS_DEFINE_FUNCTION (gumjs_script_find_source_map)
 #ifdef HAVE_OBJC_BRIDGE
       else if (strcmp (name, "/_objc.js") == 0)
       {
-        json = platform->GetObjCSourceMap ();
+        json = gumjs_objc_source_map;
       }
 #endif
 #ifdef HAVE_SWIFT_BRIDGE
       else if (strcmp (name, "/_swift.js") == 0)
       {
-        json = platform->GetSwiftSourceMap ();
+        json = gumjs_swift_source_map;
       }
 #endif
 #ifdef HAVE_JAVA_BRIDGE
       else if (strcmp (name, "/_java.js") == 0)
       {
-        json = platform->GetJavaSourceMap ();
+        json = gumjs_java_source_map;
       }
 #endif
     }

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -9,11 +9,16 @@
 
 #include "gumscripttask.h"
 #include "gumv8script-priv.h"
+#include "gumv8script-runtime.h"
 #include "gumv8value.h"
 
 #include <cstring>
 
+#define GUM_V8_INSPECTOR_LOCK(o) g_mutex_lock (&(o)->inspector_mutex)
+#define GUM_V8_INSPECTOR_UNLOCK(o) g_mutex_unlock (&(o)->inspector_mutex)
+
 using namespace v8;
+using namespace v8_inspector;
 
 typedef void (* GumUnloadNotifyFunc) (GumV8Script * self, gpointer user_data);
 
@@ -33,20 +38,18 @@ enum
   PROP_BACKEND
 };
 
-enum _GumScriptState
-{
-  GUM_SCRIPT_STATE_CREATED,
-  GUM_SCRIPT_STATE_LOADING,
-  GUM_SCRIPT_STATE_LOADED,
-  GUM_SCRIPT_STATE_UNLOADING,
-  GUM_SCRIPT_STATE_UNLOADED
-};
-
 struct GumUnloadNotifyCallback
 {
   GumUnloadNotifyFunc func;
   gpointer data;
   GDestroyNotify data_destroy;
+};
+
+struct GumPostData
+{
+  GumV8Script * script;
+  gchar * message;
+  GBytes * data;
 };
 
 struct GumEmitData
@@ -56,11 +59,50 @@ struct GumEmitData
   GBytes * data;
 };
 
-struct GumPostData
+struct GumEmitDebugMessageData
 {
   GumV8Script * script;
   gchar * message;
-  GBytes * data;
+};
+
+class GumInspectorClient : public V8InspectorClient
+{
+public:
+  GumInspectorClient (GumV8Script * script);
+
+  void runMessageLoopOnPause (int context_group_id) override;
+  void quitMessageLoopOnPause () override;
+
+  Local<Context> ensureDefaultContextInGroup (int contextGroupId) override;
+
+  double currentTimeMS () override;
+
+private:
+  void startSkippingAllPauses ();
+
+  GumV8Script * script;
+};
+
+class GumInspectorChannel : public V8Inspector::Channel
+{
+public:
+  GumInspectorChannel (GumV8Script * script, guint id);
+
+  void takeSession (std::unique_ptr<V8InspectorSession> session);
+  void dispatchStanza (const char * stanza);
+  void startSkippingAllPauses ();
+
+  void sendResponse (int call_id,
+      std::unique_ptr<StringBuffer> message) override;
+  void sendNotification (std::unique_ptr<StringBuffer> message) override;
+  void flushProtocolNotifications () override;
+
+private:
+  void emitStanza (std::unique_ptr<StringBuffer> stanza);
+
+  GumV8Script * script;
+  guint id;
+  std::unique_ptr<V8InspectorSession> inspector_session;
 };
 
 static void gum_v8_script_iface_init (gpointer g_iface, gpointer iface_data);
@@ -117,12 +159,38 @@ static void gum_v8_script_post (GumScript * script, const gchar * message,
 static void gum_v8_script_do_post (GumPostData * d);
 static void gum_v8_post_data_free (GumPostData * d);
 
-static GumStalker * gum_v8_script_get_stalker (GumScript * script);
-
 static void gum_v8_script_emit (GumV8Script * self, const gchar * message,
     GBytes * data);
 static gboolean gum_v8_script_do_emit (GumEmitData * d);
 static void gum_v8_emit_data_free (GumEmitData * d);
+
+static void gum_v8_script_set_debug_message_handler (GumScript * backend,
+    GumScriptDebugMessageHandler handler, gpointer data,
+    GDestroyNotify data_destroy);
+static void gum_v8_script_post_debug_message (GumScript * backend,
+    const gchar * message);
+static void gum_v8_script_process_queued_debug_messages (GumV8Script * self);
+static void gum_v8_script_process_queued_debug_messages_unlocked (
+    GumV8Script * self);
+static void gum_v8_script_drop_queued_debug_messages_unlocked (
+    GumV8Script * self);
+static void gum_v8_script_process_debug_message (GumV8Script * self,
+    const gchar * message);
+static gboolean gum_v8_script_do_emit_debug_message (
+    GumEmitDebugMessageData * d);
+static void gum_emit_debug_message_data_free (GumEmitDebugMessageData * d);
+static void gum_v8_script_clear_inspector_channels (GumV8Script * self);
+static void gum_v8_script_connect_inspector_channel (GumV8Script * self,
+    guint id);
+static void gum_v8_script_disconnect_inspector_channel (GumV8Script * self,
+    guint id);
+static void gum_v8_script_dispatch_inspector_stanza (GumV8Script * self,
+    guint channel_id, const gchar * stanza);
+
+static GumStalker * gum_v8_script_get_stalker (GumScript * script);
+
+static void gum_v8_script_on_fatal_error (const char * location,
+    const char * message);
 
 static GumESProgram * gum_es_program_new (void);
 static void gum_es_program_free (GumESProgram * program);
@@ -131,6 +199,10 @@ static GumESAsset * gum_es_asset_new_take (const gchar * name, gpointer data,
     gsize data_size);
 static GumESAsset * gum_es_asset_ref (GumESAsset * asset);
 static void gum_es_asset_unref (GumESAsset * asset);
+
+static std::unique_ptr<StringBuffer> gum_string_buffer_from_utf8 (
+    const gchar * str);
+static gchar * gum_string_view_to_utf8 (const StringView & view);
 
 G_DEFINE_TYPE_EXTENDED (GumV8Script,
                         gum_v8_script,
@@ -195,6 +267,9 @@ gum_v8_script_iface_init (gpointer g_iface,
   iface->set_message_handler = gum_v8_script_set_message_handler;
   iface->post = gum_v8_script_post;
 
+  iface->set_debug_message_handler = gum_v8_script_set_debug_message_handler;
+  iface->post_debug_message = gum_v8_script_post_debug_message;
+
   iface->get_stalker = gum_v8_script_get_stalker;
 }
 
@@ -203,6 +278,16 @@ gum_v8_script_init (GumV8Script * self)
 {
   self->state = GUM_SCRIPT_STATE_CREATED;
   self->on_unload = NULL;
+
+  g_mutex_init (&self->inspector_mutex);
+  g_cond_init (&self->inspector_cond);
+  self->inspector_state = GUM_V8_RUNNING;
+  self->context_group_id = 1;
+
+  g_queue_init (&self->debug_messages);
+  self->flush_scheduled = false;
+
+  self->channels = new GumInspectorChannelMap ();
 }
 
 static void
@@ -212,7 +297,16 @@ gum_v8_script_constructed (GObject * object)
 
   G_OBJECT_CLASS (gum_v8_script_parent_class)->constructed (object);
 
-  self->isolate = (Isolate *) gum_v8_script_backend_get_isolate (self->backend);
+  Isolate::CreateParams params;
+  params.array_buffer_allocator =
+      ((GumV8Platform *) gum_v8_script_backend_get_platform (self->backend))
+      ->GetArrayBufferAllocator ();
+
+  Isolate * isolate = Isolate::New (params);
+  isolate->SetData (0, self);
+  isolate->SetFatalErrorHandler (gum_v8_script_on_fatal_error);
+  isolate->SetMicrotasksPolicy (MicrotasksPolicy::kExplicit);
+  self->isolate = isolate;
 }
 
 static void
@@ -233,7 +327,40 @@ gum_v8_script_dispose (GObject * object)
     if (self->state == GUM_SCRIPT_STATE_CREATED && self->context != nullptr)
       gum_v8_script_destroy_context (self);
 
-    self->isolate = nullptr;
+    g_clear_pointer (&self->debug_handler_context, g_main_context_unref);
+    if (self->debug_handler_data_destroy != NULL)
+      self->debug_handler_data_destroy (self->debug_handler_data);
+    self->debug_handler = NULL;
+    self->debug_handler_data = NULL;
+    self->debug_handler_data_destroy = NULL;
+
+    GUM_V8_INSPECTOR_LOCK (self);
+    self->inspector_state = GUM_V8_RUNNING;
+    g_cond_signal (&self->inspector_cond);
+    GUM_V8_INSPECTOR_UNLOCK (self);
+
+    gum_v8_script_clear_inspector_channels (self);
+
+    GUM_V8_INSPECTOR_LOCK (self);
+    gum_v8_script_drop_queued_debug_messages_unlocked (self);
+    GUM_V8_INSPECTOR_UNLOCK (self);
+
+    auto isolate = self->isolate;
+    {
+      Locker locker (isolate);
+      Isolate::Scope isolate_scope (isolate);
+      HandleScope handle_scope (isolate);
+
+      delete self->inspector;
+      self->inspector = nullptr;
+
+      delete self->inspector_client;
+      self->inspector_client = nullptr;
+    }
+
+    auto platform =
+        (GumV8Platform *) gum_v8_script_backend_get_platform (self->backend);
+    platform->ForgetIsolate (isolate);
 
     g_clear_pointer (&self->main_context, g_main_context_unref);
     g_clear_pointer (&self->backend, g_object_unref);
@@ -247,8 +374,14 @@ gum_v8_script_finalize (GObject * object)
 {
   auto self = GUM_V8_SCRIPT (object);
 
+  g_cond_clear (&self->inspector_cond);
+  g_mutex_clear (&self->inspector_mutex);
+
+  delete self->channels;
+
   g_free (self->name);
   g_free (self->source);
+  self->isolate->Dispose ();
 
   G_OBJECT_CLASS (gum_v8_script_parent_class)->finalize (object);
 }
@@ -323,9 +456,7 @@ gum_v8_script_create_context (GumV8Script * self,
     HandleScope handle_scope (isolate);
 
     auto global_templ = ObjectTemplate::New (isolate);
-    auto platform =
-        (GumV8Platform *) gum_v8_script_backend_get_platform (self->backend);
-    _gum_v8_core_init (&self->core, self, platform->GetRuntimeSourceMap (),
+    _gum_v8_core_init (&self->core, self, gumjs_frida_source_map,
         gum_v8_script_emit, gum_v8_script_backend_get_scheduler (self->backend),
         isolate, global_templ);
     _gum_v8_kernel_init (&self->kernel, &self->core, global_templ);
@@ -355,6 +486,13 @@ gum_v8_script_create_context (GumV8Script * self,
 
     Local<Context> context (Context::New (isolate, NULL, global_templ));
     g_signal_emit (self, gum_v8_script_signals[CONTEXT_CREATED], 0, &context);
+    if (self->inspector != nullptr)
+    {
+      auto name_buffer = gum_string_buffer_from_utf8 (self->name);
+      V8ContextInfo info (context, self->context_group_id,
+          name_buffer->string ());
+      self->inspector->contextCreated (info);
+    }
     self->context = new GumPersistent<Context>::type (isolate, context);
     Context::Scope context_scope (context);
     _gum_v8_core_realize (&self->core);
@@ -771,6 +909,8 @@ gum_v8_script_destroy_context (GumV8Script * self)
 
     auto context = Local<Context>::New (self->isolate, *self->context);
     g_signal_emit (self, gum_v8_script_signals[CONTEXT_DESTROYED], 0, &context);
+    if (self->inspector != nullptr)
+      self->inspector->contextDestroyed (context);
   }
 
   gum_es_program_free (self->program);
@@ -872,9 +1012,9 @@ gum_v8_script_execute_entrypoints (GumV8Script * self,
     auto isolate = self->isolate;
     auto context = isolate->GetCurrentContext ();
 
-    auto platform =
-        (GumV8Platform *) gum_v8_script_backend_get_platform (self->backend);
-    gum_v8_bundle_run (platform->GetRuntimeBundle ());
+    auto runtime = gum_v8_bundle_new (isolate, gumjs_runtime_modules);
+    gum_v8_bundle_run (runtime);
+    gum_v8_bundle_free (runtime);
 
     auto program = self->program;
     if (program->entrypoints != NULL)
@@ -1133,14 +1273,6 @@ gum_v8_post_data_free (GumPostData * d)
   g_slice_free (GumPostData, d);
 }
 
-static GumStalker *
-gum_v8_script_get_stalker (GumScript * script)
-{
-  auto self = GUM_V8_SCRIPT (script);
-
-  return _gum_v8_stalker_get (&self->stalker);
-}
-
 static void
 gum_v8_script_emit (GumV8Script * self,
                     const gchar * message,
@@ -1165,10 +1297,7 @@ gum_v8_script_do_emit (GumEmitData * d)
   auto self = d->script;
 
   if (self->message_handler != NULL)
-  {
-    self->message_handler (GUM_SCRIPT (self), d->message, d->data,
-        self->message_handler_data);
-  }
+    self->message_handler (d->message, d->data, self->message_handler_data);
 
   return FALSE;
 }
@@ -1181,6 +1310,425 @@ gum_v8_emit_data_free (GumEmitData * d)
   g_object_unref (d->script);
 
   g_slice_free (GumEmitData, d);
+}
+
+static void
+gum_v8_script_set_debug_message_handler (GumScript * backend,
+                                         GumScriptDebugMessageHandler handler,
+                                         gpointer data,
+                                         GDestroyNotify data_destroy)
+{
+  auto self = GUM_V8_SCRIPT (backend);
+
+  if (handler != NULL && self->inspector == nullptr)
+  {
+    auto isolate = self->isolate;
+    Locker locker (isolate);
+    Isolate::Scope isolate_scope (isolate);
+    HandleScope handle_scope (isolate);
+
+    auto client = new GumInspectorClient (self);
+    self->inspector_client = client;
+
+    auto inspector = V8Inspector::create (isolate, client);
+    self->inspector = inspector.release ();
+  }
+
+  if (self->debug_handler_data_destroy != NULL)
+    self->debug_handler_data_destroy (self->debug_handler_data);
+
+  self->debug_handler = handler;
+  self->debug_handler_data = data;
+  self->debug_handler_data_destroy = data_destroy;
+
+  auto new_context = (handler != NULL)
+      ? g_main_context_ref_thread_default ()
+      : NULL;
+
+  GUM_V8_INSPECTOR_LOCK (self);
+
+  auto old_context = self->debug_handler_context;
+  self->debug_handler_context = new_context;
+
+  if (handler != NULL)
+  {
+    if (self->inspector_state == GUM_V8_RUNNING)
+      self->inspector_state = GUM_V8_DEBUGGING;
+  }
+  else
+  {
+    gum_v8_script_drop_queued_debug_messages_unlocked (self);
+
+    self->inspector_state = GUM_V8_RUNNING;
+    g_cond_signal (&self->inspector_cond);
+  }
+
+  GUM_V8_INSPECTOR_UNLOCK (self);
+
+  if (old_context != NULL)
+    g_main_context_unref (old_context);
+
+  if (handler == NULL)
+  {
+    gum_script_scheduler_push_job_on_js_thread (
+        gum_v8_script_backend_get_scheduler (self->backend), G_PRIORITY_DEFAULT,
+        (GumScriptJobFunc) gum_v8_script_clear_inspector_channels,
+        self, NULL);
+  }
+}
+
+static void
+gum_v8_script_post_debug_message (GumScript * backend,
+                                  const gchar * message)
+{
+  auto self = GUM_V8_SCRIPT (backend);
+
+  if (self->debug_handler == NULL)
+    return;
+
+  gchar * message_copy = g_strdup (message);
+
+  GUM_V8_INSPECTOR_LOCK (self);
+
+  g_queue_push_tail (&self->debug_messages, message_copy);
+  g_cond_signal (&self->inspector_cond);
+
+  bool flush_not_already_scheduled = !self->flush_scheduled;
+  self->flush_scheduled = true;
+
+  GUM_V8_INSPECTOR_UNLOCK (self);
+
+  if (flush_not_already_scheduled)
+  {
+    gum_script_scheduler_push_job_on_js_thread (
+        gum_v8_script_backend_get_scheduler (self->backend), G_PRIORITY_DEFAULT,
+        (GumScriptJobFunc) gum_v8_script_process_queued_debug_messages,
+        self, NULL);
+  }
+}
+
+static void
+gum_v8_script_process_queued_debug_messages (GumV8Script * self)
+{
+  auto isolate = self->isolate;
+  Locker locker (isolate);
+  Isolate::Scope isolate_scope (isolate);
+  HandleScope handle_scope (isolate);
+
+  GUM_V8_INSPECTOR_LOCK (self);
+  gum_v8_script_process_queued_debug_messages_unlocked (self);
+  GUM_V8_INSPECTOR_UNLOCK (self);
+
+  isolate->PerformMicrotaskCheckpoint ();
+}
+
+static void
+gum_v8_script_process_queued_debug_messages_unlocked (GumV8Script * self)
+{
+  gchar * message;
+  while ((message = (gchar *) g_queue_pop_head (&self->debug_messages)) != NULL)
+  {
+    GUM_V8_INSPECTOR_UNLOCK (self);
+    gum_v8_script_process_debug_message (self, message);
+    GUM_V8_INSPECTOR_LOCK (self);
+
+    g_free (message);
+  }
+
+  self->flush_scheduled = false;
+}
+
+static void
+gum_v8_script_drop_queued_debug_messages_unlocked (GumV8Script * self)
+{
+  gchar * message;
+  while ((message = (gchar *) g_queue_pop_head (&self->debug_messages)) != NULL)
+    g_free (message);
+}
+
+static void
+gum_v8_script_process_debug_message (GumV8Script * self,
+                                     const gchar * message)
+{
+  guint id;
+  const char * id_start, * id_end;
+  id_start = strchr (message, ' ');
+  if (id_start == NULL)
+    return;
+  id_start++;
+  id = (guint) g_ascii_strtoull (id_start, (gchar **) &id_end, 10);
+  if (id_end == id_start)
+    return;
+
+  if (g_str_has_prefix (message, "CONNECT "))
+  {
+    gum_v8_script_connect_inspector_channel (self, id);
+  }
+  else if (g_str_has_prefix (message, "DISCONNECT "))
+  {
+    gum_v8_script_disconnect_inspector_channel (self, id);
+  }
+  else if (g_str_has_prefix (message, "DISPATCH "))
+  {
+    if (*id_end != ' ')
+      return;
+    const char * stanza = id_end + 1;
+    gum_v8_script_dispatch_inspector_stanza (self, id, stanza);
+  }
+}
+
+static void
+gum_v8_script_emit_debug_message (GumV8Script * self,
+                                  const gchar * format,
+                                  ...)
+{
+  GUM_V8_INSPECTOR_LOCK (self);
+  auto context = (self->debug_handler_context != NULL)
+      ? g_main_context_ref (self->debug_handler_context)
+      : NULL;
+  GUM_V8_INSPECTOR_UNLOCK (self);
+
+  if (context == NULL)
+    return;
+
+  auto d = g_slice_new (GumEmitDebugMessageData);
+
+  d->script = self;
+  g_object_ref (self);
+
+  va_list args;
+  va_start (args, format);
+  d->message = g_strdup_vprintf (format, args);
+  va_end (args);
+
+  auto source = g_idle_source_new ();
+  g_source_set_callback (source,
+      (GSourceFunc) gum_v8_script_do_emit_debug_message, d,
+      (GDestroyNotify) gum_emit_debug_message_data_free);
+  g_source_attach (source, context);
+  g_source_unref (source);
+
+  g_main_context_unref (context);
+}
+
+static gboolean
+gum_v8_script_do_emit_debug_message (GumEmitDebugMessageData * d)
+{
+  auto self = d->script;
+
+  if (self->debug_handler != NULL)
+    self->debug_handler (d->message, self->debug_handler_data);
+
+  return FALSE;
+}
+
+static void
+gum_emit_debug_message_data_free (GumEmitDebugMessageData * d)
+{
+  g_free (d->message);
+  g_object_unref (d->script);
+
+  g_slice_free (GumEmitDebugMessageData, d);
+}
+
+static void
+gum_v8_script_clear_inspector_channels (GumV8Script * self)
+{
+  auto isolate = self->isolate;
+  Locker locker (isolate);
+  Isolate::Scope isolate_scope (isolate);
+  HandleScope handle_scope (isolate);
+
+  GUM_V8_INSPECTOR_LOCK (self);
+  bool debugger_still_disabled = (self->inspector_state == GUM_V8_RUNNING);
+  GUM_V8_INSPECTOR_UNLOCK (self);
+
+  if (debugger_still_disabled)
+    self->channels->clear ();
+}
+
+static void
+gum_v8_script_connect_inspector_channel (GumV8Script * self,
+                                         guint id)
+{
+  auto channel = new GumInspectorChannel (self, id);
+  (*self->channels)[id] = std::unique_ptr<GumInspectorChannel> (channel);
+
+  auto session = self->inspector->connect (self->context_group_id, channel,
+      StringView ());
+  channel->takeSession (std::move (session));
+}
+
+static void
+gum_v8_script_disconnect_inspector_channel (GumV8Script * self,
+                                            guint id)
+{
+  self->channels->erase (id);
+}
+
+static void
+gum_v8_script_dispatch_inspector_stanza (GumV8Script * self,
+                                         guint channel_id,
+                                         const gchar * stanza)
+{
+  auto channel = (*self->channels)[channel_id].get ();
+  if (channel == nullptr)
+    return;
+
+  channel->dispatchStanza (stanza);
+}
+
+static void
+gum_v8_script_emit_inspector_stanza (GumV8Script * self,
+                                     guint channel_id,
+                                     const gchar * stanza)
+{
+  gum_v8_script_emit_debug_message (self, "DISPATCH %u %s",
+      channel_id, stanza);
+}
+
+GumInspectorClient::GumInspectorClient (GumV8Script * script)
+  : script (script)
+{
+}
+
+void
+GumInspectorClient::runMessageLoopOnPause (int context_group_id)
+{
+  GUM_V8_INSPECTOR_LOCK (script);
+
+  if (script->inspector_state == GUM_V8_RUNNING)
+  {
+    startSkippingAllPauses ();
+    GUM_V8_INSPECTOR_UNLOCK (script);
+    return;
+  }
+
+  script->inspector_state = GUM_V8_PAUSED;
+  while (script->inspector_state == GUM_V8_PAUSED)
+  {
+    gum_v8_script_process_queued_debug_messages_unlocked (script);
+
+    if (script->inspector_state == GUM_V8_PAUSED)
+      g_cond_wait (&script->inspector_cond, &script->inspector_mutex);
+  }
+
+  gum_v8_script_process_queued_debug_messages_unlocked (script);
+
+  if (script->inspector_state == GUM_V8_RUNNING)
+  {
+    startSkippingAllPauses ();
+  }
+
+  GUM_V8_INSPECTOR_UNLOCK (script);
+}
+
+void
+GumInspectorClient::quitMessageLoopOnPause ()
+{
+  GUM_V8_INSPECTOR_LOCK (script);
+
+  if (script->inspector_state == GUM_V8_PAUSED)
+  {
+    script->inspector_state = GUM_V8_DEBUGGING;
+    g_cond_signal (&script->inspector_cond);
+  }
+
+  GUM_V8_INSPECTOR_UNLOCK (script);
+}
+
+Local<Context>
+GumInspectorClient::ensureDefaultContextInGroup (int contextGroupId)
+{
+  return Local<Context>::New (script->isolate, *script->context);
+}
+
+double
+GumInspectorClient::currentTimeMS ()
+{
+  auto platform =
+      (GumV8Platform *) gum_v8_script_backend_get_platform (script->backend);
+
+  return platform->CurrentClockTimeMillis ();
+}
+
+void
+GumInspectorClient::startSkippingAllPauses ()
+{
+  for (const auto & pair : *script->channels)
+  {
+    pair.second->startSkippingAllPauses ();
+  }
+}
+
+GumInspectorChannel::GumInspectorChannel (GumV8Script * script,
+                                          guint id)
+  : script (script),
+    id (id)
+{
+}
+
+void
+GumInspectorChannel::takeSession (std::unique_ptr<V8InspectorSession> session)
+{
+  inspector_session = std::move (session);
+}
+
+void
+GumInspectorChannel::dispatchStanza (const char * stanza)
+{
+  auto buffer = gum_string_buffer_from_utf8 (stanza);
+
+  inspector_session->dispatchProtocolMessage (buffer->string ());
+}
+
+void
+GumInspectorChannel::startSkippingAllPauses ()
+{
+  inspector_session->setSkipAllPauses (true);
+}
+
+void
+GumInspectorChannel::emitStanza (std::unique_ptr<StringBuffer> stanza)
+{
+  gchar * stanza_utf8 = gum_string_view_to_utf8 (stanza->string ());
+
+  gum_v8_script_emit_inspector_stanza (script, id, stanza_utf8);
+
+  g_free (stanza_utf8);
+}
+
+void
+GumInspectorChannel::sendResponse (int call_id,
+                                   std::unique_ptr<StringBuffer> message)
+{
+  emitStanza (std::move (message));
+}
+
+void
+GumInspectorChannel::sendNotification (std::unique_ptr<StringBuffer> message)
+{
+  emitStanza (std::move (message));
+}
+
+void
+GumInspectorChannel::flushProtocolNotifications ()
+{
+}
+
+static GumStalker *
+gum_v8_script_get_stalker (GumScript * script)
+{
+  auto self = GUM_V8_SCRIPT (script);
+
+  return _gum_v8_stalker_get (&self->stalker);
+}
+
+static void
+gum_v8_script_on_fatal_error (const char * location,
+                              const char * message)
+{
+  g_log ("V8", G_LOG_LEVEL_ERROR, "%s: %s", location, message);
 }
 
 static GumESProgram *
@@ -1245,4 +1793,28 @@ gum_es_asset_unref (GumESAsset * asset)
   g_free (asset->data);
 
   g_slice_free (GumESAsset, asset);
+}
+
+static std::unique_ptr<StringBuffer>
+gum_string_buffer_from_utf8 (const gchar * str)
+{
+  glong length;
+  auto str_utf16 = g_utf8_to_utf16 (str, -1, NULL, &length, NULL);
+  g_assert (str_utf16 != NULL);
+
+  auto buffer = StringBuffer::create (StringView (str_utf16, length));
+
+  g_free (str_utf16);
+
+  return buffer;
+}
+
+static gchar *
+gum_string_view_to_utf8 (const StringView & view)
+{
+  if (view.is8Bit ())
+    return g_strndup ((const gchar *) view.characters8 (), view.length ());
+
+  return g_utf16_to_utf8 (view.characters16 (), (glong) view.length (), NULL,
+      NULL, NULL);
 }

--- a/bindings/gumjs/gumv8scriptbackend.cpp
+++ b/bindings/gumjs/gumv8scriptbackend.cpp
@@ -14,15 +14,6 @@
 
 #include <gum/guminterceptor.h>
 #include <string.h>
-#include <v8/v8-inspector.h>
-
-#define GUM_V8_SCRIPT_BACKEND_LOCK(o) g_mutex_lock (&(o)->mutex)
-#define GUM_V8_SCRIPT_BACKEND_UNLOCK(o) g_mutex_unlock (&(o)->mutex)
-
-#define GUM_V8_SCRIPT_BACKEND_GET_PLATFORM(backend) \
-    ((GumV8Platform *) gum_v8_script_backend_get_platform (backend))
-#define GUM_V8_SCRIPT_BACKEND_GET_ISOLATE(backend) \
-    ((Isolate *) gum_v8_script_backend_get_isolate (backend))
 
 #ifdef HAVE_IOS
 # define GUM_V8_PLATFORM_FLAGS \
@@ -43,45 +34,21 @@
     "--experimental-wasm-simd " \
     "--experimental-wasm-return-call"
 
+#define GUM_V8_SCRIPT_BACKEND_LOCK(o) g_mutex_lock (&(o)->mutex)
+#define GUM_V8_SCRIPT_BACKEND_UNLOCK(o) g_mutex_unlock (&(o)->mutex)
+
 using namespace v8;
 using namespace v8_inspector;
-
-class GumInspectorClient;
-class GumInspectorChannel;
-
-typedef std::map<guint, std::unique_ptr<GumInspectorChannel>>
-    GumInspectorChannelMap;
-
-enum GumV8ScriptBackendState
-{
-  GUM_V8_BACKEND_RUNNING,
-  GUM_V8_BACKEND_DEBUGGING,
-  GUM_V8_BACKEND_PAUSED
-};
 
 struct _GumV8ScriptBackend
 {
   GObject parent;
 
-  GMutex mutex;
-  GCond cond;
-  volatile GumV8ScriptBackendState state;
   gboolean scope_mutex_trapped;
 
-  GPtrArray * live_scripts;
+  GMutex mutex;
+  GHashTable * live_scripts;
   GumV8Platform * platform;
-  int context_group_id;
-
-  GumScriptBackendDebugMessageHandler debug_handler;
-  gpointer debug_handler_data;
-  GDestroyNotify debug_handler_data_destroy;
-  GMainContext * debug_handler_context;
-  GQueue debug_messages;
-  volatile bool flush_scheduled;
-
-  V8Inspector * inspector;
-  GumInspectorClient * inspector_client;
-  GumInspectorChannelMap * channels;
 };
 
 struct GumCreateScriptData
@@ -101,55 +68,8 @@ struct GumCompileScriptData
   gchar * source;
 };
 
-struct GumEmitDebugMessageData
-{
-  GumV8ScriptBackend * backend;
-  gchar * message;
-};
-
-class GumInspectorClient : public V8InspectorClient
-{
-public:
-  GumInspectorClient (GumV8ScriptBackend * backend);
-
-  void runMessageLoopOnPause (int context_group_id) override;
-  void quitMessageLoopOnPause () override;
-
-  Local<Context> ensureDefaultContextInGroup (int contextGroupId) override;
-
-  double currentTimeMS () override;
-
-private:
-  void startSkippingAllPauses ();
-
-  GumV8ScriptBackend * backend;
-};
-
-class GumInspectorChannel : public V8Inspector::Channel
-{
-public:
-  GumInspectorChannel (GumV8ScriptBackend * backend, guint id);
-
-  void takeSession (std::unique_ptr<V8InspectorSession> session);
-  void dispatchStanza (const char * stanza);
-  void startSkippingAllPauses ();
-
-  void sendResponse (int call_id,
-      std::unique_ptr<StringBuffer> message) override;
-  void sendNotification (std::unique_ptr<StringBuffer> message) override;
-  void flushProtocolNotifications () override;
-
-private:
-  void emitStanza (std::unique_ptr<StringBuffer> stanza);
-
-  GumV8ScriptBackend * backend;
-  guint id;
-  std::unique_ptr<V8InspectorSession> inspector_session;
-};
-
 static void gum_v8_script_backend_iface_init (gpointer g_iface,
     gpointer iface_data);
-static void gum_v8_script_backend_dispose (GObject * object);
 static void gum_v8_script_backend_finalize (GObject * object);
 
 static void gum_v8_script_backend_create (GumScriptBackend * backend,
@@ -184,11 +104,6 @@ static void gum_create_script_from_bytes_task_run (GumScriptTask * task,
 static void gum_create_script_from_bytes_data_free (
     GumCreateScriptFromBytesData * d);
 
-static void gum_v8_script_backend_on_context_created (GumV8ScriptBackend * self,
-    Local<Context> * context, GumV8Script * script);
-static void gum_v8_script_backend_on_context_destroyed (
-    GumV8ScriptBackend * self, Local<Context> * context, GumV8Script * script);
-
 static void gum_v8_script_backend_compile (GumScriptBackend * backend,
     const gchar * name, const gchar * source, GCancellable * cancellable,
     GAsyncReadyCallback callback, gpointer user_data);
@@ -206,43 +121,14 @@ static void gum_compile_script_task_run (GumScriptTask * task,
     GCancellable * cancellable);
 static void gum_compile_script_data_free (GumCompileScriptData * d);
 
-static void gum_v8_script_backend_set_debug_message_handler (
-    GumScriptBackend * backend, GumScriptBackendDebugMessageHandler handler,
-    gpointer data, GDestroyNotify data_destroy);
-static void gum_v8_script_backend_post_debug_message (
-    GumScriptBackend * backend, const gchar * message);
-static void gum_v8_script_backend_process_queued_debug_messages (
-    GumV8ScriptBackend * self);
-static void gum_v8_script_backend_process_queued_debug_messages_unlocked (
-    GumV8ScriptBackend * self);
-static void gum_v8_script_backend_drop_queued_debug_messages_unlocked (
-    GumV8ScriptBackend * self);
-static void gum_v8_script_backend_process_debug_message (
-    GumV8ScriptBackend * self, const gchar * message);
-static gboolean gum_v8_script_backend_do_emit_debug_message (
-    GumEmitDebugMessageData * d);
-static void gum_emit_debug_message_data_free (GumEmitDebugMessageData * d);
-
 static void gum_v8_script_backend_with_lock_held (GumScriptBackend * backend,
     GumScriptBackendLockedFunc func, gpointer user_data);
 static gboolean gum_v8_script_backend_is_locked (GumScriptBackend * backend);
 
-static void gum_v8_script_backend_clear_inspector_channels (
-    GumV8ScriptBackend * self);
-static void gum_v8_script_backend_notify_context_created (
+static void gum_v8_script_backend_on_context_created (GumV8ScriptBackend * self,
+    Local<Context> * context, GumV8Script * script);
+static void gum_v8_script_backend_on_context_destroyed (
     GumV8ScriptBackend * self, Local<Context> * context, GumV8Script * script);
-static void gum_v8_script_backend_notify_context_destroyed (
-    GumV8ScriptBackend * self, Local<Context> * context, GumV8Script * script);
-static void gum_v8_script_backend_connect_inspector_channel (
-    GumV8ScriptBackend * self, guint id);
-static void gum_v8_script_backend_disconnect_inspector_channel (
-    GumV8ScriptBackend * self, guint id);
-static void gum_v8_script_backend_dispatch_inspector_stanza (
-    GumV8ScriptBackend * self, guint channel_id, const gchar * stanza);
-
-static std::unique_ptr<StringBuffer> gum_string_buffer_from_utf8 (
-    const gchar * str);
-static gchar * gum_string_view_to_utf8 (const StringView & view);
 
 G_DEFINE_TYPE_EXTENDED (GumV8ScriptBackend,
                         gum_v8_script_backend,
@@ -256,7 +142,6 @@ gum_v8_script_backend_class_init (GumV8ScriptBackendClass * klass)
 {
   auto object_class = G_OBJECT_CLASS (klass);
 
-  object_class->dispose = gum_v8_script_backend_dispose;
   object_class->finalize = gum_v8_script_backend_finalize;
 }
 
@@ -278,10 +163,6 @@ gum_v8_script_backend_iface_init (gpointer g_iface,
   iface->compile_finish = gum_v8_script_backend_compile_finish;
   iface->compile_sync = gum_v8_script_backend_compile_sync;
 
-  iface->set_debug_message_handler =
-      gum_v8_script_backend_set_debug_message_handler;
-  iface->post_debug_message = gum_v8_script_backend_post_debug_message;
-
   iface->with_lock_held = gum_v8_script_backend_with_lock_held;
   iface->is_locked = gum_v8_script_backend_is_locked;
 }
@@ -289,58 +170,11 @@ gum_v8_script_backend_iface_init (gpointer g_iface,
 static void
 gum_v8_script_backend_init (GumV8ScriptBackend * self)
 {
-  g_mutex_init (&self->mutex);
-  g_cond_init (&self->cond);
-  self->state = GUM_V8_BACKEND_RUNNING;
   self->scope_mutex_trapped = FALSE;
 
-  self->live_scripts = g_ptr_array_sized_new (1);
+  g_mutex_init (&self->mutex);
+  self->live_scripts = g_hash_table_new (NULL, NULL);
   self->platform = NULL;
-  self->context_group_id = 1;
-
-  g_queue_init (&self->debug_messages);
-  self->flush_scheduled = false;
-
-  self->channels = new GumInspectorChannelMap ();
-}
-
-static void
-gum_v8_script_backend_dispose (GObject * object)
-{
-  auto self = GUM_V8_SCRIPT_BACKEND (object);
-
-  g_clear_pointer (&self->debug_handler_context, g_main_context_unref);
-  if (self->debug_handler_data_destroy != NULL)
-    self->debug_handler_data_destroy (self->debug_handler_data);
-  self->debug_handler = NULL;
-  self->debug_handler_data = NULL;
-  self->debug_handler_data_destroy = NULL;
-
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-  self->state = GUM_V8_BACKEND_RUNNING;
-  g_cond_signal (&self->cond);
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  gum_v8_script_backend_clear_inspector_channels (self);
-
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-  gum_v8_script_backend_drop_queued_debug_messages_unlocked (self);
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  {
-    auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
-    Locker locker (isolate);
-    Isolate::Scope isolate_scope (isolate);
-    HandleScope handle_scope (isolate);
-
-    delete self->inspector;
-    self->inspector = nullptr;
-
-    delete self->inspector_client;
-    self->inspector_client = nullptr;
-  }
-
-  G_OBJECT_CLASS (gum_v8_script_backend_parent_class)->dispose (object);
 }
 
 static void
@@ -348,12 +182,8 @@ gum_v8_script_backend_finalize (GObject * object)
 {
   auto self = GUM_V8_SCRIPT_BACKEND (object);
 
-  delete self->channels;
-
   delete self->platform;
-  g_ptr_array_free (self->live_scripts, TRUE);
-
-  g_cond_clear (&self->cond);
+  g_hash_table_unref (self->live_scripts);
   g_mutex_clear (&self->mutex);
 
   G_OBJECT_CLASS (gum_v8_script_backend_parent_class)->finalize (object);
@@ -378,33 +208,17 @@ gum_v8_script_backend_get_platform (GumV8ScriptBackend * self)
     g_string_free (flags, TRUE);
 
     self->platform = new GumV8Platform ();
-    self->platform->GetIsolate ()->SetData (0, self);
-
-    auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
-    Locker locker (isolate);
-    Isolate::Scope isolate_scope (isolate);
-    HandleScope handle_scope (isolate);
-
-    auto client = new GumInspectorClient (self);
-    self->inspector_client = client;
-
-    auto inspector = V8Inspector::create (isolate, client);
-    self->inspector = inspector.release ();
   }
 
   return self->platform;
 }
 
-gpointer
-gum_v8_script_backend_get_isolate (GumV8ScriptBackend * self)
-{
-  return GUM_V8_SCRIPT_BACKEND_GET_PLATFORM (self)->GetIsolate ();
-}
-
 GumScriptScheduler *
 gum_v8_script_backend_get_scheduler (GumV8ScriptBackend * self)
 {
-  return GUM_V8_SCRIPT_BACKEND_GET_PLATFORM (self)->GetScheduler ();
+  auto platform = (GumV8Platform *) gum_v8_script_backend_get_platform (self);
+
+  return platform->GetScheduler ();
 }
 
 static void
@@ -478,8 +292,6 @@ gum_create_script_task_run (GumScriptTask * task,
                             GumCreateScriptData * d,
                             GCancellable * cancellable)
 {
-  auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
-
   auto script = GUM_V8_SCRIPT (g_object_new (GUM_V8_TYPE_SCRIPT,
       "name", d->name,
       "source", d->source,
@@ -492,14 +304,7 @@ gum_create_script_task_run (GumScriptTask * task,
       G_CALLBACK (gum_v8_script_backend_on_context_destroyed), self);
 
   GError * error = NULL;
-
-  {
-    Locker locker (isolate);
-    Isolate::Scope isolate_scope (isolate);
-    HandleScope handle_scope (isolate);
-
-    gum_v8_script_create_context (script, &error);
-  }
+  gum_v8_script_create_context (script, &error);
 
   if (error == NULL)
   {
@@ -602,22 +407,6 @@ gum_create_script_from_bytes_data_free (GumCreateScriptFromBytesData * d)
 }
 
 static void
-gum_v8_script_backend_on_context_created (GumV8ScriptBackend * self,
-                                          Local<Context> * context,
-                                          GumV8Script * script)
-{
-  gum_v8_script_backend_notify_context_created (self, context, script);
-}
-
-static void
-gum_v8_script_backend_on_context_destroyed (GumV8ScriptBackend * self,
-                                            Local<Context> * context,
-                                            GumV8Script * script)
-{
-  gum_v8_script_backend_notify_context_destroyed (self, context, script);
-}
-
-static void
 gum_v8_script_backend_compile (GumScriptBackend * backend,
                                const gchar * name,
                                const gchar * source,
@@ -703,215 +492,6 @@ gum_compile_script_data_free (GumCompileScriptData * d)
 }
 
 static void
-gum_v8_script_backend_set_debug_message_handler (
-    GumScriptBackend * backend,
-    GumScriptBackendDebugMessageHandler handler,
-    gpointer data,
-    GDestroyNotify data_destroy)
-{
-  auto self = GUM_V8_SCRIPT_BACKEND (backend);
-
-  if (self->debug_handler_data_destroy != NULL)
-    self->debug_handler_data_destroy (self->debug_handler_data);
-
-  self->debug_handler = handler;
-  self->debug_handler_data = data;
-  self->debug_handler_data_destroy = data_destroy;
-
-  auto new_context = (handler != NULL)
-      ? g_main_context_ref_thread_default ()
-      : NULL;
-
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-
-  auto old_context = self->debug_handler_context;
-  self->debug_handler_context = new_context;
-
-  if (handler != NULL)
-  {
-    if (self->state == GUM_V8_BACKEND_RUNNING)
-      self->state = GUM_V8_BACKEND_DEBUGGING;
-  }
-  else
-  {
-    gum_v8_script_backend_drop_queued_debug_messages_unlocked (self);
-
-    self->state = GUM_V8_BACKEND_RUNNING;
-    g_cond_signal (&self->cond);
-  }
-
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  if (old_context != NULL)
-    g_main_context_unref (old_context);
-
-  if (handler == NULL)
-  {
-    gum_script_scheduler_push_job_on_js_thread (
-        gum_v8_script_backend_get_scheduler (self), G_PRIORITY_DEFAULT,
-        (GumScriptJobFunc) gum_v8_script_backend_clear_inspector_channels,
-        self, NULL);
-  }
-}
-
-static void
-gum_v8_script_backend_post_debug_message (GumScriptBackend * backend,
-                                          const gchar * message)
-{
-  auto self = GUM_V8_SCRIPT_BACKEND (backend);
-
-  if (self->debug_handler == NULL)
-    return;
-
-  gchar * message_copy = g_strdup (message);
-
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-
-  g_queue_push_tail (&self->debug_messages, message_copy);
-  g_cond_signal (&self->cond);
-
-  bool flush_not_already_scheduled = !self->flush_scheduled;
-  self->flush_scheduled = true;
-
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  if (flush_not_already_scheduled)
-  {
-    gum_script_scheduler_push_job_on_js_thread (
-        gum_v8_script_backend_get_scheduler (self), G_PRIORITY_DEFAULT,
-        (GumScriptJobFunc) gum_v8_script_backend_process_queued_debug_messages,
-        self, NULL);
-  }
-}
-
-static void
-gum_v8_script_backend_process_queued_debug_messages (GumV8ScriptBackend * self)
-{
-  auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
-
-  Locker locker (isolate);
-  Isolate::Scope isolate_scope (isolate);
-  HandleScope handle_scope (isolate);
-
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-  gum_v8_script_backend_process_queued_debug_messages_unlocked (self);
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  isolate->PerformMicrotaskCheckpoint ();
-}
-
-static void
-gum_v8_script_backend_process_queued_debug_messages_unlocked (
-    GumV8ScriptBackend * self)
-{
-  gchar * message;
-  while ((message = (gchar *) g_queue_pop_head (&self->debug_messages)) != NULL)
-  {
-    GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-    gum_v8_script_backend_process_debug_message (self, message);
-    GUM_V8_SCRIPT_BACKEND_LOCK (self);
-
-    g_free (message);
-  }
-
-  self->flush_scheduled = false;
-}
-
-static void
-gum_v8_script_backend_drop_queued_debug_messages_unlocked (
-    GumV8ScriptBackend * self)
-{
-  gchar * message;
-  while ((message = (gchar *) g_queue_pop_head (&self->debug_messages)) != NULL)
-    g_free (message);
-}
-
-static void
-gum_v8_script_backend_process_debug_message (GumV8ScriptBackend * self,
-                                             const gchar * message)
-{
-  guint id;
-  const char * id_start, * id_end;
-  id_start = strchr (message, ' ');
-  if (id_start == NULL)
-    return;
-  id_start++;
-  id = (guint) g_ascii_strtoull (id_start, (gchar **) &id_end, 10);
-  if (id_end == id_start)
-    return;
-
-  if (g_str_has_prefix (message, "CONNECT "))
-  {
-    gum_v8_script_backend_connect_inspector_channel (self, id);
-  }
-  else if (g_str_has_prefix (message, "DISCONNECT "))
-  {
-    gum_v8_script_backend_disconnect_inspector_channel (self, id);
-  }
-  else if (g_str_has_prefix (message, "DISPATCH "))
-  {
-    if (*id_end != ' ')
-      return;
-    const char * stanza = id_end + 1;
-    gum_v8_script_backend_dispatch_inspector_stanza (self, id, stanza);
-  }
-}
-
-static void
-gum_v8_script_backend_emit_debug_message (GumV8ScriptBackend * self,
-                                          const gchar * format,
-                                          ...)
-{
-  GUM_V8_SCRIPT_BACKEND_LOCK (self);
-  auto context = (self->debug_handler_context != NULL)
-      ? g_main_context_ref (self->debug_handler_context)
-      : NULL;
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  if (context == NULL)
-    return;
-
-  auto d = g_slice_new (GumEmitDebugMessageData);
-
-  d->backend = self;
-  g_object_ref (self);
-
-  va_list args;
-  va_start (args, format);
-  d->message = g_strdup_vprintf (format, args);
-  va_end (args);
-
-  auto source = g_idle_source_new ();
-  g_source_set_callback (source,
-      (GSourceFunc) gum_v8_script_backend_do_emit_debug_message, d,
-      (GDestroyNotify) gum_emit_debug_message_data_free);
-  g_source_attach (source, context);
-  g_source_unref (source);
-
-  g_main_context_unref (context);
-}
-
-static gboolean
-gum_v8_script_backend_do_emit_debug_message (GumEmitDebugMessageData * d)
-{
-  auto self = d->backend;
-
-  if (self->debug_handler != NULL)
-    self->debug_handler (d->message, self->debug_handler_data);
-
-  return FALSE;
-}
-
-static void
-gum_emit_debug_message_data_free (GumEmitDebugMessageData * d)
-{
-  g_free (d->message);
-  g_object_unref (d->backend);
-
-  g_slice_free (GumEmitDebugMessageData, d);
-}
-
-static void
 gum_v8_script_backend_with_lock_held (GumScriptBackend * backend,
                                       GumScriptBackendLockedFunc func,
                                       gpointer user_data)
@@ -924,13 +504,28 @@ gum_v8_script_backend_with_lock_held (GumScriptBackend * backend,
     return;
   }
 
-  auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
+  GUM_V8_SCRIPT_BACKEND_LOCK (self);
 
+  gint n = g_hash_table_size (self->live_scripts);
+  auto lockers = g_newa (Locker, n);
+
+  GHashTableIter iter;
+  g_hash_table_iter_init (&iter, self->live_scripts);
+
+  GumV8Script * script;
+  for (gint i = 0;
+      g_hash_table_iter_next (&iter, (gpointer *) &script, NULL);
+      i++)
   {
-    Locker locker (isolate);
-
-    func (user_data);
+    new (&lockers[i]) Locker (script->isolate);
   }
+
+  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
+
+  func (user_data);
+
+  for (gint i = n - 1; i != -1; i--)
+    lockers[i].~Locker ();
 }
 
 static gboolean
@@ -941,12 +536,30 @@ gum_v8_script_backend_is_locked (GumScriptBackend * backend)
   if (self->scope_mutex_trapped)
     return FALSE;
 
-  auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
+  GUM_V8_SCRIPT_BACKEND_LOCK (self);
 
-  if (Locker::IsLocked (isolate))
-    return FALSE;
+  GHashTableIter iter;
+  g_hash_table_iter_init (&iter, self->live_scripts);
 
-  return Locker::IsLockedByAnyThread (isolate);
+  gboolean is_locked = FALSE;
+  GumV8Script * script;
+  while (g_hash_table_iter_next (&iter, (gpointer *) &script, NULL))
+  {
+    auto isolate = script->isolate;
+
+    if (Locker::IsLocked (isolate))
+      continue;
+
+    if (Locker::IsLockedByAnyThread (isolate))
+    {
+      is_locked = TRUE;
+      break;
+    }
+  }
+
+  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
+
+  return is_locked;
 }
 
 gboolean
@@ -962,237 +575,21 @@ gum_v8_script_backend_mark_scope_mutex_trapped (GumV8ScriptBackend * self)
 }
 
 static void
-gum_v8_script_backend_clear_inspector_channels (GumV8ScriptBackend * self)
+gum_v8_script_backend_on_context_created (GumV8ScriptBackend * self,
+                                          Local<Context> * context,
+                                          GumV8Script * script)
 {
-  auto isolate = GUM_V8_SCRIPT_BACKEND_GET_ISOLATE (self);
-
-  Locker locker (isolate);
-  Isolate::Scope isolate_scope (isolate);
-  HandleScope handle_scope (isolate);
-
   GUM_V8_SCRIPT_BACKEND_LOCK (self);
-  bool debugger_still_disabled = (self->state == GUM_V8_BACKEND_RUNNING);
+  g_hash_table_add (self->live_scripts, script);
   GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
-
-  if (debugger_still_disabled)
-    self->channels->clear ();
 }
 
 static void
-gum_v8_script_backend_notify_context_created (GumV8ScriptBackend * self,
-                                              Local<Context> * context,
-                                              GumV8Script * script)
+gum_v8_script_backend_on_context_destroyed (GumV8ScriptBackend * self,
+                                            Local<Context> * context,
+                                            GumV8Script * script)
 {
-  g_ptr_array_add (self->live_scripts, script);
-
-  auto name_buffer = gum_string_buffer_from_utf8 (script->name);
-  V8ContextInfo info (*context, self->context_group_id, name_buffer->string ());
-
-  self->inspector->contextCreated (info);
-}
-
-static void
-gum_v8_script_backend_notify_context_destroyed (GumV8ScriptBackend * self,
-                                                Local<Context> * context,
-                                                GumV8Script * script)
-{
-  self->inspector->contextDestroyed (*context);
-
-  g_ptr_array_remove (self->live_scripts, script);
-}
-
-static void
-gum_v8_script_backend_connect_inspector_channel (GumV8ScriptBackend * self,
-                                                 guint id)
-{
-  auto channel = new GumInspectorChannel (self, id);
-  (*self->channels)[id] = std::unique_ptr<GumInspectorChannel> (channel);
-
-  auto session = self->inspector->connect (self->context_group_id, channel,
-      StringView ());
-  channel->takeSession (std::move (session));
-}
-
-static void
-gum_v8_script_backend_disconnect_inspector_channel (GumV8ScriptBackend * self,
-                                                    guint id)
-{
-  self->channels->erase (id);
-}
-
-static void
-gum_v8_script_backend_dispatch_inspector_stanza (GumV8ScriptBackend * self,
-                                                 guint channel_id,
-                                                 const gchar * stanza)
-{
-  auto channel = (*self->channels)[channel_id].get ();
-  if (channel == nullptr)
-    return;
-
-  channel->dispatchStanza (stanza);
-}
-
-static void
-gum_v8_script_backend_emit_inspector_stanza (GumV8ScriptBackend * self,
-                                             guint channel_id,
-                                             const gchar * stanza)
-{
-  gum_v8_script_backend_emit_debug_message (self, "DISPATCH %u %s",
-      channel_id, stanza);
-}
-
-GumInspectorClient::GumInspectorClient (GumV8ScriptBackend * backend)
-  : backend (backend)
-{
-}
-
-void
-GumInspectorClient::runMessageLoopOnPause (int context_group_id)
-{
-  GUM_V8_SCRIPT_BACKEND_LOCK (backend);
-
-  if (backend->state == GUM_V8_BACKEND_RUNNING)
-  {
-    startSkippingAllPauses ();
-    GUM_V8_SCRIPT_BACKEND_UNLOCK (backend);
-    return;
-  }
-
-  backend->state = GUM_V8_BACKEND_PAUSED;
-  while (backend->state == GUM_V8_BACKEND_PAUSED)
-  {
-    gum_v8_script_backend_process_queued_debug_messages_unlocked (backend);
-
-    if (backend->state == GUM_V8_BACKEND_PAUSED)
-      g_cond_wait (&backend->cond, &backend->mutex);
-  }
-
-  gum_v8_script_backend_process_queued_debug_messages_unlocked (backend);
-
-  if (backend->state == GUM_V8_BACKEND_RUNNING)
-  {
-    startSkippingAllPauses ();
-  }
-
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (backend);
-}
-
-void
-GumInspectorClient::quitMessageLoopOnPause ()
-{
-  GUM_V8_SCRIPT_BACKEND_LOCK (backend);
-
-  if (backend->state == GUM_V8_BACKEND_PAUSED)
-  {
-    backend->state = GUM_V8_BACKEND_DEBUGGING;
-    g_cond_signal (&backend->cond);
-  }
-
-  GUM_V8_SCRIPT_BACKEND_UNLOCK (backend);
-}
-
-Local<Context>
-GumInspectorClient::ensureDefaultContextInGroup (int contextGroupId)
-{
-  GPtrArray * live_scripts = backend->live_scripts;
-
-  if (live_scripts->len == 0)
-    return Local<Context> ();
-
-  GumV8Script * script = GUM_V8_SCRIPT (g_ptr_array_index (live_scripts, 0));
-  return Local<Context>::New (script->isolate, *script->context);
-}
-
-double
-GumInspectorClient::currentTimeMS ()
-{
-  return backend->platform->CurrentClockTimeMillis ();
-}
-
-void
-GumInspectorClient::startSkippingAllPauses ()
-{
-  for (const auto & pair : *backend->channels)
-  {
-    pair.second->startSkippingAllPauses ();
-  }
-}
-
-GumInspectorChannel::GumInspectorChannel (GumV8ScriptBackend * backend,
-                                          guint id)
-  : backend (backend),
-    id (id)
-{
-}
-
-void
-GumInspectorChannel::takeSession (std::unique_ptr<V8InspectorSession> session)
-{
-  inspector_session = std::move (session);
-}
-
-void
-GumInspectorChannel::dispatchStanza (const char * stanza)
-{
-  auto buffer = gum_string_buffer_from_utf8 (stanza);
-
-  inspector_session->dispatchProtocolMessage (buffer->string ());
-}
-
-void
-GumInspectorChannel::startSkippingAllPauses ()
-{
-  inspector_session->setSkipAllPauses (true);
-}
-
-void
-GumInspectorChannel::emitStanza (std::unique_ptr<StringBuffer> stanza)
-{
-  gchar * stanza_utf8 = gum_string_view_to_utf8 (stanza->string ());
-
-  gum_v8_script_backend_emit_inspector_stanza (backend, id, stanza_utf8);
-
-  g_free (stanza_utf8);
-}
-
-void
-GumInspectorChannel::sendResponse (int call_id,
-                                   std::unique_ptr<StringBuffer> message)
-{
-  emitStanza (std::move (message));
-}
-
-void
-GumInspectorChannel::sendNotification (std::unique_ptr<StringBuffer> message)
-{
-  emitStanza (std::move (message));
-}
-
-void
-GumInspectorChannel::flushProtocolNotifications ()
-{
-}
-
-static std::unique_ptr<StringBuffer>
-gum_string_buffer_from_utf8 (const gchar * str)
-{
-  glong length;
-  auto str_utf16 = g_utf8_to_utf16 (str, -1, NULL, &length, NULL);
-  g_assert (str_utf16 != NULL);
-
-  auto buffer = StringBuffer::create (StringView (str_utf16, length));
-
-  g_free (str_utf16);
-
-  return buffer;
-}
-
-static gchar *
-gum_string_view_to_utf8 (const StringView & view)
-{
-  if (view.is8Bit ())
-    return g_strndup ((const gchar *) view.characters8 (), view.length ());
-
-  return g_utf16_to_utf8 (view.characters16 (), (glong) view.length (), NULL,
-      NULL, NULL);
+  GUM_V8_SCRIPT_BACKEND_LOCK (self);
+  g_hash_table_remove (self->live_scripts, script);
+  GUM_V8_SCRIPT_BACKEND_UNLOCK (self);
 }

--- a/bindings/gumjs/gumv8scriptbackend.h
+++ b/bindings/gumjs/gumv8scriptbackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -18,8 +18,6 @@ G_DECLARE_FINAL_TYPE (GumV8ScriptBackend, gum_v8_script_backend, GUM_V8,
     SCRIPT_BACKEND, GObject)
 
 G_GNUC_INTERNAL gpointer gum_v8_script_backend_get_platform (
-    GumV8ScriptBackend * self);
-G_GNUC_INTERNAL gpointer gum_v8_script_backend_get_isolate (
     GumV8ScriptBackend * self);
 G_GNUC_INTERNAL GumScriptScheduler * gum_v8_script_backend_get_scheduler (
     GumV8ScriptBackend * self);

--- a/tests/gumjs/kscript-fixture.c
+++ b/tests/gumjs/kscript-fixture.c
@@ -113,8 +113,7 @@ test_kscript_message_item_free (TestScriptMessageItem * item)
 }
 
 static void
-test_kscript_fixture_store_message (GumScript * script,
-                                    const gchar * message,
+test_kscript_fixture_store_message (const gchar * message,
                                     GBytes * data,
                                     gpointer user_data)
 {

--- a/tests/gumjs/script-fixture.c
+++ b/tests/gumjs/script-fixture.c
@@ -265,8 +265,7 @@ test_script_message_item_free (TestScriptMessageItem * item)
 }
 
 static void
-test_script_fixture_store_message (GumScript * script,
-                                   const gchar * message,
+test_script_fixture_store_message (const gchar * message,
                                    GBytes * data,
                                    gpointer user_data)
 {

--- a/vapi/frida-gumjs-1.0.vapi
+++ b/vapi/frida-gumjs-1.0.vapi
@@ -8,7 +8,6 @@ namespace GumJS {
 namespace Gum {
 	[CCode (cheader_filename = "gumjs/gumscriptbackend.h", type_cname = "GumScriptBackendInterface")]
 	public interface ScriptBackend : GLib.Object {
-		public delegate void DebugMessageHandler (string message);
 		public delegate void LockedFunc ();
 
 		public static unowned ScriptBackend obtain ();
@@ -23,9 +22,6 @@ namespace Gum {
 		public async GLib.Bytes compile (string name, string source, GLib.Cancellable? cancellable = null) throws Gum.Error;
 		public GLib.Bytes compile_sync (string name, string source, GLib.Cancellable? cancellable = null) throws Gum.Error;
 
-		public void set_debug_message_handler (owned Gum.ScriptBackend.DebugMessageHandler? handler);
-		public void post_debug_message (string message);
-
 		public static unowned ScriptScheduler get_scheduler ();
 
 		public void with_lock_held (Gum.ScriptBackend.LockedFunc func);
@@ -34,7 +30,8 @@ namespace Gum {
 
 	[CCode (cheader_filename = "gumjs/gumscript.h", type_cname = "GumScriptInterface")]
 	public interface Script : GLib.Object {
-		public delegate void MessageHandler (Gum.Script script, string message, GLib.Bytes? data);
+		public delegate void MessageHandler (string message, GLib.Bytes? data);
+		public delegate void DebugMessageHandler (string message);
 
 		public async void load (GLib.Cancellable? cancellable = null);
 		public void load_sync (GLib.Cancellable? cancellable = null);
@@ -43,6 +40,9 @@ namespace Gum {
 
 		public void set_message_handler (owned Gum.Script.MessageHandler? handler);
 		public void post (string message, GLib.Bytes? data = null);
+
+		public void set_debug_message_handler (owned Gum.Script.DebugMessageHandler? handler);
+		public void post_debug_message (string message);
 
 		public unowned Stalker get_stalker ();
 	}


### PR DESCRIPTION
Instead of one Isolate shared between all scripts.

This will allow us to specify a custom startup snapshot per script.