### PR TITLE
Added fast interceptor implementation for x86/64

### DIFF
--- a/bindings/gumjs/gumquickinterceptor.c
+++ b/bindings/gumjs/gumquickinterceptor.c
@@ -592,6 +592,9 @@ unable_to_attach:
       case GUM_ATTACH_POLICY_VIOLATION:
         _gum_quick_throw_literal (ctx, "not permitted by code-signing policy");
         break;
+      case GUM_ATTACH_WRONG_TYPE:
+        _gum_quick_throw_literal (ctx, "wrong type");
+        break;
       default:
         g_assert_not_reached ();
     }
@@ -687,6 +690,9 @@ unable_to_replace:
         break;
       case GUM_REPLACE_POLICY_VIOLATION:
         _gum_quick_throw_literal (ctx, "not permitted by code-signing policy");
+        break;
+      case GUM_REPLACE_WRONG_TYPE:
+        _gum_quick_throw_literal (ctx, "wrong type");
         break;
       default:
         g_assert_not_reached ();

--- a/bindings/gumjs/gumv8interceptor.cpp
+++ b/bindings/gumjs/gumv8interceptor.cpp
@@ -662,6 +662,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_attach)
       _gum_v8_throw_ascii_literal (isolate,
           "not permitted by code-signing policy");
       break;
+    case GUM_ATTACH_WRONG_TYPE:
+      _gum_v8_throw_ascii_literal (isolate, "wrong type");
+      break;
     default:
       g_assert_not_reached ();
   }
@@ -739,6 +742,9 @@ GUMJS_DEFINE_FUNCTION (gumjs_interceptor_replace)
     case GUM_REPLACE_POLICY_VIOLATION:
       _gum_v8_throw_ascii_literal (isolate,
           "not permitted by code-signing policy");
+      break;
+    case GUM_REPLACE_WRONG_TYPE:
+      _gum_v8_throw_ascii_literal (isolate, "wrong type");
       break;
     default:
       g_assert_not_reached ();

--- a/gum/backend-arm/guminterceptor-arm.c
+++ b/gum/backend-arm/guminterceptor-arm.c
@@ -345,8 +345,7 @@ gum_interceptor_backend_emit_thumb_trampolines (GumInterceptorBackend * self,
         data->redirect_code_size == GUM_INTERCEPTOR_THUMB_TINY_REDIRECT_SIZE;
 
     ctx->trampoline_deflector = gum_code_allocator_alloc_deflector (
-        self->allocator, &caller, return_address, deflector_target,
-        dedicated);
+        self->allocator, &caller, return_address, deflector_target, dedicated);
     if (ctx->trampoline_deflector == NULL)
     {
       gum_code_slice_unref (ctx->trampoline_slice);

--- a/gum/backend-arm/guminterceptor-arm.c
+++ b/gum/backend-arm/guminterceptor-arm.c
@@ -218,11 +218,20 @@ gum_interceptor_backend_emit_arm_trampolines (GumInterceptorBackend * self,
   GumArmFunctionContextData * data = GUM_FCDATA (ctx);
   GumArmWriter * aw = &self->arm_writer;
   GumArmRelocator * ar = &self->arm_relocator;
+  gpointer deflector_target;
   guint reloc_bytes;
 
   gum_arm_writer_reset (aw, ctx->trampoline_slice->data);
 
-  ctx->on_enter_trampoline = gum_arm_writer_cur (aw);
+  if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    deflector_target = ctx->replacement_function;
+  }
+  else
+  {
+    ctx->on_enter_trampoline = gum_arm_writer_cur (aw);
+    deflector_target = ctx->on_enter_trampoline;
+  }
 
   if (data->redirect_code_size != data->full_redirect_size)
   {
@@ -238,8 +247,7 @@ gum_interceptor_backend_emit_arm_trampolines (GumInterceptorBackend * self,
     dedicated = TRUE;
 
     ctx->trampoline_deflector = gum_code_allocator_alloc_deflector (
-        self->allocator, &caller, return_address, ctx->on_enter_trampoline,
-        dedicated);
+        self->allocator, &caller, return_address, deflector_target, dedicated);
     if (ctx->trampoline_deflector == NULL)
     {
       gum_code_slice_unref (ctx->trampoline_slice);
@@ -248,20 +256,23 @@ gum_interceptor_backend_emit_arm_trampolines (GumInterceptorBackend * self,
     }
   }
 
-  gum_emit_arm_push_cpu_context_high_part (aw);
-  gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_R6, GUM_ADDRESS (ctx));
-  gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_PC,
-      GUM_ADDRESS (self->enter_thunk_arm));
+  if (ctx->type != GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    gum_emit_arm_push_cpu_context_high_part (aw);
+    gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_R6, GUM_ADDRESS (ctx));
+    gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_PC,
+        GUM_ADDRESS (self->enter_thunk_arm));
 
