### PR TITLE
interceptor: pause cloaked threads too

### DIFF
--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -11,7 +11,7 @@
 #include "guminterceptor-priv.h"
 #include "gumlibc.h"
 #include "gummemory.h"
-#include "gumprocess.h"
+#include "gumprocess-priv.h"
 #include "gumtls.h"
 
 #include <string.h>
@@ -1049,7 +1049,7 @@ gum_interceptor_transaction_end (GumInterceptorTransaction * self)
       if (!rwx_supported)
       {
         suspend_op.current_thread_id = gum_process_get_current_thread_id ();
-        gum_process_enumerate_threads (gum_maybe_suspend_thread, &suspend_op);
+        _gum_process_enumerate_threads (gum_maybe_suspend_thread, &suspend_op);
       }
 
       for (cur = addresses; cur != NULL; cur = cur->next)


### PR DESCRIPTION
This prevents random `SIGBUS` crashes on Frida's own threads while using `Interceptor` to hook functions living in the same page as any of the ones potentially used internally.