### PR TITLE
Fix NativePointer from number for 32-bit BE.

### DIFF
--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -1370,11 +1370,12 @@ _gum_quick_native_pointer_parse (JSContext * ctx,
 #else
     union
     {
-        struct {
-            gpointer _pad;
-            gpointer p;
-        };
-        int64_t i;
+      struct
+      {
+        gpointer _pad;
+        gpointer p;
+      };
+      int64_t i;
     } v;
 #endif
 

--- a/bindings/gumjs/gumquickvalue.c
+++ b/bindings/gumjs/gumquickvalue.c
@@ -1361,11 +1361,22 @@ _gum_quick_native_pointer_parse (JSContext * ctx,
   }
   else if (JS_IsNumber (val))
   {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN || GLIB_SIZEOF_VOID_P == 8
     union
     {
       gpointer p;
       int64_t i;
     } v;
+#else
+    union
+    {
+        struct {
+            gpointer _pad;
+            gpointer p;
+        };
+        int64_t i;
+    } v;
+#endif
 
     JS_ToInt64 (ctx, &v.i, val);
 


### PR DESCRIPTION
Fix new NativePointer(number) for 32-bit BE architectures (e.g. ARM BE8).

This union which overlaps gpointer and int64_t fails to allow extraction of
gpointer when architecture is 32-bit big endian. For that combination padding
is required, which this patch adds only for that combination.