-  ctx->on_leave_trampoline = gum_arm_writer_cur (aw);
+    ctx->on_leave_trampoline = gum_arm_writer_cur (aw);
 
-  gum_emit_arm_push_cpu_context_high_part (aw);
-  gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_R6, GUM_ADDRESS (ctx));
-  gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_PC,
-      GUM_ADDRESS (self->leave_thunk_arm));
+    gum_emit_arm_push_cpu_context_high_part (aw);
+    gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_R6, GUM_ADDRESS (ctx));
+    gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_PC,
+        GUM_ADDRESS (self->leave_thunk_arm));
 
-  gum_arm_writer_flush (aw);
-  g_assert (gum_arm_writer_offset (aw) <= ctx->trampoline_slice->size);
+    gum_arm_writer_flush (aw);
+    g_assert (gum_arm_writer_offset (aw) <= ctx->trampoline_slice->size);
+  }
 
   ctx->on_invoke_trampoline = gum_arm_writer_cur (aw);
 
@@ -300,6 +311,7 @@ gum_interceptor_backend_emit_thumb_trampolines (GumInterceptorBackend * self,
   GumArmFunctionContextData * data = GUM_FCDATA (ctx);
   GumThumbWriter * tw = &self->thumb_writer;
   GumThumbRelocator * tr = &self->thumb_relocator;
+  gpointer deflector_target;
   GString * signature;
   const cs_insn * insn, * trailing_bl;
   guint reloc_bytes;
@@ -308,7 +320,15 @@ gum_interceptor_backend_emit_thumb_trampolines (GumInterceptorBackend * self,
 
   gum_thumb_writer_reset (tw, ctx->trampoline_slice->data);
 
-  ctx->on_enter_trampoline = gum_thumb_writer_cur (tw) + 1;
+  if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    deflector_target = ctx->replacement_function;
+  }
+  else
+  {
+    ctx->on_enter_trampoline = gum_thumb_writer_cur (tw) + 1;
+    deflector_target = ctx->on_enter_trampoline;
+  }
 
   if (data->redirect_code_size != data->full_redirect_size)
   {
@@ -325,7 +345,7 @@ gum_interceptor_backend_emit_thumb_trampolines (GumInterceptorBackend * self,
         data->redirect_code_size == GUM_INTERCEPTOR_THUMB_TINY_REDIRECT_SIZE;
 
     ctx->trampoline_deflector = gum_code_allocator_alloc_deflector (
-        self->allocator, &caller, return_address, ctx->on_enter_trampoline,
+        self->allocator, &caller, return_address, deflector_target,
         dedicated);
     if (ctx->trampoline_deflector == NULL)
     {
@@ -335,24 +355,27 @@ gum_interceptor_backend_emit_thumb_trampolines (GumInterceptorBackend * self,
     }
   }
 
-  if (data->redirect_code_size != GUM_INTERCEPTOR_THUMB_LINK_REDIRECT_SIZE)
+  if (ctx->type != GUM_INTERCEPTOR_TYPE_FAST)
   {
+    if (data->redirect_code_size != GUM_INTERCEPTOR_THUMB_LINK_REDIRECT_SIZE)
+    {
+      gum_emit_thumb_push_cpu_context_high_part (tw);
+    }
+
+    gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_R6, GUM_ADDRESS (ctx));
+    gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
+        GUM_ADDRESS (self->enter_thunk_thumb));
+
+    ctx->on_leave_trampoline = gum_thumb_writer_cur (tw) + 1;
+
     gum_emit_thumb_push_cpu_context_high_part (tw);
+    gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_R6, GUM_ADDRESS (ctx));
+    gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
+        GUM_ADDRESS (self->leave_thunk_thumb));
+
+    gum_thumb_writer_flush (tw);
+    g_assert (gum_thumb_writer_offset (tw) <= ctx->trampoline_slice->size);
   }
