### PR TITLE
Fix Darwin symbolicator cache invalidator logic

### DIFF
--- a/gum/arch-arm64/gumarm64reader.c
+++ b/gum/arch-arm64/gumarm64reader.c
@@ -99,3 +99,20 @@ beach:
 
   return result;
 }
+
+cs_insn *
+gum_arm64_reader_disassemble_instruction_at (gconstpointer address)
+{
+  csh capstone;
+  cs_insn * insn = NULL;
+
+  cs_arch_register_arm64 ();
+  cs_open (CS_ARCH_ARM64, GUM_DEFAULT_CS_ENDIAN, &capstone);
+  cs_option (capstone, CS_OPT_DETAIL, CS_OPT_ON);
+
+  cs_disasm (capstone, address, 16, GPOINTER_TO_SIZE (address), 1, &insn);
+
+  cs_close (&capstone);
+
+  return insn;
+}

--- a/gum/arch-arm64/gumarm64reader.h
+++ b/gum/arch-arm64/gumarm64reader.h
@@ -15,6 +15,8 @@ G_BEGIN_DECLS
 
 GUM_API gpointer gum_arm64_reader_try_get_relative_jump_target (
     gconstpointer address);
+GUM_API cs_insn * gum_arm64_reader_disassemble_instruction_at (
+    gconstpointer address);
 
 G_END_DECLS
 

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2023-2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -60,6 +60,8 @@ static gboolean gum_emit_range_if_not_cloaked (const GumRangeDetails * details,
 static gboolean gum_store_address_if_name_matches (
     const GumSymbolDetails * details, gpointer user_data);
 
+static GumTeardownRequirement gum_teardown_requirement =
+    GUM_TEARDOWN_REQUIREMENT_FULL;
 static GumCodeSigningPolicy gum_code_signing_policy = GUM_CODE_SIGNING_OPTIONAL;
 
 GUM_DEFINE_BOXED_TYPE (GumModuleDetails, gum_module_details,
@@ -89,6 +91,18 @@ gum_process_get_native_os (void)
 #else
 # error Unknown OS
 #endif
+}
+
+GumTeardownRequirement
+gum_process_get_teardown_requirement (void)
+{
+  return gum_teardown_requirement;
+}
+
+void
+gum_process_set_teardown_requirement (GumTeardownRequirement requirement)
+{
+  gum_teardown_requirement = requirement;
 }
 
 GumCodeSigningPolicy

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2020-2023 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2020-2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -32,6 +32,11 @@ typedef struct _GumFileMapping GumFileMapping;
 typedef struct _GumSectionDetails GumSectionDetails;
 typedef struct _GumDependencyDetails GumDependencyDetails;
 typedef struct _GumMallocRangeDetails GumMallocRangeDetails;
+
+typedef enum {
+  GUM_TEARDOWN_REQUIREMENT_FULL,
+  GUM_TEARDOWN_REQUIREMENT_MINIMAL
+} GumTeardownRequirement;
 
 typedef enum {
   GUM_CODE_SIGNING_OPTIONAL,
@@ -194,6 +199,9 @@ typedef GumAddress (* GumResolveExportFunc) (const char * module_name,
     const char * symbol_name, gpointer user_data);
 
 GUM_API GumOS gum_process_get_native_os (void);
+GUM_API GumTeardownRequirement gum_process_get_teardown_requirement (void);
+GUM_API void gum_process_set_teardown_requirement (
+    GumTeardownRequirement requirement);
 GUM_API GumCodeSigningPolicy gum_process_get_code_signing_policy (void);
 GUM_API void gum_process_set_code_signing_policy (GumCodeSigningPolicy policy);
 GUM_API const gchar * gum_process_query_libc_name (void);

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -55,6 +55,12 @@ namespace Gum {
 		INVALID_DATA,
 	}
 
+	[CCode (cprefix = "GUM_TEARDOWN_REQUIREMENT_")]
+	public enum TeardownRequirement {
+		FULL,
+		MINIMAL
+	}
+
 	[CCode (cprefix = "GUM_CODE_SIGNING_")]
 	public enum CodeSigningPolicy {
 		OPTIONAL,
@@ -274,6 +280,8 @@ namespace Gum {
 	}
 
 	namespace Process {
+		public Gum.TeardownRequirement get_teardown_requirement ();
+		public void set_teardown_requirement (Gum.TeardownRequirement requirement);
 		public Gum.CodeSigningPolicy get_code_signing_policy ();
 		public void set_code_signing_policy (Gum.CodeSigningPolicy policy);
 		public unowned string query_libc_name ();


### PR DESCRIPTION
There are 2 problems with the existing logic:

1. Since Xcode 15.1, when Xcode launches an app it places a software breakpoint (`brk` / `int3`) instruction at the beginning of the `notification_address` returned by `all_image_infos`. That's a function which the cache invalidator hooks with `Interceptor` in order to trigger when any libraries are loaded or unloaded at runtime. The problem with this approach is that in this way `Interceptor` relocates the breakpoint instruction, so when it gets executed Xcode can't match it with the address it expected, resulting into an uncaught exception crashing the app.
2. In cases where `Interceptor` can't work on system code (like the Gadget with `required` code-signing) the symbolicator cache is never invalidated

To overcome these problems what this change proposes is:
- use `_dyld_register_func_for_add_image` / `_dyld_register_func_for_remove_image` when `TeardownRequirement` is `MINIMAL` (because there's no good way to unregister those handlers, so it's safe only if frida-gum knows it will never be unloaded)
- otherwise still place an instruction-level hook using `Interceptor`, but on the instruction following the breakpoint if present

In order to do so, though, other 2 changes are present in this MR:
- one brings back `disassemble_instruction_at ()` in arm64-reader, so we can use it to check the breakpoint instruction presence
- move the `TeardownRequirement` setting from the Gadget library to Gum's Process (following the same semantics as the codesign setting), so Gum can make better decisions taking into account its own promised lifetime like in this case

https://github.com/frida/frida-core/pull/498 depends on this
