### PR TITLE
Changes to add ability to run a function on a given thread

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -6141,3 +6141,18 @@ gum_count_trailing_zeros (guint16 value)
 }
 
 #endif
+
+gboolean
+gum_stalker_is_run_on_thread_supported (void)
+{
+  return FALSE;
+}
+
+void
+gum_stalker_run_on_thread_async (GumStalker * self,
+                                 GumThreadId thread_id,
+                                 GumStalkerRunOnThreadFunc func,
+                                 gpointer user_data)
+{
+  g_warning ("Stalker Run-On-Thread Unsupported");
+}

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -6161,7 +6161,7 @@ gum_stalker_is_run_on_thread_supported (void)
   return TRUE;
 }
 
-void
+gboolean
 gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumThreadId thread_id,
                                  GumStalkerRunOnThreadFunc func,
@@ -6171,7 +6171,8 @@ gum_stalker_run_on_thread_async (GumStalker * self,
   ctx.stalker = self;
   ctx.func = func;
   ctx.user_data = user_data;
-  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+  return gum_process_modify_thread (thread_id,
+      gum_stalker_do_run_on_thread_async, &ctx);
 }
 
 static void

--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -80,6 +80,8 @@ typedef guint GumBackpatchType;
 typedef gboolean (* GumCheckExcludedFunc) (GumExecCtx * ctx,
     gconstpointer address);
 
+typedef struct _GumStalkerRunOnThreadCtx GumStalkerRunOnThreadCtx;
+
 struct _GumStalker
 {
   GObject parent;
@@ -406,6 +408,13 @@ struct _GumBackpatch
   GumPrologState opened_prolog;
 };
 
+struct _GumStalkerRunOnThreadCtx
+{
+  GumStalker * stalker;
+  GumStalkerRunOnThreadFunc func;
+  gpointer user_data;
+};
+
 static void gum_stalker_finalize (GObject * object);
 
 G_GNUC_INTERNAL gpointer _gum_stalker_do_follow_me (GumStalker * self,
@@ -696,6 +705,9 @@ static gboolean gum_is_exclusive_store_insn (const cs_insn * insn);
 
 static guint gum_count_bits_set (guint16 value);
 static guint gum_count_trailing_zeros (guint16 value);
+
+static void gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+    GumCpuContext * cpu_context, gpointer user_data);
 
 G_DEFINE_TYPE (GumStalker, gum_stalker, G_TYPE_OBJECT)
 
@@ -6142,10 +6154,11 @@ gum_count_trailing_zeros (guint16 value)
 
 #endif
 
+
 gboolean
 gum_stalker_is_run_on_thread_supported (void)
 {
-  return FALSE;
+  return TRUE;
 }
 
 void
@@ -6154,5 +6167,76 @@ gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumStalkerRunOnThreadFunc func,
                                  gpointer user_data)
 {
-  g_warning ("Stalker Run-On-Thread Unsupported");
+  GumStalkerRunOnThreadCtx ctx;
+  ctx.stalker = self;
+  ctx.func = func;
+  ctx.user_data = user_data;
+  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+}
+
+static void
+gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+                                    GumCpuContext * cpu_context,
+                                    gpointer user_data)
+{
+  GumStalkerRunOnThreadCtx * run_ctx = (GumStalkerRunOnThreadCtx *) user_data;
+  GumStalker * self = run_ctx->stalker;
+  GumExecCtx * ctx;
+  guint32 pc;
+  GumArmWriter * cw;
+  GumAddress cpu_ctx;
+  guint32 infect_body;
+
+  if (gum_process_get_current_thread_id () == thread_id)
+  {
+    run_ctx->func (cpu_context, run_ctx->user_data);
+  }
+  else
+  {
+    ctx = gum_stalker_create_exec_ctx (self, thread_id, NULL, NULL);
+    if ((cpu_context->cpsr & GUM_PSR_T_BIT) == 0)
+      pc = cpu_context->pc;
+    else
+      pc = cpu_context->pc + 1;
+
+    gum_spinlock_acquire (&ctx->code_lock);
+
+    gum_stalker_thaw (self, ctx->thunks, self->thunks_size);
+    cw = &ctx->arm_writer;
+    gum_arm_writer_reset (cw, ctx->infect_thunk);
+
+    /* Copy the cpu context for the target thread. */
+    cpu_ctx = GUM_ADDRESS (gum_arm_writer_cur (cw));
+    gum_arm_writer_put_bytes (cw, (gpointer) cpu_context,
+        sizeof (GumCpuContext));
+
+    infect_body = GPOINTER_TO_SIZE (gum_arm_writer_cur (cw));
+
+    gum_exec_ctx_write_arm_prolog (ctx, cw);
+
+    gum_arm_writer_put_call_address_with_arguments (cw,
+        GUM_ADDRESS (run_ctx->func), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (cpu_ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (run_ctx->user_data));
+
+    gum_arm_writer_put_call_address_with_arguments (cw,
+        GUM_ADDRESS (gum_exec_ctx_unfollow), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (pc));
+
+    gum_exec_ctx_write_arm_epilog (ctx, cw);
+
+    gum_arm_writer_put_push_regs (cw, 2, ARM_REG_R0, ARM_REG_PC);
+    gum_arm_writer_put_ldr_reg_address (cw, ARM_REG_R0, GUM_ADDRESS (pc));
+    gum_arm_writer_put_str_reg_reg_offset (cw, ARM_REG_R0, ARM_REG_SP, 4);
+    gum_arm_writer_put_pop_regs (cw, 2, ARM_REG_R0, ARM_REG_PC);
+
+    gum_arm_writer_flush (cw);
+    gum_stalker_freeze (self, cw->base, gum_arm_writer_offset (cw));
+
+    gum_spinlock_release (&ctx->code_lock);
+
+    cpu_context->cpsr &= ~GUM_PSR_T_BIT;
+    cpu_context->pc = infect_body;
+  }
 }

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -84,6 +84,7 @@ typedef struct _GumBackpatchCall GumBackpatchCall;
 typedef struct _GumBackpatchJmp GumBackpatchJmp;
 typedef struct _GumBackpatchInlineCache GumBackpatchInlineCache;
 typedef struct _GumBackpatchExcludedCall GumBackpatchExcludedCall;
+typedef struct _GumStalkerRunOnThreadCtx GumStalkerRunOnThreadCtx;
 
 #ifdef HAVE_LINUX
 typedef struct _Unwind_Exception _Unwind_Exception;
@@ -476,6 +477,13 @@ struct _GumBackpatch
   };
 };
 