-
-  gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_R6, GUM_ADDRESS (ctx));
-  gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
-      GUM_ADDRESS (self->enter_thunk_thumb));
-
-  ctx->on_leave_trampoline = gum_thumb_writer_cur (tw) + 1;
-
-  gum_emit_thumb_push_cpu_context_high_part (tw);
-  gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_R6, GUM_ADDRESS (ctx));
-  gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
-      GUM_ADDRESS (self->leave_thunk_thumb));
-
-  gum_thumb_writer_flush (tw);
-  g_assert (gum_thumb_writer_offset (tw) <= ctx->trampoline_slice->size);
 
   ctx->on_invoke_trampoline = gum_thumb_writer_cur (tw) + 1;
 
@@ -554,6 +577,11 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
             GUM_ADDRESS (ctx->trampoline_deflector->trampoline));
       }
     }
+    else if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+    {
+      gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
+          GUM_ADDRESS (ctx->replacement_function));
+    }
     else
     {
       gum_thumb_writer_put_ldr_reg_address (tw, ARM_REG_PC,
@@ -576,6 +604,11 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
           GUM_INTERCEPTOR_ARM_TINY_REDIRECT_SIZE);
       gum_arm_writer_put_b_imm (aw,
           GUM_ADDRESS (ctx->trampoline_deflector->trampoline));
+    }
+    else if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+    {
+      gum_arm_writer_put_ldr_reg_address (aw, ARM_REG_PC,
+          GUM_ADDRESS (ctx->replacement_function));
     }
     else
     {

--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -870,13 +870,9 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
   GumAddress on_enter;
 
   if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
-  {
     on_enter = GUM_ADDRESS (ctx->replacement_function);
-  }
   else
-  {
     on_enter = GUM_ADDRESS (ctx->on_enter_trampoline);
-  }
 
 #ifdef HAVE_DARWIN
   if (ctx->grafted_hook != NULL)

--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -666,7 +666,7 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
 
   gum_arm64_writer_reset (aw, ctx->trampoline_slice->data);
 
-   if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
   {
     deflector_target = ctx->replacement_function;
   }

--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -656,6 +656,7 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
   gpointer function_address = ctx->function_address;
   GumArm64FunctionContextData * data = GUM_FCDATA (ctx);
   gboolean need_deflector;
+  gpointer deflector_target;
   GString * signature;
   gboolean is_eligible_for_lr_rewriting;
   guint reloc_bytes;
@@ -665,7 +666,15 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
 
   gum_arm64_writer_reset (aw, ctx->trampoline_slice->data);
 
-  ctx->on_enter_trampoline = gum_sign_code_pointer (gum_arm64_writer_cur (aw));
+   if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    deflector_target = ctx->replacement_function;
+  }
+  else
+  {
+    ctx->on_enter_trampoline = gum_sign_code_pointer (gum_arm64_writer_cur (aw));
+    deflector_target = ctx->on_enter_trampoline;
+  }
 
   if (need_deflector)
   {
@@ -681,8 +690,7 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
     dedicated = data->redirect_code_size == 4;
 
     ctx->trampoline_deflector = gum_code_allocator_alloc_deflector (
-        self->allocator, &caller, return_address, ctx->on_enter_trampoline,
-        dedicated);
+        self->allocator, &caller, return_address, deflector_target, dedicated);
     if (ctx->trampoline_deflector == NULL)
     {
       gum_code_slice_unref (ctx->trampoline_slice);
@@ -693,20 +701,23 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
     gum_arm64_writer_put_pop_reg_reg (aw, ARM64_REG_X0, ARM64_REG_LR);
   }
 
-  gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X17, GUM_ADDRESS (ctx));
-  gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X16,
-      GUM_ADDRESS (gum_sign_code_pointer (self->enter_thunk)));
-  gum_arm64_writer_put_br_reg (aw, ARM64_REG_X16);
+  if (ctx->type != GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X17, GUM_ADDRESS (ctx));
+    gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X16,
+        GUM_ADDRESS (gum_sign_code_pointer (self->enter_thunk)));
+    gum_arm64_writer_put_br_reg (aw, ARM64_REG_X16);
 
