### PR TITLE
Allow transformer to skip calls on x86

### DIFF
--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -3062,7 +3062,7 @@ gum_stalker_iterator_next (GumStalkerIterator * self,
       gc->continuation_real_address = instruction->end;
       return FALSE;
     }
-    else if (gum_x86_relocator_eob (rl))
+    else if (!skip_implicitly_requested && gum_x86_relocator_eob (rl))
     {
       return FALSE;
     }

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -30,6 +30,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (call_depth)
   TESTENTRY (call_probe)
   TESTENTRY (custom_transformer)
+  TESTENTRY (transformer_should_be_able_to_skip_call)
   TESTENTRY (unfollow_should_be_allowed_before_first_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_first_transform)
   TESTENTRY (unfollow_should_be_allowed_after_first_transform)
@@ -164,6 +165,8 @@ static void pretend_workload (GumMemoryRange * runner_range);
 static void insert_extra_increment_after_xor (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static void store_xax (GumCpuContext * cpu_context, gpointer user_data);
+static void skip_call (GumStalkerIterator * iterator, GumStalkerOutput * output,
+    gpointer user_data);
 static void unfollow_during_transform (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static void modify_to_return_true_after_three_calls (
@@ -928,6 +931,48 @@ store_xax (GumCpuContext * cpu_context,
   gsize * last_xax = user_data;
 
   *last_xax = GUM_CPU_CONTEXT_XAX (cpu_context);
+}
+
+TESTCASE (transformer_should_be_able_to_skip_call)
+{
+  guint8 code_template[] =
+  {
+    0xb8, 0x14, 0x05, 0x00, 0x00, //        mov    eax,0x514
+    0xe8, 0x01, 0x00, 0x00, 0x00, //        call   b <bump_number>
+    0xc3,                         //        ret
+                                  //  0000000b <bump_number>:
+    0x83, 0xc0, 0x25,             //        add    eax,0x25
+    0xc3                          //        ret
+  };
+  StalkerTestFunc func;
+  gint ret;
+
+  func = (StalkerTestFunc) test_stalker_fixture_dup_code (fixture,
+      code_template, sizeof (code_template));
+
+  fixture->transformer = gum_stalker_transformer_make_from_callback (skip_call,
+      func, NULL);
+
+  ret = test_stalker_fixture_follow_and_invoke (fixture, func, 0);
+  g_assert_cmpuint (ret, ==, 1300);
+}
+
+static void
+skip_call (GumStalkerIterator * iterator,
+           GumStalkerOutput * output,
+           gpointer user_data)
+{
+  const guint8 * func_start = user_data;
+  const cs_insn * insn;
+
+  while (gum_stalker_iterator_next (iterator, &insn))
+  {
+    if (insn->address == GPOINTER_TO_SIZE (func_start + 5))
+      continue;
+
+    gum_stalker_iterator_keep (iterator);
+  }
+
 }
 
 TESTCASE (unfollow_should_be_allowed_before_first_transform)

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -937,12 +937,12 @@ TESTCASE (transformer_should_be_able_to_skip_call)
 {
   guint8 code_template[] =
   {
-    0xb8, 0x14, 0x05, 0x00, 0x00, //        mov    eax,0x514
-    0xe8, 0x01, 0x00, 0x00, 0x00, //        call   b <bump_number>
-    0xc3,                         //        ret
-                                  //  0000000b <bump_number>:
-    0x83, 0xc0, 0x25,             //        add    eax,0x25
-    0xc3                          //        ret
+    0xb8, 0x14, 0x05, 0x00, 0x00, /* mov eax, 1300    */
+    0xe8, 0x01, 0x00, 0x00, 0x00, /* call bump_number */
+    0xc3,                         /* ret              */
+    /* bump_number:                                   */
+    0x83, 0xc0, 0x25,             /* add eax, 37      */
+    0xc3,                         /* ret              */
   };
   StalkerTestFunc func;
   gint ret;

--- a/tests/core/arch-x86/stalker-x86.c
+++ b/tests/core/arch-x86/stalker-x86.c
@@ -972,7 +972,6 @@ skip_call (GumStalkerIterator * iterator,
 
     gum_stalker_iterator_keep (iterator);
   }
-
 }
 
 TESTCASE (unfollow_should_be_allowed_before_first_transform)


### PR DESCRIPTION
Adds a test and a fix allowing transformer to skip calls on x86, inspired by https://github.com/frida/frida-gum/commit/10160db8588051e87cecc94902c59846116be43a