+struct _GumStalkerRunOnThreadCtx
+{
+  GumStalker * stalker;
+  GumStalkerRunOnThreadFunc func;
+  gpointer user_data;
+};
+
 #ifdef HAVE_LINUX
 
 extern _Unwind_Reason_Code __gxx_personality_v0 (int version,
@@ -753,6 +761,9 @@ static gpointer gum_slab_try_reserve (GumSlab * self, gsize size);
 static gpointer gum_find_thread_exit_implementation (void);
 
 static gboolean gum_is_bl_imm (guint32 insn) G_GNUC_UNUSED;
+
+static void gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+    GumCpuContext * cpu_context, gpointer user_data);
 
 G_DEFINE_TYPE (GumStalker, gum_stalker, G_TYPE_OBJECT)
 
@@ -5828,7 +5839,7 @@ gum_is_bl_imm (guint32 insn)
 gboolean
 gum_stalker_is_run_on_thread_supported (void)
 {
-  return FALSE;
+  return TRUE;
 }
 
 void
@@ -5837,5 +5848,73 @@ gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumStalkerRunOnThreadFunc func,
                                  gpointer user_data)
 {
-  g_warning ("Stalker Run-On-Thread Unsupported");
+  GumStalkerRunOnThreadCtx ctx;
+  ctx.stalker = self;
+  ctx.func = func;
+  ctx.user_data = user_data;
+  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+}
+
+static void
+gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+                                    GumCpuContext * cpu_context,
+                                    gpointer user_data)
+{
+  GumStalkerRunOnThreadCtx * run_ctx = (GumStalkerRunOnThreadCtx *) user_data;
+  GumStalker * self = run_ctx->stalker;
+  GumExecCtx * ctx;
+  guint8 * pc;
+  GumArm64Writer * cw;
+  GumAddress cpu_ctx;
+
+  if (gum_process_get_current_thread_id () == thread_id)
+  {
+    run_ctx->func (cpu_context, run_ctx->user_data);
+  }
+  else
+  {
+    ctx = gum_stalker_create_exec_ctx (self, thread_id, NULL, NULL);
+
+    pc = GSIZE_TO_POINTER (gum_strip_code_address (cpu_context->pc));
+
+    gum_spinlock_acquire (&ctx->code_lock);
+
+    gum_stalker_thaw (self, ctx->thunks, self->thunks_size);
+    cw = &ctx->code_writer;
+    gum_arm64_writer_reset (cw, ctx->infect_thunk);
+
+    /* Copy the cpu context for the target thread. */
+    cpu_ctx = GUM_ADDRESS (gum_arm64_writer_cur (cw));
+    gum_arm64_writer_put_bytes (cw, (gpointer) cpu_context,
+        sizeof (GumCpuContext));
+
+    ctx->infect_body = GUM_ADDRESS (gum_arm64_writer_cur (cw));
+
+#ifdef HAVE_PTRAUTH
+    ctx->infect_body = GPOINTER_TO_SIZE (ptrauth_sign_unauthenticated (
+        GSIZE_TO_POINTER (ctx->infect_body), ptrauth_key_process_independent_code,
+        ptrauth_string_discriminator ("pc")));
+#endif
+    gum_exec_ctx_write_prolog (ctx, GUM_PROLOG_MINIMAL, cw);
+
+    gum_arm64_writer_put_call_address_with_arguments (cw,
+        GUM_ADDRESS (run_ctx->func), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (cpu_ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (run_ctx->user_data));
+
+    gum_arm64_writer_put_call_address_with_arguments (cw,
+        GUM_ADDRESS (gum_exec_ctx_unfollow), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (pc));
+
+    gum_exec_ctx_write_epilog (ctx, GUM_PROLOG_MINIMAL, cw);
+    gum_arm64_writer_put_b_imm (cw, GUM_ADDRESS (pc));
+
+    gum_arm64_writer_flush (cw);
+    gum_stalker_freeze (self, cw->base, gum_arm64_writer_offset (cw));
+
+    gum_spinlock_release (&ctx->code_lock);
+
+    cpu_context->pc = ctx->infect_body;
+  }
 }

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -5842,7 +5842,7 @@ gum_stalker_is_run_on_thread_supported (void)
   return TRUE;
 }
 
-void
+gboolean
 gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumThreadId thread_id,
                                  GumStalkerRunOnThreadFunc func,
@@ -5852,7 +5852,8 @@ gum_stalker_run_on_thread_async (GumStalker * self,
   ctx.stalker = self;
   ctx.func = func;
   ctx.user_data = user_data;
-  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+  return gum_process_modify_thread (thread_id,
+      gum_stalker_do_run_on_thread_async, &ctx);
 }
 
 static void

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -5824,3 +5824,18 @@ gum_is_bl_imm (guint32 insn)
 }
 
 #endif
+
+gboolean
+gum_stalker_is_run_on_thread_supported (void)
+{
+  return FALSE;
+}
+
+void
+gum_stalker_run_on_thread_async (GumStalker * self,
+                                 GumThreadId thread_id,
+                                 GumStalkerRunOnThreadFunc func,
+                                 gpointer user_data)
+{
+  g_warning ("Stalker Run-On-Thread Unsupported");
+}

--- a/gum/backend-mips/gumstalker-mips.c
+++ b/gum/backend-mips/gumstalker-mips.c
@@ -202,3 +202,18 @@ gum_stalker_iterator_put_callout (GumStalkerIterator * self,
                                   GDestroyNotify data_destroy)
 {
 }