-  ctx->on_leave_trampoline = gum_arm64_writer_cur (aw);
+    ctx->on_leave_trampoline = gum_arm64_writer_cur (aw);
 
-  gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X17, GUM_ADDRESS (ctx));
-  gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X16,
-      GUM_ADDRESS (gum_sign_code_pointer (self->leave_thunk)));
-  gum_arm64_writer_put_br_reg (aw, ARM64_REG_X16);
+    gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X17, GUM_ADDRESS (ctx));
+    gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X16,
+        GUM_ADDRESS (gum_sign_code_pointer (self->leave_thunk)));
+    gum_arm64_writer_put_br_reg (aw, ARM64_REG_X16);
 
-  gum_arm64_writer_flush (aw);
-  g_assert (gum_arm64_writer_offset (aw) <= ctx->trampoline_slice->size);
+    gum_arm64_writer_flush (aw);
+    g_assert (gum_arm64_writer_offset (aw) <= ctx->trampoline_slice->size);
+  }
 
   ctx->on_invoke_trampoline = gum_sign_code_pointer (gum_arm64_writer_cur (aw));
 
@@ -856,7 +867,16 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
 {
   GumArm64Writer * aw = &self->writer;
   GumArm64FunctionContextData * data = GUM_FCDATA (ctx);
-  GumAddress on_enter = GUM_ADDRESS (ctx->on_enter_trampoline);
+  GumAddress on_enter;
+
+  if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    on_enter = GUM_ADDRESS (ctx->replacement_function);
+  }
+  else
+  {
+    on_enter = GUM_ADDRESS (ctx->on_enter_trampoline);
+  }
 
 #ifdef HAVE_DARWIN
   if (ctx->grafted_hook != NULL)

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -181,7 +181,8 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
   if (ctx->type != GUM_INTERCEPTOR_TYPE_FAST)
   {
     function_ctx_ptr = GUM_ADDRESS (gum_x86_writer_cur (cw));
-    gum_x86_writer_put_bytes (cw, (guint8 *) &ctx, sizeof (GumFunctionContext *));
+    gum_x86_writer_put_bytes (cw, (guint8 *) &ctx,
+        sizeof (GumFunctionContext *));
 
     ctx->on_enter_trampoline = gum_x86_writer_cur (cw);
 

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -244,9 +244,15 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
   cw->pc = GPOINTER_TO_SIZE (ctx->function_address);
 
   if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
-    gum_x86_writer_put_jmp_address (cw, GUM_ADDRESS (ctx->replacement_function));
+  {
+    gum_x86_writer_put_jmp_address (cw,
+        GUM_ADDRESS (ctx->replacement_function));
+  }
   else
-    gum_x86_writer_put_jmp_address (cw, GUM_ADDRESS (ctx->on_enter_trampoline));
+  {
+    gum_x86_writer_put_jmp_address (cw,
+        GUM_ADDRESS (ctx->on_enter_trampoline));
+  }
 
   gum_x86_writer_flush (cw);
   g_assert (gum_x86_writer_offset (cw) <= GUM_FCDATA (ctx)->redirect_code_size);

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -134,7 +134,7 @@ gum_interceptor_backend_prepare_trampoline (GumInterceptorBackend * self,
   if (ctx->type == GUM_INTERCEPTOR_TYPE_DEFAULT)
   {
     ctx->trampoline_slice = gum_code_allocator_try_alloc_slice_near (
-      self->allocator, &spec, default_alignment);
+        self->allocator, &spec, default_alignment);
   }
 
   if (ctx->trampoline_slice == NULL)

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -147,7 +147,6 @@ gum_interceptor_backend_prepare_trampoline (GumInterceptorBackend * self,
   {
     data->redirect_code_size = GUM_INTERCEPTOR_NEAR_REDIRECT_SIZE;
   }
-
 #endif
 
   if (!gum_x86_relocator_can_relocate (ctx->function_address,

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -113,24 +113,41 @@ gum_interceptor_backend_prepare_trampoline (GumInterceptorBackend * self,
 
   spec.near_address = ctx->function_address;
   spec.max_distance = GUM_X86_JMP_MAX_DISTANCE;
-  ctx->trampoline_slice = gum_code_allocator_try_alloc_slice_near (
-      self->allocator, &spec, default_alignment);
+
   /*
    * When creating a fast interceptor, we won't be vectoring from the target
    * function to the trampoline slice, we will instead be re-directing direct to
    * the target replacement function and therefore must consider the worst case
    * scenario of a JMP with RIP-relative immediate embedded in the code stream.
+   * We will still use the trampoline slice for writing the trampoline for the
+   * original function in the event that the patched function wishes to call the
+   * original. Thus it isn't important where the trampoline slice is located.
+   *
+   * When creating a normal interceptor, the patch to the target function
+   * re-directs first to the on_enter trampoline written to the trampoline
+   * slice. If we are able to allocate the slice nearby the target function,
+   * then we are able to use a near rather than far jump and hence a shorter
+   * op-code. This reduces the amount of the target function prologue which
+   * needs to be over-written. If we cannot allocate nearby, however, we
+   * just revert to assuming the worst case scenario.
    */
-  if (ctx->trampoline_slice != NULL && ctx->type != GUM_INTERCEPTOR_TYPE_FAST)
+  if (ctx->type == GUM_INTERCEPTOR_TYPE_DEFAULT)
   {
-    data->redirect_code_size = GUM_INTERCEPTOR_NEAR_REDIRECT_SIZE;
+    ctx->trampoline_slice = gum_code_allocator_try_alloc_slice_near (
+      self->allocator, &spec, default_alignment);
   }
-  else
+
+  if (ctx->trampoline_slice == NULL)
   {
     data->redirect_code_size = GUM_INTERCEPTOR_FULL_REDIRECT_SIZE;
 
     ctx->trampoline_slice = gum_code_allocator_alloc_slice (self->allocator);
   }
+  else
+  {
+    data->redirect_code_size = GUM_INTERCEPTOR_NEAR_REDIRECT_SIZE;
+  }
+
 #endif
 
   if (!gum_x86_relocator_can_relocate (ctx->function_address,
@@ -227,13 +244,9 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
   cw->pc = GPOINTER_TO_SIZE (ctx->function_address);
 
   if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
-  {
     gum_x86_writer_put_jmp_address (cw, GUM_ADDRESS (ctx->replacement_function));
-  }
   else
-  {
     gum_x86_writer_put_jmp_address (cw, GUM_ADDRESS (ctx->on_enter_trampoline));
-  }
 
   gum_x86_writer_flush (cw);
   g_assert (gum_x86_writer_offset (cw) <= GUM_FCDATA (ctx)->redirect_code_size);

--- a/gum/guminterceptor-priv.h
+++ b/gum/guminterceptor-priv.h
@@ -24,7 +24,7 @@ enum _GumInterceptorType
 {
   GUM_INTERCEPTOR_TYPE_DEFAULT = 0,
   GUM_INTERCEPTOR_TYPE_FAST    = 1
-} ;
+};
 
 union _GumFunctionContextBackendData
 {

--- a/gum/guminterceptor-priv.h
+++ b/gum/guminterceptor-priv.h
@@ -18,6 +18,14 @@ typedef struct _GumInterceptorBackend GumInterceptorBackend;
 typedef struct _GumFunctionContext GumFunctionContext;
 typedef union _GumFunctionContextBackendData GumFunctionContextBackendData;
 
+typedef guint GumInterceptorType;
+
+enum _GumInterceptorType
+{
+  GUM_INTERCEPTOR_TYPE_DEFAULT = 0,
+  GUM_INTERCEPTOR_TYPE_FAST    = 1
+} ;
+
 union _GumFunctionContextBackendData
 {
   gchar storage[2 * GLIB_SIZEOF_VOID_P];
@@ -26,6 +34,8 @@ union _GumFunctionContextBackendData
 
 struct _GumFunctionContext
 {
+  GumInterceptorType type;
+
   gpointer function_address;
 
   gboolean destroyed;

--- a/gum/guminterceptor-priv.h
+++ b/gum/guminterceptor-priv.h
@@ -15,10 +15,9 @@
 #include "gumtls.h"
 
 typedef struct _GumInterceptorBackend GumInterceptorBackend;
+typedef guint GumInterceptorType;
 typedef struct _GumFunctionContext GumFunctionContext;
 typedef union _GumFunctionContextBackendData GumFunctionContextBackendData;
-
-typedef guint GumInterceptorType;
 
 enum _GumInterceptorType
 {

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -571,8 +571,8 @@ gum_interceptor_replace_with_type (GumInterceptor * self,
 
   function_address = gum_interceptor_resolve (self, function_address);
 
-  function_ctx = gum_interceptor_instrument (self, type,
-      function_address, &error);
+  function_ctx =
+      gum_interceptor_instrument (self, type, function_address, &error);
 
   if (function_ctx == NULL)
     goto instrumentation_error;

--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -25,7 +25,8 @@ typedef enum
   GUM_ATTACH_OK               =  0,
   GUM_ATTACH_WRONG_SIGNATURE  = -1,
   GUM_ATTACH_ALREADY_ATTACHED = -2,
-  GUM_ATTACH_POLICY_VIOLATION = -3
+  GUM_ATTACH_POLICY_VIOLATION = -3,
+  GUM_ATTACH_WRONG_TYPE       = -4
 } GumAttachReturn;
 
 typedef enum
@@ -33,7 +34,8 @@ typedef enum
   GUM_REPLACE_OK               =  0,
   GUM_REPLACE_WRONG_SIGNATURE  = -1,
   GUM_REPLACE_ALREADY_REPLACED = -2,
-  GUM_REPLACE_POLICY_VIOLATION = -3
+  GUM_REPLACE_POLICY_VIOLATION = -3,
+  GUM_REPLACE_WRONG_TYPE       = -4
 } GumReplaceReturn;
 
 GUM_API GumInterceptor * gum_interceptor_obtain (void);
@@ -47,6 +49,9 @@ GUM_API void gum_interceptor_detach (GumInterceptor * self,
 GUM_API GumReplaceReturn gum_interceptor_replace (GumInterceptor * self,
     gpointer function_address, gpointer replacement_function,
     gpointer replacement_data, gpointer * original_function);
+GumReplaceReturn gum_interceptor_replace_fast (GumInterceptor * self,
+    gpointer function_address, gpointer replacement_function,
+    gpointer * original_function);
 GUM_API void gum_interceptor_revert (GumInterceptor * self,
     gpointer function_address);
 

--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -26,7 +26,7 @@ typedef enum
   GUM_ATTACH_WRONG_SIGNATURE  = -1,
   GUM_ATTACH_ALREADY_ATTACHED = -2,
   GUM_ATTACH_POLICY_VIOLATION = -3,
-  GUM_ATTACH_WRONG_TYPE       = -4
+  GUM_ATTACH_WRONG_TYPE       = -4,
 } GumAttachReturn;
 
 typedef enum
@@ -35,7 +35,7 @@ typedef enum
   GUM_REPLACE_WRONG_SIGNATURE  = -1,
   GUM_REPLACE_ALREADY_REPLACED = -2,
   GUM_REPLACE_POLICY_VIOLATION = -3,
-  GUM_REPLACE_WRONG_TYPE       = -4
+  GUM_REPLACE_WRONG_TYPE       = -4,
 } GumReplaceReturn;
 
 GUM_API GumInterceptor * gum_interceptor_obtain (void);

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -868,8 +868,8 @@ replacement_malloc (gsize size)
 TESTCASE (replace_then_replace_fast)
 {
   g_assert_cmpint (gum_interceptor_replace (fixture->interceptor,
-      target_function, replacement_target_function, NULL, NULL), ==,
-      GUM_REPLACE_OK);
+      target_function, replacement_target_function, NULL, NULL),
+      ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
       target_function, replacement_target_function, NULL), ==,
       GUM_REPLACE_WRONG_TYPE);

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -927,10 +927,8 @@ TESTCASE (replace_fast_then_attach)
   g_object_unref (listener);
 }
 
-
 TESTCASE (replace_fast_then_replace_fast)
 {
-
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
       target_function, replacement_target_function, NULL), ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
@@ -946,7 +944,7 @@ TESTCASE (i_can_has_replaceability_fast)
 
   unsupported_functions = unsupported_function_list_new (&count);
 
-  for (i = 0; i < count; i++)
+  for (i = 0; i != count; i++)
   {
     UnsupportedFunction * func = &unsupported_functions[i];
 
@@ -978,7 +976,6 @@ TESTCASE (replace_one_fast)
   result = target_function (fixture->result);
   g_assert_cmphex (GPOINTER_TO_SIZE (result), ==, 0);
   g_assert_cmpstr (fixture->result->str, ==, "|");
-
 }
 
 static gpointer
@@ -993,7 +990,6 @@ replacement_target_function_fast (GString * str)
   return result;
 }
 
-
 TESTCASE (fast_interceptor_performance)
 {
   GTimer * timer;
@@ -1005,10 +1001,10 @@ TESTCASE (fast_interceptor_performance)
   /* Normal Interceptor */
   g_assert_cmpint (gum_interceptor_replace (fixture->interceptor,
       target_function, replacement_target_function_fast, NULL,
-      (void *)&target_function_fast), ==, GUM_REPLACE_OK);
+      (gpointer) &target_function_fast), ==, GUM_REPLACE_OK);
   g_timer_reset (timer);
 
-  for (gsize i = 0; i < 1000000; i++)
+  for (gsize i = 0; i != 1000000; i++)
   {
     g_string_truncate (fixture->result, 0);
     result = target_function (fixture->result);
@@ -1021,9 +1017,9 @@ TESTCASE (fast_interceptor_performance)
   /* Fast Interceptor */
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
       target_function, replacement_target_function_fast,
-      (void *)&target_function_fast), ==, GUM_REPLACE_OK);
+      (gpointer) &target_function_fast), ==, GUM_REPLACE_OK);
   g_timer_reset (timer);
