### PR TITLE
debug-symbol: Ensure path is absolute and add column field

### DIFF
--- a/bindings/gumjs/gumquicksymbol.c
+++ b/bindings/gumjs/gumquicksymbol.c
@@ -35,6 +35,7 @@ GUMJS_DECLARE_GETTER (gumjs_symbol_get_name)
 GUMJS_DECLARE_GETTER (gumjs_symbol_get_module_name)
 GUMJS_DECLARE_GETTER (gumjs_symbol_get_file_name)
 GUMJS_DECLARE_GETTER (gumjs_symbol_get_line_number)
+GUMJS_DECLARE_GETTER (gumjs_symbol_get_column)
 GUMJS_DECLARE_FUNCTION (gumjs_symbol_to_string)
 GUMJS_DECLARE_FUNCTION (gumjs_symbol_to_json)
 
@@ -65,6 +66,7 @@ static const JSCFunctionListEntry gumjs_symbol_entries[] =
   JS_CGETSET_DEF ("moduleName", gumjs_symbol_get_module_name, NULL),
   JS_CGETSET_DEF ("fileName", gumjs_symbol_get_file_name, NULL),
   JS_CGETSET_DEF ("lineNumber", gumjs_symbol_get_line_number, NULL),
+  JS_CGETSET_DEF ("column", gumjs_symbol_get_column, NULL),
   JS_CFUNC_DEF ("toString", 0, gumjs_symbol_to_string),
   JS_CFUNC_DEF ("toJSON", 0, gumjs_symbol_to_json),
 };
@@ -346,6 +348,19 @@ GUMJS_DEFINE_GETTER (gumjs_symbol_get_line_number)
   return JS_NewInt32 (ctx, self->details.line_number);
 }
 
+GUMJS_DEFINE_GETTER (gumjs_symbol_get_column)
+{
+  GumSymbol * self;
+
+  if (!gum_symbol_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  if (!self->resolved)
+    return JS_NULL;
+
+  return JS_NewInt32 (ctx, self->details.column);
+}
+
 GUMJS_DEFINE_FUNCTION (gumjs_symbol_to_string)
 {
   JSValue result;
@@ -366,7 +381,15 @@ GUMJS_DEFINE_FUNCTION (gumjs_symbol_to_string)
         d->module_name, d->symbol_name);
     if (d->file_name[0] != '\0')
     {
-      g_string_append_printf (s, " %s:%u", d->file_name, d->line_number);
+      if (d->column != 0)
+      {
+        g_string_append_printf (s, " %s:%u:%u", d->file_name, d->line_number,
+            d->column);
+      }
+      else
+      {
+        g_string_append_printf (s, " %s:%u", d->file_name, d->line_number);
+      }
     }
   }
   else if (d->address != 0)

