### PR TITLE
Improve worker

### DIFF
--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -972,7 +972,7 @@ _gum_quick_script_make_worker (GumQuickScript * self,
     GumQuickScope scope = { core, NULL, };
 
     _gum_quick_core_init (core, self, ctx, global_obj, &worker->scope_mutex,
-        NULL, gumjs_frida_source_map, NULL, NULL,
+        self->program, gumjs_frida_source_map, NULL, NULL,
         (GumQuickMessageEmitter) gum_quick_worker_emit, worker,
         worker->scheduler);
 

--- a/bindings/gumjs/runtime/worker.js
+++ b/bindings/gumjs/runtime/worker.js
@@ -22,7 +22,7 @@ class Worker {
     const message = JSON.parse(rawMessage);
 
     if (message.type !== 'send') {
-      engine._send(rawMessage, data);
+      _send(rawMessage, data);
       return;
     }
 


### PR DESCRIPTION
This change contains two minor fixes:

- Fix typo in worker.js `_dispatchMessage()`
  - so that `console.log` works from within the worker
- Pass `program` to worker's core init
  - so that js exceptions can be generated without segfaulting