-    for (gsize i = 0; i < 1000; i++)
+  for (gsize i = 0; i != 1000; i++)
   {
     g_string_truncate (fixture->result, 0);
     result = target_function (fixture->result);

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -1019,7 +1019,7 @@ TESTCASE (fast_interceptor_performance)
       target_function, replacement_target_function_fast,
       (gpointer) &target_function_fast), ==, GUM_REPLACE_OK);
   g_timer_reset (timer);
-  for (gsize i = 0; i != 1000; i++)
+  for (gsize i = 0; i != 1000000; i++)
   {
     g_string_truncate (fixture->result, 0);
     result = target_function (fixture->result);

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -871,8 +871,8 @@ TESTCASE (replace_then_replace_fast)
       target_function, replacement_target_function, NULL, NULL),
       ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==,
-      GUM_REPLACE_WRONG_TYPE);
+      target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_WRONG_TYPE);
   gum_interceptor_revert (fixture->interceptor, target_function);
 }
 

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -868,10 +868,10 @@ replacement_malloc (gsize size)
 TESTCASE (replace_then_replace_fast)
 {
   g_assert_cmpint (gum_interceptor_replace (fixture->interceptor,
-      target_function, replacement_target_function, NULL, NULL),
+        target_function, replacement_target_function, NULL, NULL),
       ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL),
