### PR TITLE
fix detection of libv8

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -529,13 +529,13 @@ if have_gumjs
     quickjs_dep_native = dependency('quickjs', native: true)
   endif
 
-  v8_dep = dependency('v8-10.0',
+  v8_dep = dependency('v8',
     version: '>=10.6.122',
     required: get_option('v8'),
   )
   cdata.set('HAVE_V8', v8_dep.found())
   if v8_dep.found()
-    gumjs_extra_requires += 'v8-10.0'
+    gumjs_extra_requires += 'v8'
   endif
 
   if not (quickjs_dep.found() or v8_dep.found())


### PR DESCRIPTION
fix build with libv8-10.8.25 from nodejs-19.4.0

> Run-time dependency v8-10.0 found: NO (tried pkgconfig and cmake)
>
> meson.build:532:2: ERROR: Dependency "v8-10.0" not found, tried pkgconfig and cmake
