### PR TITLE
fix source-charset to utf-8

### DIFF
--- a/bindings/gumjs/gumjs-32.vcxproj
+++ b/bindings/gumjs/gumjs-32.vcxproj
@@ -64,6 +64,7 @@
     <ClCompile>
       <PreprocessorDefinitions>$(FridaComponentDefines);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/bindings/gumjs/gumjs-64.vcxproj
+++ b/bindings/gumjs/gumjs-64.vcxproj
@@ -64,6 +64,7 @@
     <ClCompile>
       <PreprocessorDefinitions>$(FridaComponentDefines);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
I encountered an error when I use VisualStudio2022 to build frida-gadget : [[frida-gadget] Failed to load script: malformed package](https://github.com/frida/frida/issues/2728)

In the end, I found the error source-charset caused this problem. The VisualStudio complied project using the default charset for the environment. However, the result of compile must be utf-8 in order to be connected using frida-tools, which a script coding with python. So we must set charset attribute directly before using VS to build project