### PR TITLE
Fix ARM Stalker handling of LDMIA without writeback

### DIFF
--- a/gum/arch-arm/gumarmwriter.c
+++ b/gum/arch-arm/gumarmwriter.c
@@ -635,7 +635,7 @@ gum_arm_writer_put_pop_regs (GumArmWriter * self,
 
   va_end (args);
 
-  gum_arm_writer_put_ldmia_reg_mask (self, ARM_REG_SP, mask);
+  gum_arm_writer_put_ldmia_reg_mask_wb (self, ARM_REG_SP, mask);
 }
 
 gboolean
@@ -779,6 +779,19 @@ gum_arm_writer_put_ldmia_reg_mask (GumArmWriter * self,
   GumArmRegInfo ri;
 
   gum_arm_reg_describe (reg, &ri);
+
+  gum_arm_writer_put_instruction (self, 0xe8900000 | (ri.index << 16) | mask);
+}
+
+void
+gum_arm_writer_put_ldmia_reg_mask_wb (GumArmWriter * self,
+                                      arm_reg reg,
+                                      guint16 mask)
+{
+  GumArmRegInfo ri;
+
+  gum_arm_reg_describe (reg, &ri);
+
   gum_arm_writer_put_instruction (self, 0xe8b00000 | (ri.index << 16) | mask);
 }
 

--- a/gum/arch-arm/gumarmwriter.h
+++ b/gum/arch-arm/gumarmwriter.h
@@ -111,6 +111,8 @@ GUM_API gboolean gum_arm_writer_put_ldr_cond_reg_reg_offset (
     gssize src_offset);
 GUM_API void gum_arm_writer_put_ldmia_reg_mask (GumArmWriter * self,
     arm_reg reg, guint16 mask);