+
+gboolean
+gum_stalker_is_run_on_thread_supported (void)
+{
+  return FALSE;
+}
+
+void
+gum_stalker_run_on_thread_async (GumStalker * self,
+                                 GumThreadId thread_id,
+                                 GumStalkerRunOnThreadFunc func,
+                                 gpointer user_data)
+{
+  g_warning ("Stalker Run-On-Thread Unsupported");
+}

--- a/gum/backend-mips/gumstalker-mips.c
+++ b/gum/backend-mips/gumstalker-mips.c
@@ -209,11 +209,11 @@ gum_stalker_is_run_on_thread_supported (void)
   return FALSE;
 }
 
-void
+gboolean
 gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumThreadId thread_id,
                                  GumStalkerRunOnThreadFunc func,
                                  gpointer user_data)
 {
-  g_warning ("Stalker Run-On-Thread Unsupported");
+  return FALSE;
 }

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -110,6 +110,7 @@ typedef struct _GumBackpatchRet GumBackpatchRet;
 typedef struct _GumBackpatchJmp GumBackpatchJmp;
 typedef struct _GumBackpatchInlineCache GumBackpatchInlineCache;
 typedef struct _GumIcEntry GumIcEntry;
+typedef struct _GumStalkerRunOnThreadCtx GumStalkerRunOnThreadCtx;
 
 typedef guint GumVirtualizationRequirements;
 
@@ -544,6 +545,13 @@ struct _GumCheckElfSection
 
 #endif
 
+struct _GumStalkerRunOnThreadCtx
+{
+  GumStalker * stalker;
+  GumStalkerRunOnThreadFunc func;
+  gpointer user_data;
+};
+
 #if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
 
 extern _Unwind_Reason_Code __gxx_personality_v0 (int version,
@@ -865,6 +873,9 @@ static const guint8 gum_syscall_code[] = { 0x0f, 0x05 };
 static GumInterceptor * gum_exec_ctx_interceptor = NULL;
 # endif
 #endif
+
+static void gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+    GumCpuContext * cpu_context, gpointer user_data);
 
 gboolean
 gum_stalker_is_supported (void)
