### PR TITLE
process: Expose thread names via enumerate_threads()

### DIFF
--- a/bindings/gumjs/gumquickprocess.c
+++ b/bindings/gumjs/gumquickprocess.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2023 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -291,6 +292,13 @@ gum_emit_thread (const GumThreadDetails * details,
       GUM_QUICK_CORE_ATOM (core, id),
       JS_NewInt64 (ctx, details->id),
       JS_PROP_C_W_E);
+  if (details->name != NULL)
+  {
+    JS_DefinePropertyValue (ctx, thread,
+        GUM_QUICK_CORE_ATOM (core, name),
+        JS_NewString (ctx, details->name),
+        JS_PROP_C_W_E);
+  }
   JS_DefinePropertyValue (ctx, thread,
       GUM_QUICK_CORE_ATOM (core, state),
       _gum_quick_thread_state_new (ctx, details->state),

--- a/bindings/gumjs/gumv8process.cpp
+++ b/bindings/gumjs/gumv8process.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2023 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -251,6 +252,8 @@ gum_emit_thread (const GumThreadDetails * details,
 
   auto thread = Object::New (isolate);
   _gum_v8_object_set (thread, "id", Number::New (isolate, details->id), core);
+  if (details->name != NULL)
+    _gum_v8_object_set_utf8 (thread, "name", details->name, core);
   _gum_v8_object_set (thread, "state", _gum_v8_string_new_ascii (isolate,
       _gum_v8_thread_state_to_string (details->state)), core);
   auto cpu_context =

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2022-2024 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -408,6 +408,7 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
     GumThreadDetails details;
 
     details.id = p->ki_tid;
+    details.name = (p->ki_tdname[0] != '\0') ? p->ki_tdname : NULL;
     details.state = gum_thread_state_from_proc (p);
     if (!gum_process_modify_thread (details.id, gum_store_cpu_context,
           &details.cpu_context, GUM_MODIFY_THREAD_FLAGS_ABORT_SAFELY))

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2010-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -257,6 +258,7 @@ static void gum_proc_maps_iter_init_for_path (GumProcMapsIter * iter,
 static void gum_acquire_dumpability (void);
 static void gum_release_dumpability (void);
 
+static gchar * gum_thread_read_name (GumThreadId thread_id);
 static gboolean gum_thread_read_state (GumThreadId tid, GumThreadState * state);
 static GumThreadState gum_thread_state_from_proc_status_character (gchar c);
 static GumPageProtection gum_page_protection_from_proc_perms_string (
@@ -721,7 +723,6 @@ gboolean
 gum_process_has_thread (GumThreadId thread_id)
 {
   gchar path[16 + 20 + 1];
-
   sprintf (path, "/proc/self/task/%" G_GSIZE_MODIFIER "u", thread_id);
 
   return g_file_test (path, G_FILE_TEST_EXISTS);
@@ -1021,8 +1022,13 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
   while (carry_on && (name = g_dir_read_name (dir)) != NULL)
   {
     GumThreadDetails details;
+    gchar * thread_name;
 
     details.id = atoi (name);
+
+    thread_name = gum_thread_read_name (details.id);
+    details.name = thread_name;
+
     if (gum_thread_read_state (details.id, &details.state))
     {
       if (gum_process_modify_thread (details.id, gum_store_cpu_context,
@@ -1031,6 +1037,8 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
         carry_on = func (&details, user_data);
       }
     }
+
+    g_free (thread_name);
   }
 
   g_dir_close (dir);
@@ -2669,6 +2677,26 @@ gum_unparse_regs (const GumCpuContext * ctx,
 #else
 # error Unsupported architecture
 #endif
+}
+
+static gchar *
+gum_thread_read_name (GumThreadId thread_id)
+{
+  gchar * name = NULL;
+  gchar * path;
+  gchar * comm = NULL;
+
+  path = g_strdup_printf ("/proc/self/task/%" G_GSIZE_FORMAT "/comm",
+      thread_id);
+  if (!g_file_get_contents (path, &comm, NULL, NULL))
+    goto beach;
+  name = g_strchomp (g_steal_pointer (&comm));
+
+beach:
+  g_free (comm);
+  g_free (path);
+
+  return name;
 }
 
 static gboolean

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2024 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -238,8 +238,20 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
       (devctl (fd, DCMD_PROC_TIDSTATUS, &thread, sizeof (thread), NULL) == 0))
   {
     GumThreadDetails details;
+    gchar thread_name[_NTO_THREAD_NAME_MAX];
 
     details.id = thread.tid;
+
+    if (pthread_getname_np (thread.tid, thread_name,
+          sizeof (thread_name)) == 0 && thread_name[0] != '\0')
+    {
+      details.name = thread_name;
+    }
+    else
+    {
+      details.name = NULL;
+    }
+
     details.state = gum_thread_state_from_system_thread_state (thread.state);
 
     if (thread.state != STATE_DEAD &&

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2008-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2020-2024 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -59,6 +60,7 @@ typedef enum {
 struct _GumThreadDetails
 {
   GumThreadId id;
+  const gchar * name;
   GumThreadState state;
   GumCpuContext cpu_context;
 };


### PR DESCRIPTION
Exposes thread names via `Process.enumerateThreads`.

Currently implemented:
- [X] Darwin
- [X] Linux (Android)
- [x] Windows
- [x] FreeBSD
- [x] QNX

Tested on iOS and Android, but not macOS + Linux yet.