### PR TITLE
Fix ARMv8 BTI issue

### DIFF
--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -1145,5 +1145,5 @@ gum_emit_epilog (GumArm64Writer * aw)
     gum_arm64_writer_put_pop_reg_reg (aw, ARM64_REG_Q0 + i, ARM64_REG_Q1 + i);
 
   gum_arm64_writer_put_pop_reg_reg (aw, ARM64_REG_X16, ARM64_REG_X17);
-  gum_arm64_writer_put_br_reg (aw, ARM64_REG_X16);
+  gum_arm64_writer_put_ret_reg (aw, ARM64_REG_X16);
 }


### PR DESCRIPTION
Fix ARMv8 BTI issue https://github.com/frida/frida/issues/2389
use `RET X16` instead of `BR X16` to bypass BTI