@@ -6627,3 +6638,78 @@ gum_store_thread_exit_match (GumAddress address,
 #endif
 
 #endif
+
+gboolean
+gum_stalker_is_run_on_thread_supported (void)
+{
+  return TRUE;
+}
+
+void
+gum_stalker_run_on_thread_async (GumStalker * self,
+                                 GumThreadId thread_id,
+                                 GumStalkerRunOnThreadFunc func,
+                                 gpointer user_data)
+{
+  GumStalkerRunOnThreadCtx ctx;
+  ctx.stalker = self;
+  ctx.func = func;
+  ctx.user_data = user_data;
+  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+}
+
+static void
+gum_stalker_do_run_on_thread_async (GumThreadId thread_id,
+                                    GumCpuContext * cpu_context,
+                                    gpointer user_data)
+{
+  GumStalkerRunOnThreadCtx * run_ctx = (GumStalkerRunOnThreadCtx *) user_data;
+  GumStalker * self = run_ctx->stalker;
+  GumExecCtx * ctx;
+  guint8 * pc;
+  GumX86Writer * cw;
+  GumAddress cpu_ctx;
+
+  if (gum_process_get_current_thread_id () == thread_id)
+  {
+    run_ctx->func (cpu_context, run_ctx->user_data);
+  }
+  else
+  {
+    ctx = gum_stalker_create_exec_ctx (self, thread_id, NULL, NULL);
+
+    pc = GSIZE_TO_POINTER (GUM_CPU_CONTEXT_XIP (cpu_context));
+
+    gum_spinlock_acquire (&ctx->code_lock);
+
+    gum_stalker_thaw (self, ctx->thunks, self->thunks_size);
+    cw = &ctx->code_writer;
+    gum_x86_writer_reset (cw, ctx->infect_thunk);
+
+    /* Copy the cpu context for the target thread. */
+    cpu_ctx = GUM_ADDRESS (gum_x86_writer_cur (cw));
+    gum_x86_writer_put_bytes (cw, (gpointer) cpu_context,
+        sizeof (GumCpuContext));
+
+    ctx->infect_body = GUM_ADDRESS (gum_x86_writer_cur (cw));
+    gum_exec_ctx_write_prolog (ctx, GUM_PROLOG_MINIMAL, cw);
+    gum_x86_writer_put_call_address_with_aligned_arguments (cw, GUM_CALL_CAPI,
+        GUM_ADDRESS (run_ctx->func), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (cpu_ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (run_ctx->user_data));
+    gum_x86_writer_put_call_address_with_aligned_arguments (cw, GUM_CALL_CAPI,
+        GUM_ADDRESS (gum_exec_ctx_unfollow), 2,
+        GUM_ARG_ADDRESS, GUM_ADDRESS (ctx),
+        GUM_ARG_ADDRESS, GUM_ADDRESS (pc));
+    gum_exec_ctx_write_epilog (ctx, GUM_PROLOG_MINIMAL, cw);
+
+    gum_x86_writer_put_jmp_address (cw, GUM_ADDRESS (pc));
+
+    gum_x86_writer_flush (cw);
+    gum_stalker_freeze (self, cw->base, gum_x86_writer_offset (cw));
+
+    gum_spinlock_release (&ctx->code_lock);
+
+    GUM_CPU_CONTEXT_XIP (cpu_context) = ctx->infect_body;
+  }
+}

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -6645,7 +6645,7 @@ gum_stalker_is_run_on_thread_supported (void)
   return TRUE;
 }
 
-void
+gboolean
 gum_stalker_run_on_thread_async (GumStalker * self,
                                  GumThreadId thread_id,
                                  GumStalkerRunOnThreadFunc func,
@@ -6655,7 +6655,8 @@ gum_stalker_run_on_thread_async (GumStalker * self,
   ctx.stalker = self;
   ctx.func = func;
   ctx.user_data = user_data;
-  gum_process_modify_thread (thread_id, gum_stalker_do_run_on_thread_async, &ctx);
+  return gum_process_modify_thread (thread_id,
+      gum_stalker_do_run_on_thread_async, &ctx);
 }
 
 static void

--- a/gum/gumstalker.c
+++ b/gum/gumstalker.c
@@ -8,6 +8,8 @@
 
 #include "gumstalker.h"
 
+typedef struct _RunOnThreadSyncCtx RunOnThreadSyncCtx;
+
 struct _GumDefaultStalkerTransformer
 {
   GObject parent;
@@ -20,6 +22,15 @@ struct _GumCallbackStalkerTransformer
   GumStalkerTransformerCallback callback;
   gpointer data;
   GDestroyNotify data_destroy;
+};
+
+struct _RunOnThreadSyncCtx
+{
+  GMutex mutex;
+  GCond cond;
+  volatile gboolean done;
+  GumStalkerRunOnThreadFunc func;
+  gpointer user_data;
 };
 
 static void gum_default_stalker_transformer_iface_init (gpointer g_iface,
@@ -37,6 +48,9 @@ static void gum_callback_stalker_transformer_transform_block (
 
 static void gum_stalker_observer_default_init (
     GumStalkerObserverInterface * iface);
+
+static void gum_stalker_do_run_on_thread_sync (
+    const GumCpuContext * cpu_context, gpointer user_data);
 
 G_DEFINE_INTERFACE (GumStalkerTransformer, gum_stalker_transformer,
                     G_TYPE_OBJECT)
@@ -410,4 +424,60 @@ gum_stalker_observer_switch_callback (GumStalkerObserver * observer,
       target);
 }
 
+void
+gum_stalker_run_on_thread_sync (GumStalker * self,
+                                GumThreadId thread_id,
+                                GumStalkerRunOnThreadFunc func,
+                                gpointer user_data)
+{
+  RunOnThreadSyncCtx ctx;
+
+  if (!gum_stalker_is_run_on_thread_supported ())
+  {
+    g_warning ("Stalker Run-On-Thread Unsupported");
+    return;
+  }
+
+  if (gum_process_get_current_thread_id () == thread_id)
+  {
+    gum_stalker_run_on_thread_async (self, thread_id, func, user_data);
+  }
+  else
+  {
+    g_mutex_init (&ctx.mutex);
+    g_cond_init (&ctx.cond);
+    ctx.done = FALSE;
+    ctx.func = func;
+    ctx.user_data = user_data;
+
+    g_mutex_lock (&ctx.mutex);
+    gum_stalker_run_on_thread_async (self, thread_id,
+        gum_stalker_do_run_on_thread_sync, &ctx);
+
+    while (!ctx.done)
+      g_cond_wait (&ctx.cond, &ctx.mutex);
+
+    g_mutex_unlock (&ctx.mutex);
+
+    g_cond_clear (&ctx.cond);
+    g_mutex_clear (&ctx.mutex);
+  }
+
+}
+
+static void
+gum_stalker_do_run_on_thread_sync (const GumCpuContext * cpu_context,
+                                   gpointer user_data)
+{
+  RunOnThreadSyncCtx * ctx = (RunOnThreadSyncCtx *) user_data;
+
+  ctx->func (cpu_context, ctx->user_data);
+
+  g_mutex_lock (&ctx->mutex);
+  ctx->done = TRUE;
+  g_cond_signal (&ctx->cond);
+  g_mutex_unlock (&ctx->mutex);
+}
+
 #endif
+

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -65,6 +65,8 @@ typedef guint GumProbeId;
 typedef struct _GumCallDetails GumCallDetails;
 typedef void (* GumCallProbeCallback) (GumCallDetails * details,
     gpointer user_data);
+typedef void (* GumStalkerRunOnThreadFunc) (const GumCpuContext * cpu_context,
+    gpointer user_data);
 
 #ifndef GUM_DIET
 
@@ -270,6 +272,14 @@ GUM_API void gum_stalker_observer_notify_backpatch (
 GUM_API void gum_stalker_observer_switch_callback (
     GumStalkerObserver * observer, gpointer from_address,
     gpointer start_address, gpointer from_insn, gpointer * target);
+
+GUM_API gboolean gum_stalker_is_run_on_thread_supported (void);
+
+GUM_API void gum_stalker_run_on_thread_async (GumStalker * self,
+    GumThreadId thread_id, GumStalkerRunOnThreadFunc func, gpointer user_data);
+
+GUM_API void gum_stalker_run_on_thread_sync (GumStalker * self,
+    GumThreadId thread_id, GumStalkerRunOnThreadFunc func, gpointer user_data);
 
 G_END_DECLS
 

--- a/gum/gumstalker.h
+++ b/gum/gumstalker.h
@@ -275,10 +275,10 @@ GUM_API void gum_stalker_observer_switch_callback (
 
 GUM_API gboolean gum_stalker_is_run_on_thread_supported (void);
 
-GUM_API void gum_stalker_run_on_thread_async (GumStalker * self,
+GUM_API gboolean gum_stalker_run_on_thread_async (GumStalker * self,
     GumThreadId thread_id, GumStalkerRunOnThreadFunc func, gpointer user_data);
 
-GUM_API void gum_stalker_run_on_thread_sync (GumStalker * self,
+GUM_API gboolean gum_stalker_run_on_thread_sync (GumStalker * self,
     GumThreadId thread_id, GumStalkerRunOnThreadFunc func, gpointer user_data);
 
 G_END_DECLS

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -3719,21 +3719,19 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-
-  gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
-      &ctx);
+  success = gum_stalker_run_on_thread_async (fixture->stalker, thread_id,
+      run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }
@@ -3742,20 +3740,19 @@ TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-  gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
-    &ctx);
+  success = gum_stalker_run_on_thread_sync (fixture->stalker, thread_id,
+    run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -123,7 +123,29 @@ TESTLIST_BEGIN (stalker)
 #ifdef HAVE_LINUX
   TESTENTRY (prefetch)
 #endif
+  TESTENTRY (run_on_thread_support)
+  TESTENTRY (run_on_thread_current_async)
+  TESTENTRY (run_on_thread_current_sync)
+  TESTENTRY (run_on_thread_other_async)
+  TESTENTRY (run_on_thread_other_sync)
 TESTLIST_END ()
+
+typedef struct _RunOnThreadCtx RunOnThreadCtx;
+typedef struct _TestThreadSyncData TestThreadSyncData;
+
+struct _RunOnThreadCtx
+{
+  GumThreadId thread_id;
+};
+
+struct _TestThreadSyncData
+{
+  GMutex mutex;
+  GCond cond;
+  volatile gboolean started;
+  volatile GumThreadId thread_id;
+  volatile gboolean * volatile done;
+};
 
 static gboolean store_range_of_test_runner (const GumModuleDetails * details,
     gpointer user_data);
@@ -185,6 +207,12 @@ static void prefetch_read_blocks (int fd, GHashTable * table);
 static GHashTable * prefetch_compiled = NULL;
 static GHashTable * prefetch_executed = NULL;
 #endif
+static void run_on_thread (const GumCpuContext * cpu_context,
+    gpointer user_data);
+static GThread * create_sleeping_dummy_thread_sync (volatile gboolean * done,
+    GumThreadId * thread_id);
+static gpointer sleeping_dummy (gpointer data);
+
 
 TESTCASE (trust_should_be_one_by_default)
 {
@@ -3678,3 +3706,124 @@ prefetch_read_blocks (int fd,
 }
 
 #endif
+
+TESTCASE (run_on_thread_support)
+{
+  gboolean supported = gum_stalker_is_run_on_thread_supported ();
+  g_assert_false (supported);
+}
+
+TESTCASE (run_on_thread_current_async)
+{
+  GumThreadId thread_id = gum_process_get_current_thread_id ();
+  RunOnThreadCtx ctx;
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+  gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
+    &ctx);
+}
+
+TESTCASE (run_on_thread_current_sync)
+{
+  GumThreadId thread_id = gum_process_get_current_thread_id ();
+  RunOnThreadCtx ctx;
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+  gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
+    &ctx);
+}
+
+static void
+run_on_thread (const GumCpuContext * cpu_context, gpointer user_data)
+{
+  RunOnThreadCtx * ctx = (RunOnThreadCtx *) user_data;
+  g_usleep (250000);
+  ctx->thread_id = gum_process_get_current_thread_id ();
+}
+
+TESTCASE (run_on_thread_other_async)
+{
+  GumThreadId other_id;
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  RunOnThreadCtx ctx;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+
+  thread = create_sleeping_dummy_thread_sync (&done, &other_id);
+  gum_stalker_run_on_thread_async (fixture->stalker, other_id, run_on_thread,
+    &ctx);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+TESTCASE (run_on_thread_other_sync)
+{
+  GumThreadId other_id;
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  RunOnThreadCtx ctx;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+
+  thread = create_sleeping_dummy_thread_sync (&done, &other_id);
+  gum_stalker_run_on_thread_sync (fixture->stalker, other_id, run_on_thread,
+    &ctx);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+static GThread *
+create_sleeping_dummy_thread_sync (volatile gboolean * done,
+                                   GumThreadId * thread_id)
+{
+  TestThreadSyncData sync_data;
+  GThread * thread;
+
+  g_mutex_init (&sync_data.mutex);
+  g_cond_init (&sync_data.cond);
+  sync_data.started = FALSE;
+  sync_data.thread_id = 0;
+  sync_data.done = done;
+
+  g_mutex_lock (&sync_data.mutex);
+
+  thread = g_thread_new ("sleepy", sleeping_dummy, &sync_data);
+
+  while (!sync_data.started)
+    g_cond_wait (&sync_data.cond, &sync_data.mutex);
+
+  if (thread_id != NULL)
+    *thread_id = sync_data.thread_id;
+
+  g_mutex_unlock (&sync_data.mutex);
+
+  g_cond_clear (&sync_data.cond);
+  g_mutex_clear (&sync_data.mutex);
+
+  return thread;
+}
+
+static gpointer
+sleeping_dummy (gpointer data)
+{
+  TestThreadSyncData * sync_data = data;
+  volatile gboolean * done = sync_data->done;
+
+  g_mutex_lock (&sync_data->mutex);
+  sync_data->started = TRUE;
+  sync_data->thread_id = gum_process_get_current_thread_id ();
+  g_cond_signal (&sync_data->cond);
+  g_mutex_unlock (&sync_data->mutex);
+
+  while (!(*done))
+    g_thread_yield ();
+
+  return NULL;
+}

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -3719,20 +3719,45 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
+
   gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
       &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
   gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
     &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 static void

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -75,7 +75,15 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (prefetch)
   TESTENTRY (observer)
 #endif
+  TESTENTRY (run_on_thread_support)
+  TESTENTRY (run_on_thread_current_async)
+  TESTENTRY (run_on_thread_current_sync)
+  TESTENTRY (run_on_thread_other_async)
+  TESTENTRY (run_on_thread_other_sync)
 TESTLIST_END ()
+
+typedef struct _RunOnThreadCtx RunOnThreadCtx;
+typedef struct _TestThreadSyncData TestThreadSyncData;
 
 #ifdef HAVE_LINUX
 
@@ -87,6 +95,20 @@ struct _GumTestStalkerObserver
 };
 
 #endif
+
+struct _RunOnThreadCtx
+{
+  GumThreadId thread_id;
+};
+
+struct _TestThreadSyncData
+{
+  GMutex mutex;
+  GCond cond;
+  volatile gboolean started;
+  volatile GumThreadId thread_id;
+  volatile gboolean * volatile done;
+};
 
 static void insert_extra_add_after_sub (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
@@ -152,6 +174,11 @@ G_DEFINE_TYPE_EXTENDED (GumTestStalkerObserver,
                         G_IMPLEMENT_INTERFACE (GUM_TYPE_STALKER_OBSERVER,
                             gum_test_stalker_observer_iface_init))
 #endif
+static void run_on_thread (const GumCpuContext * cpu_context,
+    gpointer user_data);
+static GThread * create_sleeping_dummy_thread_sync (volatile gboolean * done,
+    GumThreadId * thread_id);
+static gpointer sleeping_dummy (gpointer data);
 
 static const guint32 flat_code[] = {
     0xcb000000, /* sub w0, w0, w0 */
@@ -2256,3 +2283,124 @@ gum_test_stalker_observer_increment_total (GumStalkerObserver * observer)
 }
 
 #endif
+
+TESTCASE (run_on_thread_support)
+{
+  gboolean supported = gum_stalker_is_run_on_thread_supported ();
+  g_assert_false (supported);
+}
+
+TESTCASE (run_on_thread_current_async)
+{
+  GumThreadId thread_id = gum_process_get_current_thread_id ();
+  RunOnThreadCtx ctx;
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+  gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
+      &ctx);
+}
+
+TESTCASE (run_on_thread_current_sync)
+{
+  GumThreadId thread_id = gum_process_get_current_thread_id ();
+  RunOnThreadCtx ctx;
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+  gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
+      &ctx);
+}
+
+static void
+run_on_thread (const GumCpuContext * cpu_context, gpointer user_data)
+{
+  RunOnThreadCtx * ctx = (RunOnThreadCtx *) user_data;
+  g_usleep (250000);
+  ctx->thread_id = gum_process_get_current_thread_id ();
+}
+
+TESTCASE (run_on_thread_other_async)
+{
+  GumThreadId other_id;
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  RunOnThreadCtx ctx;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+
+  thread = create_sleeping_dummy_thread_sync (&done, &other_id);
+  gum_stalker_run_on_thread_async (fixture->stalker, other_id, run_on_thread,
+      &ctx);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+TESTCASE (run_on_thread_other_sync)
+{
+  GumThreadId other_id;
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  RunOnThreadCtx ctx;
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+
+  thread = create_sleeping_dummy_thread_sync (&done, &other_id);
+  gum_stalker_run_on_thread_sync (fixture->stalker, other_id, run_on_thread,
+    &ctx);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+static GThread *
+create_sleeping_dummy_thread_sync (volatile gboolean * done,
+                                   GumThreadId * thread_id)
+{
+  TestThreadSyncData sync_data;
+  GThread * thread;
+
+  g_mutex_init (&sync_data.mutex);
+  g_cond_init (&sync_data.cond);
+  sync_data.started = FALSE;
+  sync_data.thread_id = 0;
+  sync_data.done = done;
+
+  g_mutex_lock (&sync_data.mutex);
+
+  thread = g_thread_new ("sleepy", sleeping_dummy, &sync_data);
+
+  while (!sync_data.started)
+    g_cond_wait (&sync_data.cond, &sync_data.mutex);
+
+  if (thread_id != NULL)
+    *thread_id = sync_data.thread_id;
+
+  g_mutex_unlock (&sync_data.mutex);
+
+  g_cond_clear (&sync_data.cond);
+  g_mutex_clear (&sync_data.mutex);
+
+  return thread;
+}
+
+static gpointer
+sleeping_dummy (gpointer data)
+{
+  TestThreadSyncData * sync_data = data;
+  volatile gboolean * done = sync_data->done;
+
+  g_mutex_lock (&sync_data->mutex);
+  sync_data->started = TRUE;
+  sync_data->thread_id = gum_process_get_current_thread_id ();
+  g_cond_signal (&sync_data->cond);
+  g_mutex_unlock (&sync_data->mutex);
+
+  while (!(*done))
+    g_thread_yield ();
+
+  return NULL;
+}

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -2296,21 +2296,19 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-
-  gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
-      &ctx);
+  success = gum_stalker_run_on_thread_async (fixture->stalker, thread_id,
+      run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }
@@ -2319,21 +2317,19 @@ TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-
-  gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
-    &ctx);
+  success = gum_stalker_run_on_thread_sync (fixture->stalker, thread_id,
+      run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -2296,20 +2296,46 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
+
   gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
       &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
+
   gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
     &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 static void

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -75,11 +75,13 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (prefetch)
   TESTENTRY (observer)
 #endif
-  TESTENTRY (run_on_thread_support)
-  TESTENTRY (run_on_thread_current_async)
-  TESTENTRY (run_on_thread_current_sync)
-  TESTENTRY (run_on_thread_other_async)
-  TESTENTRY (run_on_thread_other_sync)
+  TESTGROUP_BEGIN ("RunOnThread")
+    TESTENTRY (run_on_thread_support)
+    TESTENTRY (run_on_thread_current_async)
+    TESTENTRY (run_on_thread_current_sync)
+    TESTENTRY (run_on_thread_other_async)
+    TESTENTRY (run_on_thread_other_sync)
+  TESTGROUP_END ()
 TESTLIST_END ()
 
 typedef struct _RunOnThreadCtx RunOnThreadCtx;
@@ -2287,31 +2289,27 @@ gum_test_stalker_observer_increment_total (GumStalkerObserver * observer)
 TESTCASE (run_on_thread_support)
 {
   gboolean supported = gum_stalker_is_run_on_thread_supported ();
-  g_assert_false (supported);
+  g_assert_true (supported);
 }
 
 TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
-#if !defined (HAVE_I386)
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-      "Stalker Run-On-Thread Unsupported");
-#endif
   gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
       &ctx);
+
+  g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 }
 
 TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
-#if !defined (HAVE_I386)
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-      "Stalker Run-On-Thread Unsupported");
-#endif
   gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
-      &ctx);
+    &ctx);
+
+  g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 }
 
 static void
