### PR TITLE
Thread time

### DIFF
--- a/bindings/gumjs/gumquickthread.c
+++ b/bindings/gumjs/gumquickthread.c
@@ -17,11 +17,13 @@ enum _GumBacktracerType
 
 GUMJS_DECLARE_FUNCTION (gumjs_thread_backtrace)
 GUMJS_DECLARE_FUNCTION (gumjs_thread_sleep)
+GUMJS_DECLARE_FUNCTION (gumjs_thread_get_user_time)
 
 static const JSCFunctionListEntry gumjs_thread_entries[] =
 {
   JS_CFUNC_DEF ("_backtrace", 0, gumjs_thread_backtrace),
   JS_CFUNC_DEF ("sleep", 0, gumjs_thread_sleep),
+  JS_CFUNC_DEF ("getUserTime", 0, gumjs_thread_get_user_time),
 };
 
 static const JSCFunctionListEntry gumjs_backtracer_entries[] =
@@ -159,3 +161,11 @@ GUMJS_DEFINE_FUNCTION (gumjs_thread_sleep)
 
   return JS_UNDEFINED;
 }
+
+GUMJS_DEFINE_FUNCTION (gumjs_thread_get_user_time)
+{
+  guint64 user_time = gum_thead_get_user_time ();
+
+  return JS_NewFloat64 (ctx, ((double) user_time) / G_USEC_PER_SEC);
+}
+

--- a/bindings/gumjs/gumv8thread.cpp
+++ b/bindings/gumjs/gumv8thread.cpp
@@ -15,11 +15,13 @@ using namespace v8;
 
 GUMJS_DECLARE_FUNCTION (gumjs_thread_backtrace)
 GUMJS_DECLARE_FUNCTION (gumjs_thread_sleep)
+GUMJS_DECLARE_FUNCTION (gumjs_thread_get_user_time)
 
 static const GumV8Function gumjs_thread_functions[] =
 {
   { "_backtrace", gumjs_thread_backtrace },
   { "sleep", gumjs_thread_sleep },
+  { "getUserTime", gumjs_thread_get_user_time},
 
   { NULL, NULL }
 };
@@ -171,3 +173,11 @@ GUMJS_DEFINE_FUNCTION (gumjs_thread_sleep)
     g_usleep (delay * G_USEC_PER_SEC);
   }
 }
+
+GUMJS_DEFINE_FUNCTION (gumjs_thread_get_user_time)
+{
+  guint64 user_time = gum_thead_get_user_time ();
+
+  info.GetReturnValue ().Set ((double) user_time / G_USEC_PER_SEC);
+}
+

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -686,6 +686,24 @@ failure:
 #endif
 }
 
+guint64
+gum_thead_get_user_time (void)
+{
+  mach_port_t port;
+  thread_basic_info_data_t info;
+  mach_msg_type_number_t info_count = THREAD_BASIC_INFO_COUNT;
+  G_GNUC_UNUSED kern_return_t kr;
+
+  port = mach_thread_self ();
+  kr = thread_info (port, THREAD_BASIC_INFO,
+      (thread_info_t) &info, &info_count);
+  g_assert (kr == KERN_SUCCESS);
+  mach_port_deallocate (mach_task_self (), port);
+
+  return ((guint64) info.user_time.seconds * G_USEC_PER_SEC) +
+      info.user_time.microseconds;
+}
+
 gboolean
 gum_module_load (const gchar * module_name,
                  GError ** error)

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -20,6 +20,7 @@
 #include <ucontext.h>
 #include <unistd.h>
 #include <sys/ptrace.h>
+#include <sys/resource.h>
 #include <sys/sysctl.h>
 #include <sys/thr.h>
 #include <sys/types.h>
@@ -714,6 +715,21 @@ failure:
     g_set_error (error, GUM_ERROR, GUM_ERROR_FAILED, "%s", g_strerror (errno));
     return FALSE;
   }
+}
+
+guint64
+gum_thead_get_user_time (void)
+{
+  guint64 user_time = 0;
+  struct rusage usage;
+
+  if (getrusage (RUSAGE_THREAD, &usage) == 0)
+  {
+    user_time = (usage.ru_utime.tv_sec * G_USEC_PER_SEC)
+      + usage.ru_utime.tv_usec;
+  }
+
+  return user_time;
 }
 
 gboolean

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -48,6 +48,8 @@
 #ifdef HAVE_SYS_USER_H
 # include <sys/user.h>
 #endif
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #define GUM_PAGE_START(value, page_size) \
     (GUM_ADDRESS (value) & ~GUM_ADDRESS (page_size - 1))
@@ -86,6 +88,9 @@
 #endif
 #ifndef NT_PRSTATUS
 # define NT_PRSTATUS 1
+#endif
+#ifndef RUSAGE_THREAD
+# define RUSAGE_THREAD 1
 #endif
 
 #define GUM_TEMP_FAILURE_RETRY(expression) \
@@ -1546,6 +1551,26 @@ failure:
     g_set_error (error, GUM_ERROR, GUM_ERROR_FAILED, "%s", g_strerror (errno));
     return FALSE;
   }
+}
+
+/**
+ * gum_thead_get_user_time:
+ *
+ * Returns: the time the thread has spend executing in user-mode in micro-seconds
+ */
+guint64
+gum_thead_get_user_time (void)
+{
+  guint64 user_time = 0;
+  struct rusage usage;
+
+  if (getrusage (RUSAGE_THREAD, &usage) == 0)
+  {
+    user_time = (usage.ru_utime.tv_sec * G_USEC_PER_SEC)
+      + usage.ru_utime.tv_usec;
+  }
+
+  return user_time;
 }
 
 gboolean

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -508,6 +508,12 @@ failure:
   }
 }
 
+guint64
+gum_thead_get_user_time (void)
+{
+  return 0;
+}
+
 gboolean
 gum_module_load (const gchar * module_name,
                  GError ** error)

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -9,6 +9,7 @@
 
 #include "gum-init.h"
 #include "gumcloak.h"
+#include "gumstalker.h"
 
 typedef struct _GumEmitThreadsContext GumEmitThreadsContext;
 typedef struct _GumResolveModulePointerContext GumResolveModulePointerContext;

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -230,6 +230,7 @@ GUM_API gint gum_thread_get_system_error (void);
 GUM_API void gum_thread_set_system_error (gint value);
 GUM_API gboolean gum_thread_suspend (GumThreadId thread_id, GError ** error);
 GUM_API gboolean gum_thread_resume (GumThreadId thread_id, GError ** error);
+GUM_API guint64 gum_thead_get_user_time (void);
 GUM_API gboolean gum_module_load (const gchar * module_name, GError ** error);
 GUM_API gboolean gum_module_ensure_initialized (const gchar * module_name);
 GUM_API void gum_module_enumerate_imports (const gchar * module_name,


### PR DESCRIPTION
Please note that this PR also contains the following:
* https://github.com/frida/frida-gum/pull/762

This is because the RunOnThread functionality is necessary for it to function.
This PR adds support for reading user_time (the time the CPU has spent executing in user-mode in microseconds) on Linux and Android based systems. Similar support for other systems should be relatively straightforward, but aren't included in this PR.