### PR TITLE
Update libdwarf

### DIFF
--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -555,7 +555,7 @@ static void
 gum_module_entry_free (GumModuleEntry * entry)
 {
   if (entry->dbg != NULL)
-    dwarf_finish (entry->dbg, NULL);
+    dwarf_finish (entry->dbg);
 
   if (entry->module != NULL)
     gum_object_unref (entry->module);

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -821,7 +821,7 @@ gum_store_cu_die_offset_if_containing_address (const GumCuDieDetails * details,
     }
   }
 
-  dwarf_ranges_dealloc (dbg, ranges, range_count);
+  dwarf_dealloc_ranges (dbg, ranges, range_count);
 
 skip:
   return !op->found;

--- a/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
+++ b/gum/backend-libdwarf/gumsymbolutil-libdwarf.c
@@ -1133,15 +1133,12 @@ gum_read_attribute_location (Dwarf_Debug dbg,
   if (loclist_count != 1)
     goto invalid_locations;
 
-  if (dwarf_get_location_op_value_d (loclist,
+  if (dwarf_get_location_op_value_c (loclist,
       0,
       &atom,
       &op1,
       &op2,
       &op3,
-      &rawop1,
-      &rawop2,
-      &rawop3,
       &offset_for_branch,
       NULL) != DW_DLV_OK)
   {
@@ -1156,7 +1153,7 @@ gum_read_attribute_location (Dwarf_Debug dbg,
   success = TRUE;
 
 invalid_locations:
-  dwarf_loc_head_c_dealloc (locations);
+  dwarf_dealloc_loc_head_c (locations);
 
 invalid_type:
   dwarf_dealloc (dbg, attribute, DW_DLA_ATTR);

--- a/meson.build
+++ b/meson.build
@@ -470,7 +470,7 @@ if host_os_family in ['linux', 'freebsd', 'qnx']
     endif
   endif
 
-  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.1', '< 0.2'])
+  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.2', '< 0.3'])
   if not libdwarf_dep.found()
     found = false
     if not meson.is_cross_build()

--- a/meson.build
+++ b/meson.build
@@ -470,7 +470,7 @@ if host_os_family in ['linux', 'freebsd', 'qnx']
     endif
   endif
 
-  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.3', '< 0.4'])
+  libdwarf_dep = dependency('libdwarf', required: false, version: '>= 0.4')
   if not libdwarf_dep.found()
     found = false
     if not meson.is_cross_build()

--- a/meson.build
+++ b/meson.build
@@ -470,13 +470,13 @@ if host_os_family in ['linux', 'freebsd', 'qnx']
     endif
   endif
 
-  libdwarf_dep = dependency('libdwarf', required: false, version: '< 0.1')
+  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.1', '< 0.2'])
   if not libdwarf_dep.found()
     found = false
     if not meson.is_cross_build()
       foreach idir : ['/usr/include/libdwarf', '/usr/local/include/libdwarf']
         inc_arg = '-I' + idir
-        if not found and cc.has_header_symbol('libdwarf.h', 'dwarf_elf_init_b', args: inc_arg)
+        if not found and cc.has_header_symbol('libdwarf.h', 'dwarf_srclines_b', args: inc_arg)
           libdwarf_dep = declare_dependency(compile_args: [inc_arg])
           extra_libs_private += '-ldwarf'
           extra_gir_args_private += '--extra-library=dwarf'

--- a/meson.build
+++ b/meson.build
@@ -470,7 +470,7 @@ if host_os_family in ['linux', 'freebsd', 'qnx']
     endif
   endif
 
-  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.2', '< 0.3'])
+  libdwarf_dep = dependency('libdwarf', required: false, version: ['>= 0.3', '< 0.4'])
   if not libdwarf_dep.found()
     found = false
     if not meson.is_cross_build()

--- a/meson.build
+++ b/meson.build
@@ -470,7 +470,7 @@ if host_os_family in ['linux', 'freebsd', 'qnx']
     endif
   endif
 
-  libdwarf_dep = dependency('libdwarf', required: false)
+  libdwarf_dep = dependency('libdwarf', required: false, version: '< 0.1')
   if not libdwarf_dep.found()
     found = false
     if not meson.is_cross_build()


### PR DESCRIPTION
fix #710 

build works with all versions of libdwarf

<details>
<summary>
frida-gum.nix
</summary>

```nix
{ lib
, stdenv
, fetchFromGitHub
, meson
, vala
, pkg-config
, cmake
, ninja
, glib
, frida-core
, capstone_5
, lzma
, gobject-introspection
, libunwind
, libelf
#, libdwarf_20210528 # https://github.com/davea42/libdwarf-code/releases/tag/20210528
#, gioopenssl

# libdwarf
, zlib
, zstd
, autoreconfHook
}:

let
  # nix-shell -E 'with import ./. {}; mkShell { buildInputs = [ pkg-config frida-gum.libdwarf ]; }'
  libdwarf = let
    versions = {
      # note: libdwarf has API-breaks between minor versions
      # git ls-remote --tags https://github.com/davea42/libdwarf-code | grep -v '\^{}$' | sed 's|^.*refs/tags/||'
      /*
      20200114
      20200703
      20200719
      20200825
      20201020
      */
      "20201201" = {
        # build ok
        # Run-time dependency libdwarf found: NO (tried pkgconfig and cmake)
        # Header "libdwarf.h" has symbol "dwarf_elf_init_b" : YES
        sha256 = "sha256-wykePin202alnuGpibYW+nn7GeZqfHK1udWx6iN3TgA=";
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      "20210305" = {
        # build ok
        # Run-time dependency libdwarf found: NO (tried pkgconfig and cmake)
        # Header "libdwarf.h" has symbol "dwarf_elf_init_b" : YES
        sha256 = "sha256-cOTVbxNhmwbN9jFwMhr/cesXhL/PkY+OvrFTusMOaKM=";
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      "20210528" = {
        # build ok
        # Run-time dependency libdwarf found: NO (tried pkgconfig and cmake)
        # Header "libdwarf.h" has symbol "dwarf_elf_init_b" : YES
        sha256 = "sha256-JHGYEwxmpFu++uac67tJGZ3SXXss5ZAOVR5cI69CaIQ=";
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      # breaks frida-gum be5fc6d95bfc490dbd83d3e0847f0fef01c1f009
      # patches up to ./01-use-libdwarf-0.1.1.diff
      "0.1.1" = {
        # Run-time dependency libdwarf found: YES 0.1.1
        rev = "libdwarf-0.1.1";
        sha256 = "sha256-Dox76yivIIJCRe6H1pQV12tqVKMjEQ/GbdaY3m1L7Og=";
        nativeBuildInputs = [ autoreconfHook ];
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      # patches up to ./02-use-libdwarf-0.2.0.diff
      "0.2.0" = {
        rev = "libdwarf-0.2.0";
        sha256 = "sha256-1eCub9zincEVXtRLt6P4m2fKNO8x8ZClbRwXEPp36RU=";
        nativeBuildInputs = [ autoreconfHook ];
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      # patches up to ./02-use-libdwarf-0.3.diff
      "0.3.0" = {
        rev = "libdwarf-0.3.0";
        sha256 = "sha256-mdtwtqoadxIP6p3gQXc7uhS6U6Ohuk4MvxvzQJnT6Qo=";
        nativeBuildInputs = [ autoreconfHook ];
        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
      };
      /*
      "0.3.1" = {
      };
      "0.3.2" = {
      };
      # meson support since libdwarf 0.3.3
      "0.3.3" = {
      };
      */
      "0.3.4" = {
        rev = "v0.3.4";
        sha256 = "sha256-8VfHO18o5opEpru1g9U94rhF1HyeMk8W4CvoCLKWFQ4=";
        nativeBuildInputs = [ meson ninja ];
      };
      # patches up to ./03-use-libdwarf-0.4.diff
      "0.4.0" = {
        rev = "v0.4.0";
        sha256 = "sha256-o5ABsWSKU8UUBEg5Pp8Vqs7De+r9vLZz1TXZv2+hPIk=";
        nativeBuildInputs = [ meson ninja ];
      };
      /*
      "0.4.1" = {
        rev = "v0.4.1";
        sha256 = "";
        nativeBuildInputs = [ meson ninja ];
      };
      */
      "0.4.2" = {
        rev = "v0.4.2";
        sha256 = "sha256-rh5EfEBbp9rYquv2p/e0/RwjsAuIyaFyPtp6R1ftfPA=";
        nativeBuildInputs = [ meson ninja ];
      };
      "0.5.0" = {
        rev = "v0.5.0";
        sha256 = "sha256-wqI4TxEZTDbkuK2hnfBXMqEFpEOshzds390aY3qXT58=";
        nativeBuildInputs = [ meson ninja ];
      };
      # fix 0.5.0: Run-time dependency zstd found: NO (tried pkgconfig)
      # with https://github.com/davea42/libdwarf-code/commit/31c3f298d4d11ec92fde6b5d176007ed20fe3755
      "0.6.0-unstable-2023-01-29" = {
        rev = "ef60bff461a533da09f4ad3e9c1ece1249237ea2";
        sha256 = "sha256-PLZOlYRrP16oO8ALeRoQ9d+Xy5w0Q/SGJ2LMZEFRYME=";
        nativeBuildInputs = [ meson ninja ];
      };
    };

    #version = "20201201";
    #version = "20210305"; # ok: Header "libdwarf.h" has symbol "dwarf_elf_init_b" : YES
    #version = "20210528"; # ok: Header "libdwarf.h" has symbol "dwarf_elf_init_b" : YES
    #version = "0.1.1";
    #version = "0.2.0";
    #version = "0.3.0";
    #version = "0.3.4";
    #version = "0.4.0";
    #version = "0.4.2";
    #version = "0.5.0";
    version = "0.6.0-unstable-2023-01-29";

    baseAttrs = versions.${version};
  in stdenv.mkDerivation (baseAttrs // rec {
    pname = "libdwarf";
    inherit version;

    src = fetchFromGitHub rec {
      owner = "davea42";
      repo = "libdwarf-code";
      #rev = "v${version}";
      rev = versions.${version}.rev or version;
      sha256 = versions.${version}.sha256 or "";
    };

    #nativeBuildInputs = (if (builtins.hasAttr "nativeBuildInputs" versions.${version}) then versions.${version}.nativeBuildInputs else []);
    #nativeBuildInputs = versions.${version}.nativeBuildInputs or [];

    buildInputs = [
      pkg-config
      libelf
      zlib
      zstd
    ];

    meta = with lib; {
      description = "library for the DWARF Debugging Information Format";
      homepage = "https://github.com/davea42/libdwarf-code";
      license = licenses.lgpl2;
      maintainers = with maintainers; [ milahu ];
      platforms = platforms.unix;
    };
  });

in

stdenv.mkDerivation rec {
  pname = "frida-gum";
  inherit (frida-core) version; # TODO better. mkScope?

  src = fetchFromGitHub {
    owner = "frida";
    repo = "frida-gum";
    # pinned in https://github.com/frida/frida
    rev = "be5fc6d95bfc490dbd83d3e0847f0fef01c1f009";
    sha256 = "sha256-GNxCLbi35qH4bvSwdxF3h2eirOhKKdg9BWNzx2OmXik=";
  };

  patches = [
    # https://github.com/frida/frida-gum/issues/710
    #./frida-gum.libdwarf_20210528.diff
    ./00-use-libdwarf-20210528.patch
    ./01-use-libdwarf-0.1.1.diff
    ./02-use-libdwarf-0.2.0.diff
    ./02-use-libdwarf-0.3.diff
    ./03-use-libdwarf-0.4.diff
  ];

  nativeBuildInputs = [
    meson
  ];

  /*
  TODO?
  Fetching value of define "FRIDA_VERSION" :
  Has header "android/api-level.h" : NO
  Checking for function "g_thread_set_callbacks" with dependency glib-2.0: NO
  Checking for function "ffi_set_mem_callbacks" with dependency libffi: NO
  */

  buildInputs = [
    pkg-config
    cmake
    ninja
    glib
    capstone_5
    lzma
    libunwind
    libelf
    libdwarf
    gobject-introspection # g-ir-scanner
    #gioopenssl
  ];

  meta = with lib; {
    description = "instrumentation and introspection library";
    homepage = "https://github.com/frida/frida-gum";
    license = licenses.wxWindows;
    maintainers = with maintainers; [ milahu ];
    platforms = platforms.unix;
  };

  passthru = {
    inherit libdwarf;
  };
}
```

</details>