@@ -2324,12 +2322,12 @@ run_on_thread (const GumCpuContext * cpu_context, gpointer user_data)
 
 TESTCASE (run_on_thread_other_async)
 {
-  GumThreadId other_id;
+  GumThreadId this_id, other_id;
   volatile gboolean done = FALSE;
   GThread * thread;
   RunOnThreadCtx ctx;
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-      "Stalker Run-On-Thread Unsupported");
+
+  this_id = gum_process_get_current_thread_id ();
 
   thread = create_sleeping_dummy_thread_sync (&done, &other_id);
   gum_stalker_run_on_thread_async (fixture->stalker, other_id, run_on_thread,
@@ -2337,16 +2335,18 @@ TESTCASE (run_on_thread_other_async)
 
   done = TRUE;
   g_thread_join (thread);
+  g_assert_cmpuint (this_id, !=, other_id);
+  g_assert_cmpuint (other_id, ==, ctx.thread_id);
 }
 
 TESTCASE (run_on_thread_other_sync)
 {
-  GumThreadId other_id;
+  GumThreadId this_id, other_id;
   volatile gboolean done = FALSE;
   GThread * thread;
   RunOnThreadCtx ctx;
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-      "Stalker Run-On-Thread Unsupported");
+
+  this_id = gum_process_get_current_thread_id ();
 
   thread = create_sleeping_dummy_thread_sync (&done, &other_id);
   gum_stalker_run_on_thread_sync (fixture->stalker, other_id, run_on_thread,
@@ -2354,6 +2354,8 @@ TESTCASE (run_on_thread_other_sync)
 
   done = TRUE;
   g_thread_join (thread);
+  g_assert_cmpuint (this_id, !=, other_id);
+  g_assert_cmpuint (other_id, ==, ctx.thread_id);
 }
 
 static GThread *

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -119,11 +119,13 @@ TESTLIST_BEGIN (stalker)
     TESTENTRY (try_and_dont_catch_excluded)
   TESTGROUP_END ()
 #endif