+        target_function, replacement_target_function, NULL),
       ==, GUM_REPLACE_WRONG_TYPE);
   gum_interceptor_revert (fixture->interceptor, target_function);
 }
@@ -886,11 +886,11 @@ TESTCASE (attach_then_replace_fast)
   listener->user_data = fixture->result;
 
   g_assert_cmpint (gum_interceptor_attach (fixture->interceptor,
-      target_function, GUM_INVOCATION_LISTENER (listener), NULL), ==,
-      GUM_ATTACH_OK);
+        target_function, GUM_INVOCATION_LISTENER (listener), NULL),
+      ==, GUM_ATTACH_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==,
-      GUM_REPLACE_WRONG_TYPE);
+        target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_WRONG_TYPE);
   gum_interceptor_detach (fixture->interceptor,
       GUM_INVOCATION_LISTENER (listener));
 
@@ -900,10 +900,11 @@ TESTCASE (attach_then_replace_fast)
 TESTCASE (replace_fast_then_replace)
 {
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace (fixture->interceptor,
-      target_function, replacement_target_function, NULL, NULL), ==,
-      GUM_REPLACE_WRONG_TYPE);
+        target_function, replacement_target_function, NULL, NULL),
+      ==, GUM_REPLACE_WRONG_TYPE);
   gum_interceptor_revert (fixture->interceptor, target_function);
 }
 
