### PR TITLE
process: add get_main_module()

### DIFF
--- a/bindings/gumjs/gumquickprocess.c
+++ b/bindings/gumjs/gumquickprocess.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -78,6 +78,7 @@ struct _GumQuickFindRangeByAddressContext
   GumQuickCore * core;
 };
 
+static void gumjs_free_main_module_value (GumQuickProcess * self);
 GUMJS_DECLARE_GETTER (gumjs_process_get_main_module)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_current_dir)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_home_dir)
@@ -109,8 +110,6 @@ static void gum_quick_exception_handler_free (
     GumQuickExceptionHandler * handler);
 static gboolean gum_quick_exception_handler_on_exception (
     GumExceptionDetails * details, GumQuickExceptionHandler * handler);
-
-static void gumjs_free_main_module_value (GumQuickProcess * self);
 
 static const JSCFunctionListEntry gumjs_process_entries[] =
 {
@@ -167,15 +166,15 @@ _gum_quick_process_init (GumQuickProcess * self,
 void
 _gum_quick_process_flush (GumQuickProcess * self)
 {
-  gumjs_free_main_module_value (self);
   g_clear_pointer (&self->exception_handler, gum_quick_exception_handler_free);
+  gumjs_free_main_module_value (self);
 }
 
 void
 _gum_quick_process_dispose (GumQuickProcess * self)
 {
-  gumjs_free_main_module_value (self);
   g_clear_pointer (&self->exception_handler, gum_quick_exception_handler_free);
+  gumjs_free_main_module_value (self);
 }
 
 static void
@@ -207,9 +206,8 @@ GUMJS_DEFINE_GETTER (gumjs_process_get_main_module)
 
   if (JS_IsUninitialized (self->main_module_value))
   {
-    const GumModuleDetails * main_module  = gum_process_get_main_module ();
-    self->main_module_value = _gum_quick_module_new (ctx, main_module,
-        self->module);
+    self->main_module_value = _gum_quick_module_new (ctx,
+        gum_process_get_main_module (), self->module);
   }
 
   return JS_DupValue (ctx, self->main_module_value);

--- a/bindings/gumjs/gumquickprocess.h
+++ b/bindings/gumjs/gumquickprocess.h
@@ -23,7 +23,7 @@ struct _GumQuickProcess
   GumQuickCore * core;
 
   GumQuickExceptionHandler * exception_handler;
-  JSValue main_module;
+  JSValue main_module_value;
 };
 
 G_GNUC_INTERNAL void _gum_quick_process_init (GumQuickProcess * self,

--- a/bindings/gumjs/gumquickprocess.h
+++ b/bindings/gumjs/gumquickprocess.h
@@ -10,6 +10,8 @@
 #include "gumquickcore.h"
 #include "gumquickmodule.h"
 
+#include <gum/gumprocess.h>
+
 G_BEGIN_DECLS
 
 typedef struct _GumQuickProcess GumQuickProcess;
@@ -21,6 +23,7 @@ struct _GumQuickProcess
   GumQuickCore * core;
 
   GumQuickExceptionHandler * exception_handler;
+  GumModuleDetails * main_module;
 };
 
 G_GNUC_INTERNAL void _gum_quick_process_init (GumQuickProcess * self,

--- a/bindings/gumjs/gumquickprocess.h
+++ b/bindings/gumjs/gumquickprocess.h
@@ -23,7 +23,7 @@ struct _GumQuickProcess
   GumQuickCore * core;
 
   GumQuickExceptionHandler * exception_handler;
-  GumModuleDetails * main_module;
+  JSValue main_module;
 };
 
 G_GNUC_INTERNAL void _gum_quick_process_init (GumQuickProcess * self,

--- a/bindings/gumjs/gumquickprocess.h
+++ b/bindings/gumjs/gumquickprocess.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -20,8 +21,8 @@ struct _GumQuickProcess
   GumQuickModule * module;
   GumQuickCore * core;
 
-  GumQuickExceptionHandler * exception_handler;
   JSValue main_module_value;
+  GumQuickExceptionHandler * exception_handler;
 };
 
 G_GNUC_INTERNAL void _gum_quick_process_init (GumQuickProcess * self,

--- a/bindings/gumjs/gumquickprocess.h
+++ b/bindings/gumjs/gumquickprocess.h
@@ -10,8 +10,6 @@
 #include "gumquickcore.h"
 #include "gumquickmodule.h"
 
-#include <gum/gumprocess.h>
-
 G_BEGIN_DECLS
 
 typedef struct _GumQuickProcess GumQuickProcess;

--- a/bindings/gumjs/gumv8process.cpp
+++ b/bindings/gumjs/gumv8process.cpp
@@ -160,14 +160,12 @@ _gum_v8_process_realize (GumV8Process * self)
 void
 _gum_v8_process_flush (GumV8Process * self)
 {
-  g_clear_pointer (&self->main_module, gum_module_details_free);
   g_clear_pointer (&self->exception_handler, gum_v8_exception_handler_free);
 }
 
 void
 _gum_v8_process_dispose (GumV8Process * self)
 {
-  g_clear_pointer (&self->main_module, gum_module_details_free);
   g_clear_pointer (&self->exception_handler, gum_v8_exception_handler_free);
 }
 
@@ -179,11 +177,11 @@ _gum_v8_process_finalize (GumV8Process * self)
 GUMJS_DEFINE_GETTER (gumjs_process_get_main_module)
 {
   auto self = module;
+  const GumModuleDetails * main_module;
 
-  if (self->main_module == NULL)
-    self->main_module = gum_process_get_main_module ();
+  main_module = gum_process_get_main_module ();
 
-  info.GetReturnValue ().Set (_gum_v8_module_value_new (self->main_module,
+  info.GetReturnValue ().Set (_gum_v8_module_value_new (main_module,
       self->module));
 }
 

--- a/bindings/gumjs/gumv8process.h
+++ b/bindings/gumjs/gumv8process.h
@@ -10,8 +10,6 @@
 #include "gumv8core.h"
 #include "gumv8module.h"
 
-#include <gum/gumprocess.h>
-
 struct GumV8ExceptionHandler;
 
 struct GumV8Process
@@ -20,7 +18,6 @@ struct GumV8Process
   GumV8Core * core;
 
   GumV8ExceptionHandler * exception_handler;
-  GumModuleDetails * main_module;
 };
 
 G_GNUC_INTERNAL void _gum_v8_process_init (GumV8Process * self,

--- a/bindings/gumjs/gumv8process.h
+++ b/bindings/gumjs/gumv8process.h
@@ -18,6 +18,7 @@ struct GumV8Process
   GumV8Core * core;
 
   GumV8ExceptionHandler * exception_handler;
+  v8::Global<v8::Object> * main_module_value;
 };
 
 G_GNUC_INTERNAL void _gum_v8_process_init (GumV8Process * self,

--- a/bindings/gumjs/gumv8process.h
+++ b/bindings/gumjs/gumv8process.h
@@ -10,6 +10,8 @@
 #include "gumv8core.h"
 #include "gumv8module.h"
 
+#include <gum/gumprocess.h>
+
 struct GumV8ExceptionHandler;
 
 struct GumV8Process
@@ -18,6 +20,7 @@ struct GumV8Process
   GumV8Core * core;
 
   GumV8ExceptionHandler * exception_handler;
+  GumModuleDetails * main_module;
 };
 
 G_GNUC_INTERNAL void _gum_v8_process_init (GumV8Process * self,

--- a/bindings/gumjs/gumv8process.h
+++ b/bindings/gumjs/gumv8process.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2020 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -17,8 +18,8 @@ struct GumV8Process
   GumV8Module * module;
   GumV8Core * core;
 
-  GumV8ExceptionHandler * exception_handler;
   v8::Global<v8::Object> * main_module_value;
+  GumV8ExceptionHandler * exception_handler;
 };
 
 G_GNUC_INTERNAL void _gum_v8_process_init (GumV8Process * self,

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -463,6 +463,24 @@ _gum_process_enumerate_ranges (GumPageProtection prot,
   gum_darwin_enumerate_ranges (mach_task_self (), prot, func, user_data);
 }
 
+gboolean
+_gum_process_match_main_module (const GumModuleDetails * details,
+                                gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+  gum_mach_header_t * header;
+
+  header = details->range->base_address;
+  if (header->filetype == MH_EXECUTE)
+  {
+    *out = gum_module_details_copy (details);
+
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
 void
 gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
                                      gpointer user_data)

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -470,7 +470,7 @@ _gum_process_match_main_module (const GumModuleDetails * details,
   GumModuleDetails ** out = user_data;
   gum_mach_header_t * header;
 
-  header = details->range->base_address;
+  header = GSIZE_TO_POINTER (details->range->base_address);
   if (header->filetype == MH_EXECUTE)
   {
     *out = gum_module_details_copy (details);

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2010-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2015 Asger Hautop Drewsen <asgerdrewsen@gmail.com>
- * Copyright (C) 2022 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2022-2023 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2022 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Alex Soler <asoler@nowsecure.com>
  *
@@ -448,24 +448,9 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
   gum_darwin_enumerate_threads (mach_task_self (), func, user_data);
 }
 
-void
-_gum_process_enumerate_modules (GumFoundModuleFunc func,
-                                gpointer user_data)
-{
-  gum_darwin_enumerate_modules (mach_task_self (), func, user_data);
-}
-
-void
-_gum_process_enumerate_ranges (GumPageProtection prot,
-                               GumFoundRangeFunc func,
-                               gpointer user_data)
-{
-  gum_darwin_enumerate_ranges (mach_task_self (), prot, func, user_data);
-}
-
 gboolean
-_gum_process_match_main_module (const GumModuleDetails * details,
-                                gpointer user_data)
+_gum_process_collect_main_module (const GumModuleDetails * details,
+                                  gpointer user_data)
 {
   GumModuleDetails ** out = user_data;
   gum_mach_header_t * header;
@@ -479,6 +464,21 @@ _gum_process_match_main_module (const GumModuleDetails * details,
   }
 
   return TRUE;
+}
+
+void
+_gum_process_enumerate_modules (GumFoundModuleFunc func,
+                                gpointer user_data)
+{
+  gum_darwin_enumerate_modules (mach_task_self (), func, user_data);
+}
+
+void
+_gum_process_enumerate_ranges (GumPageProtection prot,
+                               GumFoundRangeFunc func,
+                               gpointer user_data)
+{
+  gum_darwin_enumerate_ranges (mach_task_self (), prot, func, user_data);
 }
 
 void

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -475,6 +476,17 @@ failure:
   }
 }
 
+gboolean
+_gum_process_collect_main_module (const GumModuleDetails * details,
+                                  gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 _gum_process_enumerate_modules (GumFoundModuleFunc func,
                                 gpointer user_data)
@@ -530,17 +542,6 @@ gum_emit_module_from_phdr (struct dl_phdr_info * info,
   g_free (name);
 
   return carry_on ? 0 : 1;
-}
-
-gboolean
-_gum_process_match_main_module (const GumModuleDetails * details,
-                                gpointer user_data)
-{
-  GumModuleDetails ** out = user_data;
-
-  *out = gum_module_details_copy (details);
-
-  return FALSE;
 }
 
 void

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -532,6 +532,17 @@ gum_emit_module_from_phdr (struct dl_phdr_info * info,
   return carry_on ? 0 : 1;
 }
 
+gboolean
+_gum_process_match_main_module (const GumModuleDetails * details,
+                                gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 _gum_process_enumerate_ranges (GumPageProtection prot,
                                GumFoundRangeFunc func,

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -1043,6 +1044,17 @@ gum_store_cpu_context (GumThreadId thread_id,
   memcpy (user_data, cpu_context, sizeof (GumCpuContext));
 }
 
+gboolean
+_gum_process_collect_main_module (const GumModuleDetails * details,
+                                  gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 _gum_process_enumerate_modules (GumFoundModuleFunc func,
                                 gpointer user_data)
@@ -1257,17 +1269,6 @@ gum_linux_enumerate_modules_using_proc_maps (GumFoundModuleFunc func,
   g_free (next_path);
 
   gum_proc_maps_iter_destroy (&iter);
-}
-
-gboolean
-_gum_process_match_main_module (const GumModuleDetails * details,
-                                gpointer user_data)
-{
-  GumModuleDetails ** out = user_data;
-
-  *out = gum_module_details_copy (details);
-
-  return FALSE;
 }
 
 GHashTable *

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -1259,6 +1259,17 @@ gum_linux_enumerate_modules_using_proc_maps (GumFoundModuleFunc func,
   gum_proc_maps_iter_destroy (&iter);
 }
 
+gboolean
+_gum_process_match_main_module (const GumModuleDetails * details,
+                                gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 GHashTable *
 gum_linux_collect_named_ranges (void)
 {

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -262,6 +263,17 @@ gum_store_cpu_context (GumThreadId thread_id,
   memcpy (user_data, cpu_context, sizeof (GumCpuContext));
 }
 
+gboolean
+_gum_process_collect_main_module (const GumModuleDetails * details,
+                                  gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 _gum_process_enumerate_modules (GumFoundModuleFunc func,
                                 gpointer user_data)
@@ -321,17 +333,6 @@ _gum_process_enumerate_modules (GumFoundModuleFunc func,
   }
 
   dlclose (handle);
-}
-
-gboolean
-_gum_process_match_main_module (const GumModuleDetails * details,
-                                gpointer user_data)
-{
-  GumModuleDetails ** out = user_data;
-
-  *out = gum_module_details_copy (details);
-
-  return FALSE;
 }
 
 void

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -323,6 +323,17 @@ _gum_process_enumerate_modules (GumFoundModuleFunc func,
   dlclose (handle);
 }
 
+gboolean
+_gum_process_match_main_module (const GumModuleDetails * details,
+                                gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 gum_qnx_enumerate_ranges (pid_t pid,
                           GumPageProtection prot,

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -260,6 +261,17 @@ gum_windows_get_thread_details (DWORD thread_id,
   return success;
 }
 
+gboolean
+_gum_process_collect_main_module (const GumModuleDetails * details,
+                                  gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 _gum_process_enumerate_modules (GumFoundModuleFunc func,
                                 gpointer user_data)
@@ -368,17 +380,6 @@ _gum_process_enumerate_ranges (GumPageProtection prot,
 
     cur_base_address += mbi.RegionSize;
   }
-}
-
-gboolean
-_gum_process_match_main_module (const GumModuleDetails * details,
-                                gpointer user_data)
-{
-  GumModuleDetails ** out = user_data;
-
-  *out = gum_module_details_copy (details);
-
-  return FALSE;
 }
 
 void

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -370,6 +370,17 @@ _gum_process_enumerate_ranges (GumPageProtection prot,
   }
 }
 
+gboolean
+_gum_process_match_main_module (const GumModuleDetails * details,
+                                gpointer user_data)
+{
+  GumModuleDetails ** out = user_data;
+
+  *out = gum_module_details_copy (details);
+
+  return FALSE;
+}
+
 void
 gum_process_enumerate_malloc_ranges (GumFoundMallocRangeFunc func,
                                      gpointer user_data)

--- a/gum/gumprocess-priv.h
+++ b/gum/gumprocess-priv.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -13,12 +14,12 @@ G_BEGIN_DECLS
 
 G_GNUC_INTERNAL void _gum_process_enumerate_threads (GumFoundThreadFunc func,
     gpointer user_data);
+G_GNUC_INTERNAL gboolean _gum_process_collect_main_module (
+    const GumModuleDetails * details, gpointer user_data);
 G_GNUC_INTERNAL void _gum_process_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
 G_GNUC_INTERNAL void _gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
-G_GNUC_INTERNAL gboolean _gum_process_match_main_module (
-    const GumModuleDetails * details, gpointer user_data);
 
 G_END_DECLS
 

--- a/gum/gumprocess-priv.h
+++ b/gum/gumprocess-priv.h
@@ -17,6 +17,8 @@ G_GNUC_INTERNAL void _gum_process_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
 G_GNUC_INTERNAL void _gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
+G_GNUC_INTERNAL gboolean _gum_process_match_main_module (
+    const GumModuleDetails * details, gpointer user_data);
 
 G_END_DECLS
 

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -163,7 +164,7 @@ gum_process_get_main_module (void)
   {
     GumModuleDetails * result;
 
-    gum_process_enumerate_modules (_gum_process_match_main_module, &result);
+    gum_process_enumerate_modules (_gum_process_collect_main_module, &result);
 
     _gum_register_destructor (gum_deinit_main_module);
 

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -214,6 +214,22 @@ gum_process_enumerate_modules (GumFoundModuleFunc func,
   _gum_process_enumerate_modules (gum_emit_module_if_not_cloaked, &ctx);
 }
 
+/**
+ * gum_process_get_main_module:
+ *
+ * Returns a copy of the details of the module representing the main executable
+ * of the process. Result must be freed with gum_module_details_free ();
+ */
+GumModuleDetails *
+gum_process_get_main_module (void)
+{
+  GumModuleDetails * result;
+
+  gum_process_enumerate_modules (_gum_process_match_main_module, &result);
+
+  return result;
+}
+
 static gboolean
 gum_emit_module_if_not_cloaked (const GumModuleDetails * details,
                                 gpointer user_data)

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -209,6 +209,7 @@ GUM_API gboolean gum_process_resolve_module_pointer (gconstpointer ptr,
     gchar ** path, GumMemoryRange * range);
 GUM_API void gum_process_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
+GUM_API GumModuleDetails * gum_process_get_main_module (void);
 GUM_API void gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 GUM_API void gum_process_enumerate_malloc_ranges (

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -205,11 +205,11 @@ GUM_API gboolean gum_process_modify_thread (GumThreadId thread_id,
     GumModifyThreadFunc func, gpointer user_data, GumModifyThreadFlags flags);
 GUM_API void gum_process_enumerate_threads (GumFoundThreadFunc func,
     gpointer user_data);
+GUM_API const GumModuleDetails * gum_process_get_main_module (void);
 GUM_API gboolean gum_process_resolve_module_pointer (gconstpointer ptr,
     gchar ** path, GumMemoryRange * range);
 GUM_API void gum_process_enumerate_modules (GumFoundModuleFunc func,
     gpointer user_data);
-GUM_API GumModuleDetails * gum_process_get_main_module (void);
 GUM_API void gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 GUM_API void gum_process_enumerate_malloc_ranges (

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2020 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */


### PR DESCRIPTION
This returns a copy of the details of the module which represents the main executable of the process.

It is exposed to JS via the `Process.mainModule` property (where it's cached because the main module is constant during the process' lifetime).

For darwin this is implemented by getting the first loaded module for which the Mach-O header's `filetype` is set to `MH_EXECUTE`. For all other archs it is currently just the first loaded module (equivalent to `Process.enumerateModules()[0]`).