-  TESTENTRY (run_on_thread_support)
-  TESTENTRY (run_on_thread_current_async)
-  TESTENTRY (run_on_thread_current_sync)
-  TESTENTRY (run_on_thread_other_async)
-  TESTENTRY (run_on_thread_other_sync)
+  TESTGROUP_BEGIN ("RunOnThread")
+    TESTENTRY (run_on_thread_support)
+    TESTENTRY (run_on_thread_current_async)
+    TESTENTRY (run_on_thread_current_sync)
+    TESTENTRY (run_on_thread_other_async)
+    TESTENTRY (run_on_thread_other_sync)
+  TESTGROUP_END ()
 TESTLIST_END ()
 
 #ifdef HAVE_LINUX

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -3474,20 +3474,46 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
+
   gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
       &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+
+  ctx.thread_id = 0xdeadc0de;
+
   gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
     &ctx);
 
+#if defined (HAVE_ANDROID)
+  /*
+   * getcontext/setcontext is not supported on the musl C-runtime (or Android),
+   * therefore `gum_process_modify_thread` does not call the callback provided
+   * when the thread_id is that of the current thread. Thus our call above is
+   * inert.
+   */
+  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+#else
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
+#endif
 }
 
 static void

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -3474,21 +3474,19 @@ TESTCASE (run_on_thread_current_async)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-
-  gum_stalker_run_on_thread_async (fixture->stalker, thread_id, run_on_thread,
-      &ctx);
+  success = gum_stalker_run_on_thread_async (fixture->stalker, thread_id,
+      run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }
@@ -3497,21 +3495,19 @@ TESTCASE (run_on_thread_current_sync)
 {
   GumThreadId thread_id = gum_process_get_current_thread_id ();
   RunOnThreadCtx ctx;
+  gboolean success;
 
-  ctx.thread_id = 0xdeadc0de;
-
-  gum_stalker_run_on_thread_sync (fixture->stalker, thread_id, run_on_thread,
-    &ctx);
+  success = gum_stalker_run_on_thread_sync (fixture->stalker, thread_id,
+      run_on_thread, &ctx);
 
 #if defined (HAVE_ANDROID)
   /*
    * getcontext/setcontext is not supported on the musl C-runtime (or Android),
-   * therefore `gum_process_modify_thread` does not call the callback provided
-   * when the thread_id is that of the current thread. Thus our call above is
-   * inert.
+   * therefore `gum_process_modify_thread` fails.
    */
-  g_assert_cmpuint (0xdeadc0de, ==, ctx.thread_id);
+  g_assert_false (success);
 #else
+  g_assert_true (success);
   g_assert_cmpuint (thread_id, ==, ctx.thread_id);
 #endif
 }

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -194,6 +194,9 @@ TESTLIST_BEGIN (script)
     TESTENTRY (process_malloc_ranges_can_be_enumerated)
     TESTENTRY (process_malloc_ranges_can_be_enumerated_legacy_style)
 #endif
