### PR TITLE
darwin: Fix mapping zero-sized segments

### DIFF
--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -724,6 +724,9 @@ gum_darwin_mapper_map (GumDarwinMapper * self,
     GumAddress segment_address;
     guint64 file_offset;
 
+    if (s->file_size == 0)
+      continue;
+
     segment_address =
         macho_base_address + s->vm_address - module->preferred_address;
     file_offset =


### PR DESCRIPTION
mach_vm_remap returns KERN_INVALID_ARGUMENT when given a size of 0.  Fix by skipping these segments.