@@ -917,11 +918,12 @@ TESTCASE (replace_fast_then_attach)
   listener->user_data = fixture->result;
 
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_OK);
 
   g_assert_cmpint (gum_interceptor_attach (fixture->interceptor,
-      target_function, GUM_INVOCATION_LISTENER (listener), NULL), ==,
-      GUM_ATTACH_WRONG_TYPE);
+        target_function, GUM_INVOCATION_LISTENER (listener), NULL),
+      ==, GUM_ATTACH_WRONG_TYPE);
 
   gum_interceptor_revert (fixture->interceptor, target_function);
   g_object_unref (listener);
@@ -930,10 +932,11 @@ TESTCASE (replace_fast_then_attach)
 TESTCASE (replace_fast_then_replace_fast)
 {
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_OK);
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function, NULL), ==,
-      GUM_REPLACE_ALREADY_REPLACED);
+        target_function, replacement_target_function, NULL),
+      ==, GUM_REPLACE_ALREADY_REPLACED);
   gum_interceptor_revert (fixture->interceptor, target_function);
 }
 
@@ -949,7 +952,7 @@ TESTCASE (i_can_has_replaceability_fast)
     UnsupportedFunction * func = &unsupported_functions[i];
 
     g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-        func->code + func->code_offset, replacement_malloc, NULL),