+  TESTGROUP_END ()
+
+  TESTGROUP_BEGIN ("RunOnThread")
     TESTENTRY (process_can_run_on_thread_sync)
     TESTENTRY (process_can_run_on_thread_async)
   TESTGROUP_END ()
@@ -5305,10 +5308,8 @@ TESTCASE (process_can_run_on_thread_sync)
       "send (out_val)",
       thread_id);
 
-#if defined (HAVE_I386)
   EXPECT_SEND_MESSAGE_WITH ("1338");
   EXPECT_SEND_MESSAGE_WITH ("1339");
-#endif
 
   done = TRUE;
   g_thread_join (thread);
@@ -5345,9 +5346,7 @@ TESTCASE (process_can_run_on_thread_async)
       "run();",
       thread_id);
 
-#if defined (HAVE_I386)
   EXPECT_SEND_MESSAGE_WITH ("1338");
-#endif
 
   done = TRUE;
   g_thread_join (thread);

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -194,6 +194,8 @@ TESTLIST_BEGIN (script)
     TESTENTRY (process_malloc_ranges_can_be_enumerated)
     TESTENTRY (process_malloc_ranges_can_be_enumerated_legacy_style)
 #endif
+    TESTENTRY (process_can_run_on_thread_sync)
+    TESTENTRY (process_can_run_on_thread_async)
   TESTGROUP_END ()
 
   TESTGROUP_BEGIN ("Module")