--- a/gum/backend-darwin/gumdarwinsymbolicator.c
+++ b/gum/backend-darwin/gumdarwinsymbolicator.c
@@ -388,7 +388,7 @@ gum_darwin_symbolicator_details_from_address (GumDarwinSymbolicator * self,
       GPOINTER_TO_SIZE (address), kCSNow);
   if (!CSIsNull (info))
   {
-    gchar * canonicalized = NULL;
+    gchar * canonicalized;
 
     canonicalized = g_canonicalize_filename (CSSourceInfoGetPath (info), "/");
     g_strlcpy (details->file_name, canonicalized, sizeof (details->file_name));

--- a/gum/backend-darwin/gumdarwinsymbolicator.c
+++ b/gum/backend-darwin/gumdarwinsymbolicator.c
@@ -152,9 +152,11 @@ GUM_DECLARE_CS_FUNC (SymbolOwnerGetName, const char *,
 GUM_DECLARE_CS_FUNC (SymbolOwnerGetBaseAddress, unsigned long long,
     (CSSymbolOwnerRef owner));
 
-GUM_DECLARE_CS_FUNC (SourceInfoGetFilename, const char *,
+GUM_DECLARE_CS_FUNC (SourceInfoGetPath, const char *,
     (CSSourceInfoRef info));
 GUM_DECLARE_CS_FUNC (SourceInfoGetLineNumber, int,
+    (CSSourceInfoRef info));
+GUM_DECLARE_CS_FUNC (SourceInfoGetColumn, int,
     (CSSourceInfoRef info));
 
 #undef GUM_DECLARE_CS_FUNC
@@ -386,14 +388,19 @@ gum_darwin_symbolicator_details_from_address (GumDarwinSymbolicator * self,
       GPOINTER_TO_SIZE (address), kCSNow);
   if (!CSIsNull (info))
   {
-    g_strlcpy (details->file_name, CSSourceInfoGetFilename (info),
-        sizeof (details->file_name));
+    gchar * canonicalized = NULL;
+
+    canonicalized = g_canonicalize_filename (CSSourceInfoGetPath (info), "/");
+    g_strlcpy (details->file_name, canonicalized, sizeof (details->file_name));
+    g_free (canonicalized);
     details->line_number = CSSourceInfoGetLineNumber (info);
+    details->column = CSSourceInfoGetColumn (info);
   }
   else
   {
     details->file_name[0] = '\0';
     details->line_number = 0;
+    details->column = 0;
   }
 
   return TRUE;
@@ -755,8 +762,9 @@ gum_cs_load_library (gpointer data)
   GUM_TRY_ASSIGN (SymbolOwnerGetName);
   GUM_TRY_ASSIGN (SymbolOwnerGetBaseAddress);
 
-  GUM_TRY_ASSIGN (SourceInfoGetFilename);
+  GUM_TRY_ASSIGN (SourceInfoGetPath);
   GUM_TRY_ASSIGN (SourceInfoGetLineNumber);
+  GUM_TRY_ASSIGN (SourceInfoGetColumn);
 
 #undef GUM_TRY_ASSIGN
 

--- a/gum/backend-dbghelp/gumsymbolutil-dbghelp.c
+++ b/gum/backend-dbghelp/gumsymbolutil-dbghelp.c
@@ -75,6 +75,7 @@ gum_symbol_details_from_address (gpointer address,
   {
     strcpy_s (details->file_name, sizeof (details->file_name), li.FileName);
     details->line_number = li.LineNumber;
+    details->column = displacement_dw;
   }
 
   dbghelp->Unlock ();

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -164,7 +164,7 @@ gum_symbol_details_from_address (gpointer address,
   Dwarf_Die cu_die;
   GumDwarfSymbolDetails symbol;
   GumDwarfSourceDetails source;
-  gchar * canonicalized = NULL;
+  gchar * canonicalized;
 
   success = FALSE;
 

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -204,8 +204,8 @@ gum_symbol_details_from_address (gpointer address,
 
   success = TRUE;
 
-  g_free (source.path);
   g_free (canonicalized);
+  g_free (source.path);
 
 line_not_found:
   g_free (symbol.name);

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -63,6 +63,7 @@ struct _GumDwarfSourceDetails
 {
   gchar * path;
   guint line_number;
+  guint column;
 };
 
 struct _GumFindCuDieOperation
@@ -163,6 +164,7 @@ gum_symbol_details_from_address (gpointer address,
   Dwarf_Die cu_die;
   GumDwarfSymbolDetails symbol;
   GumDwarfSourceDetails source;
+  gchar * canonicalized = NULL;
 
   success = FALSE;
 
@@ -195,12 +197,15 @@ gum_symbol_details_from_address (gpointer address,
       sizeof (details->module_name));
   g_strlcpy (details->symbol_name, symbol.name, sizeof (details->symbol_name));
 
-  g_strlcpy (details->file_name, source.path, sizeof (details->file_name));
+  canonicalized = g_canonicalize_filename (source.path, "/");
+  g_strlcpy (details->file_name, canonicalized, sizeof (details->file_name));
   details->line_number = source.line_number;
+  details->column = source.column;
 
   success = TRUE;
 
   g_free (source.path);
+  g_free (canonicalized);
 
 line_not_found:
   g_free (symbol.name);
@@ -918,7 +923,7 @@ gum_find_line_by_virtual_address (Dwarf_Debug dbg,
 
     if (line_address >= address)
     {
-      Dwarf_Unsigned line_number;
+      Dwarf_Unsigned line_number, column;
       char * path;
 
       if (dwarf_lineno (line, &line_number, NULL) != DW_DLV_OK)
@@ -927,11 +932,15 @@ gum_find_line_by_virtual_address (Dwarf_Debug dbg,
       if (line_number < symbol_line_number)
         continue;
 
+      if (dwarf_lineoff_b (line, &column, NULL) != DW_DLV_OK)
+        continue;
+
       if (dwarf_linesrc (line, &path, NULL) != DW_DLV_OK)
         continue;
 
       details->path = g_strdup (path);
       details->line_number = line_number;
+      details->column = column;
 
       success = TRUE;
 

--- a/gum/gumreturnaddress.c
+++ b/gum/gumreturnaddress.c
@@ -23,6 +23,7 @@ gum_return_address_details_from_address (GumReturnAddress address,
     strcpy (details->function_name, sd.symbol_name);
     strcpy (details->file_name, sd.file_name);
     details->line_number = sd.line_number;
+    details->column = sd.column;
 
     return TRUE;
   }

--- a/gum/gumreturnaddress.h
+++ b/gum/gumreturnaddress.h
@@ -20,6 +20,7 @@ struct _GumReturnAddressDetails
   gchar function_name[GUM_MAX_SYMBOL_NAME + 1];
   gchar file_name[GUM_MAX_PATH + 1];
   guint line_number;
+  guint column;
 };
 
 struct _GumReturnAddressArray

--- a/gum/gumsymbolutil.h
+++ b/gum/gumsymbolutil.h
@@ -20,6 +20,7 @@ struct _GumDebugSymbolDetails
   gchar symbol_name[GUM_MAX_SYMBOL_NAME + 1];
   gchar file_name[GUM_MAX_PATH + 1];
   guint line_number;
+  guint column;
 };
 
 G_BEGIN_DECLS

--- a/tests/core/backtracer.c
+++ b/tests/core/backtracer.c
@@ -55,6 +55,7 @@ TESTCASE (basics)
   g_assert_true (g_str_has_suffix (rad.file_name, "backtracer.c"));
   g_assert_true (rad.line_number == expected_line_number ||
       rad.line_number == expected_line_number + 1);
+  g_assert_true (rad.column == 3);
 #endif
 }
 
@@ -242,8 +243,8 @@ print_backtrace (GumReturnAddressArray * ret_addrs)
 
     if (gum_return_address_details_from_address (ra, &rad))
     {
-      g_print ("  %p %s!%s %s:%d\n", rad.address, rad.module_name,
-          rad.function_name, rad.file_name, rad.line_number);
+      g_print ("  %p %s!%s %s:%d:%d\n", rad.address, rad.module_name,
+          rad.function_name, rad.file_name, rad.line_number, rad.column);
     }
     else
     {

--- a/tests/core/backtracer.c
+++ b/tests/core/backtracer.c
@@ -55,7 +55,7 @@ TESTCASE (basics)
   g_assert_true (g_str_has_suffix (rad.file_name, "backtracer.c"));
   g_assert_true (rad.line_number == expected_line_number ||
       rad.line_number == expected_line_number + 1);
-  g_assert_true (rad.column == 3);
+  g_assert_cmpuint (rad.column, ==, 3);
 #endif
 }
 


### PR DESCRIPTION
The `file_name` field is now an absolute path on Darwin too, the `column` field has also been added to all existing backends.

`file_name` is now also canonicalized in darwin and libdwarf backends.