+          func->code + func->code_offset, replacement_malloc, NULL),
         ==, GUM_REPLACE_WRONG_SIGNATURE);
   }
 
@@ -961,8 +964,9 @@ TESTCASE (replace_one_fast)
   gpointer result;
 
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function_fast,
-      (void *)&target_function_fast), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function_fast,
+        (gpointer *) &target_function_fast),
+      ==, GUM_REPLACE_OK);
 
   result = target_function (fixture->result);
 
@@ -1000,8 +1004,9 @@ TESTCASE (fast_interceptor_performance)
 
   /* Normal Interceptor */
   g_assert_cmpint (gum_interceptor_replace (fixture->interceptor,
-      target_function, replacement_target_function_fast, NULL,
-      (gpointer) &target_function_fast), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function_fast, NULL,
+        (gpointer *) &target_function_fast),
+      ==, GUM_REPLACE_OK);
   g_timer_reset (timer);
 
   for (gsize i = 0; i != 1000000; i++)
@@ -1016,8 +1021,9 @@ TESTCASE (fast_interceptor_performance)
 
   /* Fast Interceptor */
   g_assert_cmpint (gum_interceptor_replace_fast (fixture->interceptor,
-      target_function, replacement_target_function_fast,
-      (gpointer) &target_function_fast), ==, GUM_REPLACE_OK);
+        target_function, replacement_target_function_fast,
+        (gpointer *) &target_function_fast),
+      ==, GUM_REPLACE_OK);
   g_timer_reset (timer);
   for (gsize i = 0; i != 1000000; i++)
   {

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -78,7 +78,7 @@ static gpointer hit_target_function_repeatedly (gpointer data);
 #endif
 static gpointer replacement_malloc (gsize size);
 static gpointer replacement_target_function (GString * str);
-static gpointer (*target_function_fast) (GString * str) = NULL;
+static gpointer (* target_function_fast) (GString * str) = NULL;
 static gpointer replacement_target_function_fast (GString * str);
 
 TESTCASE (attach_one)


### PR DESCRIPTION
I've only implemented for x86_64 as that's all I need right now, but the back-end changes are actually pretty minimal, so wouldn't be tricky to add to other architectures at all. On other architectures, `fast` Interceptor replacements just fall back to the standard implementation. 

I've not added any support for the `gumjs` bindings yet as again, I don't need right them now (and I had real trouble getting the HEAD to link properly with V8). But can't see it being too tricky. However, it might mean returning the NativePointer for the trampoline to the original function from the interceptor API (as fast interceptors don't support re-entrancy, so calling the original function from inside a hook will just result in an infinite loop). You'd probably want to change `Interceptor.replace` to do likewise for consistency.

I guess if you were using `gumjs`, you'd probably want to implement your hook using `CModule` as otherwise you add back in a lot of overhead anyways.