@@ -473,6 +475,7 @@ TESTLIST_END ()
 typedef struct _GumInvokeTargetContext GumInvokeTargetContext;
 typedef struct _GumCrashExceptorContext GumCrashExceptorContext;
 typedef struct _TestTrigger TestTrigger;
+typedef struct _TestRunOnThreadSyncContext TestRunOnThreadSyncContext;
 
 struct _GumInvokeTargetContext
 {
@@ -494,6 +497,15 @@ struct _TestTrigger
   volatile gboolean fired;
   GMutex mutex;
   GCond cond;
+};
+
+struct _TestRunOnThreadSyncContext
+{
+  GMutex mutex;
+  GCond cond;
+  volatile gboolean started;
+  volatile GumThreadId thread_id;
+  volatile gboolean * volatile done;
 };
 
 static size_t gum_get_size_max (void);
@@ -534,6 +546,9 @@ static gpointer run_stalked_through_target_function (gpointer data);
 #endif
 
 static gpointer sleeping_dummy (gpointer data);
+static GThread * create_sleeping_dummy_thread_sync (volatile gboolean * done,
+    GumThreadId * thread_id);
+static gpointer sleeping_dummy_func (gpointer data);
 
 static gpointer invoke_target_function_int_worker (gpointer data);
 static gpointer invoke_target_function_trigger (gpointer data);
@@ -5264,6 +5279,129 @@ TESTCASE (process_malloc_ranges_can_be_enumerated_legacy_style)
 }
 
 #endif
+
+TESTCASE (process_can_run_on_thread_sync)
+{
+  GThread * thread;
+  GumThreadId thread_id;
+  volatile gboolean done = FALSE;
+
+  thread = create_sleeping_dummy_thread_sync (&done, &thread_id);
+
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const threads = Process.enumerateThreads();"
+      "const thread = threads.find(t => t.id == " GUM_PTR_CONST ");"
+      "const data = 1338;"
+      "var out_val = 0;"
+      "const ret = Process.runOnThreadSync(thread.id, function (ctx) {"
+      "  send (data);"
+      "  out_val = 1339;"
+      "});"
+      "send (out_val)",
+      thread_id);
+
+#if defined (HAVE_I386)
+  EXPECT_SEND_MESSAGE_WITH ("1338");
+  EXPECT_SEND_MESSAGE_WITH ("1339");
+#endif
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+TESTCASE (process_can_run_on_thread_async)
+{
+  GThread * thread;
+  GumThreadId thread_id;
+  volatile gboolean done = FALSE;
+
+  thread = create_sleeping_dummy_thread_sync (&done, &thread_id);
+
+#if !defined (HAVE_I386)
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+      "Stalker Run-On-Thread Unsupported");
+#endif
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "async function run () {"
+      "  const threads = Process.enumerateThreads();"
+      "  const thread = threads.find(t => t.id == " GUM_PTR_CONST ");"
+      "  const data = 1338;"
+      "  let res;"
+      "  const prom = new Promise (function (resolve, reject) {"
+      "    res = resolve;"
+      "  });"
+      "  const ret = Process.runOnThreadAsync(thread.id, function (ctx) {"
+      "    send (data);"
+      "    res();"
+      "  });"
+      "  await prom;"
+      "};"
+      "run();",
+      thread_id);
+
+#if defined (HAVE_I386)
+  EXPECT_SEND_MESSAGE_WITH ("1338");
+#endif
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+static GThread *
+create_sleeping_dummy_thread_sync (volatile gboolean * done,
+                                   GumThreadId * thread_id)
+{
+  TestRunOnThreadSyncContext sync_data;
+  GThread * thread;
+
+  g_mutex_init (&sync_data.mutex);
+  g_cond_init (&sync_data.cond);
+  sync_data.started = FALSE;
+  sync_data.thread_id = 0;
+  sync_data.done = done;
+
+  g_mutex_lock (&sync_data.mutex);
+
+  thread = g_thread_new ("process-test-sleeping-dummy-func",
+      sleeping_dummy_func, &sync_data);
+
+  while (!sync_data.started)
+    g_cond_wait (&sync_data.cond, &sync_data.mutex);
+
+  if (thread_id != NULL)
+    *thread_id = sync_data.thread_id;
+
+  g_mutex_unlock (&sync_data.mutex);
+
+  g_cond_clear (&sync_data.cond);
+  g_mutex_clear (&sync_data.mutex);
+
+  return thread;
+}
+
+static gpointer
+sleeping_dummy_func (gpointer data)
+{
+  TestRunOnThreadSyncContext * sync_data = data;
+  volatile gboolean * done = sync_data->done;
+
+  g_mutex_lock (&sync_data->mutex);
+  sync_data->started = TRUE;
+  sync_data->thread_id = gum_process_get_current_thread_id ();
+  g_cond_signal (&sync_data->cond);
+  g_mutex_unlock (&sync_data->mutex);
+
+  while (!(*done))
+    g_thread_yield ();
+
+  return NULL;
+}
 
 TESTCASE (process_system_ranges_can_be_enumerated)
 {


### PR DESCRIPTION
...on x86/64.

A complete rework of the original PR. https://github.com/frida/frida-gum/pull/559
This solution instead uses the Stalker backend (and its associated prologues/epilogues) to do any heavy lifting. As such the architecture specific code is tiny (see here https://github.com/MissingFuzz/frida-gum/blob/5590a49c94ee138c0c76cd35e33b953766d46a1e/gum/backend-x86/gumstalker-x86.c#L6642). Almost all of this commit is unit tests.

