### PR TITLE
Symbol Deferred Loading

### DIFF
--- a/gum/backend-dbghelp/gumdbghelp.c
+++ b/gum/backend-dbghelp/gumdbghelp.c
@@ -68,6 +68,8 @@ do_init (gpointer data)
   impl->Lock = gum_dbghelp_impl_lock;
   impl->Unlock = gum_dbghelp_impl_unlock;
 
+  impl->SymSetOptions (SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+
   impl->SymInitialize (GetCurrentProcess (), NULL, TRUE);
 
   _gum_register_destructor (do_deinit);


### PR DESCRIPTION
Prevents `DebugSymbol.load` from 
looking for symbols for a long time 
and causing blocking,
defers symbol loading until symbol information is requested.
Reference:
https://learn.microsoft.com/windows/win32/debug/initializing-the-symbol-handler