### PR TITLE
darwin-mapper: Fix macro declaration

### DIFF
--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -933,8 +933,12 @@ gum_darwin_mapper_alloc_and_emit_runtime (GumDarwinMapper * self,
   pc = base_address;
 
 #define GUM_ADVANCE_BY(n) \
-    cursor += n; \
-    pc += n
+    G_STMT_START \
+    { \
+      cursor += n; \
+      pc += n; \
+    } \
+    G_STMT_END
 
   self->apple_strv = pc;
 


### PR DESCRIPTION
The `GUM_ADVANCE_BY()` macro was missing a block scope. When it was used in the context of an `if()` also without scope, a misaligment could have occured between the `pc` and `cursor` offsets.

That happening on the chained symbols array of pointers could have caused the fixup processor to bind invalid pointers, leading to crashes.

When that happened while injecting `launchd`, it caused in turn a kernel panic on arm64e iOS.