+GUM_API void gum_arm_writer_put_ldmia_reg_mask_wb (GumArmWriter * self,
+    arm_reg reg, guint16 mask);
 GUM_API gboolean gum_arm_writer_put_str_reg_reg (GumArmWriter * self,
     arm_reg src_reg, arm_reg dst_reg);
 GUM_API gboolean gum_arm_writer_put_str_reg_reg_offset (GumArmWriter * self,

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -351,6 +351,7 @@ struct _GumBranchIndirectRegOffset
 {
   arm_reg reg;
   gssize offset;
+  gboolean write_back;
 };
 
 struct _GumBranchIndirectRegShift
@@ -3005,6 +3006,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
       value->reg = ARM_REG_SP;
       value->offset = 0;
+      value->write_back = TRUE;
 
       for (i = 0; i != insn->detail->arm.op_count; i++)
       {
@@ -3033,6 +3035,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
 
       value->reg = op1->reg;
       value->offset = 0;
+      value->write_back = insn->detail->arm.writeback;
 
       for (i = 1; i != insn->detail->arm.op_count; i++)
       {
@@ -3066,6 +3069,7 @@ gum_stalker_get_target_address (const cs_insn * insn,
         value->reg = op2->mem.base;
         g_assert (op2->mem.index == ARM_REG_INVALID);
         value->offset = op2->mem.disp;
+        value->write_back = FALSE;
       }
       else
       {
@@ -4586,27 +4590,21 @@ gum_exec_block_virtualize_arm_ret_insn (GumExecBlock * block,
   if (pop)
   {
     const GumBranchIndirectRegOffset * tv = &target->value.indirect_reg_offset;
-    guint displacement = 4;
-
     g_assert (target->type == GUM_TARGET_INDIRECT_REG_OFFSET);
 
     if (mask != 0)
     {
-      if (gum_count_bits_set (mask) == 1)
-      {
-        arm_reg target_register = ARM_REG_R0 + gum_count_trailing_zeros (mask);
-        gum_arm_writer_put_ldr_reg_reg_offset (gc->arm_writer, target_register,
-            tv->reg, 0);
-        displacement += 4;
-      }
+      if (tv->write_back)
+        gum_arm_writer_put_ldmia_reg_mask_wb (gc->arm_writer, tv->reg, mask);
       else
-      {
         gum_arm_writer_put_ldmia_reg_mask (gc->arm_writer, tv->reg, mask);
-      }
     }
 
-    gum_arm_writer_put_add_reg_reg_imm (gc->arm_writer, tv->reg, tv->reg,
-        displacement);
+    if (tv->write_back)
+    {
+      gum_arm_writer_put_add_reg_reg_imm (gc->arm_writer, tv->reg, tv->reg,
+          4);
+    }
   }
 
   gum_exec_block_write_arm_exec_generated_code (gc->arm_writer, block->ctx);

--- a/tests/core/arch-arm/armwriter.c
+++ b/tests/core/arch-arm/armwriter.c
@@ -14,6 +14,7 @@ TESTLIST_BEGIN (armwriter)
 #endif
   TESTENTRY (nop)
   TESTENTRY (ldmia_with_rn_in_reglist)
+  TESTENTRY (ldmia_with_rn_in_reglist_wb)
   TESTENTRY (vpush_range)
   TESTENTRY (vpop_range)
 TESTLIST_END ()
@@ -120,6 +121,43 @@ TESTCASE (ldmia_with_rn_in_reglist)
   mask |= 1 << ri.index;
 
   gum_arm_writer_put_ldmia_reg_mask (&fixture->aw, ARM_REG_SP, mask);
+  gum_arm_writer_flush (&fixture->aw);
+  /* pop {r4, r5, r6, r7, r8, sb, sl, fp, ip, sp, pc} */
+  assert_output_n_equals (0, 0xe89dbff0);
+}
+
+
+TESTCASE (ldmia_with_rn_in_reglist_wb)
+{
+  GumArmRegInfo ri;
+  guint16 mask = 0;
+
+  gum_arm_reg_describe (ARM_REG_R4, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R5, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R5, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R6, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R7, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R8, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R9, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R10, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R11, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_R12, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_SP, &ri);
+  mask |= 1 << ri.index;
+  gum_arm_reg_describe (ARM_REG_PC, &ri);
+  mask |= 1 << ri.index;
+
+  gum_arm_writer_put_ldmia_reg_mask_wb (&fixture->aw, ARM_REG_SP, mask);
   gum_arm_writer_flush (&fixture->aw);
   /* pop {r4, r5, r6, r7, r8, sb, sl, fp, ip, sp, pc} */
   assert_output_n_equals (0, 0xe8bdbff0);

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -68,6 +68,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (arm_ldr_pc_shift)
   TESTENTRY (arm_sub_pc)
   TESTENTRY (arm_add_pc)
+  TESTENTRY (arm_ldmia_pc)
 
   TESTENTRY (thumb_it_eq)
   TESTENTRY (thumb_it_al)
@@ -1776,6 +1777,25 @@ TESTCASE (arm_add_pc)
 
   GUM_ASSERT_EVENT_ADDR (block, INVOKEE_BLOCK_INDEX + 1, start, func + 16);
   GUM_ASSERT_EVENT_ADDR (block, INVOKEE_BLOCK_INDEX + 1, end, func + 24);
+}
+
+TESTCODE (arm_ldmia_pc,
+  0x0d, 0xc0, 0xa0, 0xe1, /* mov r12, sp */
+  0x78, 0xd8, 0x2d, 0xe9, /* stmdb sp!, {r3, r4, r5, r6, r11, r12, lr, pc} */
+  0x00, 0x00, 0x40, 0xe0, /* sub r0, r0, r0 */
+  0x78, 0xa8, 0x9d, 0xe8, /* ldmia sp, {r3, r4, r5, r6, r11, sp, pc} */
+);
+
+TESTCASE (arm_ldmia_pc)
+{
+  GumAddress func;
+
+  func = INVOKE_ARM_EXPECTING (GUM_BLOCK, arm_ldmia_pc, 0);
+
+  g_assert_cmpuint (fixture->sink->events->len, ==, INVOKER_BLOCK_COUNT);
+
+  GUM_ASSERT_EVENT_ADDR (block, INVOKEE_BLOCK_INDEX + 0, start, func);
+  GUM_ASSERT_EVENT_ADDR (block, INVOKEE_BLOCK_INDEX + 0, end, func + 16);
 }
 
 TESTCODE (thumb_it_eq,


### PR DESCRIPTION
Inspecting binaries generated with an old compiler (gcc 4.7.1), we can observer the following prologue...
```
cpy r12,sp
stmdb sp!,{r3, r4, r5, r6, r11, r12, lr, pc}
```

And the corresponding epilogue...
```
ldmia sp, {r3, r4, r5, r6, r11, sp, pc}
```

Note, however that the `ldmia` instruction for the epilogue is missing the `!`, hence although the value of `sp` is incremented after the load of the other registers from the stack, it is not written back! The instruction does however, modify `sp` since it is one of the registers being popped from the stack. The mnemonic here is quite confusing!

Stalker for ARM had a defect whereby it would incorrectly modify the `sp` when executing such an instruction.