### PR TITLE
Add Cloak module

### DIFF
--- a/bindings/gumjs/gumquickcloak.c
+++ b/bindings/gumjs/gumquickcloak.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gumquickcloak.h"
+
+#include "gumquickmacros.h"
+
+#include <gum/gumcloak.h>
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_thread)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_thread)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_thread)
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_range)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_range)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_range_containing)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_clip_range)
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_file_descriptor)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_file_descriptor)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_file_descriptor)
+
+static const JSCFunctionListEntry gumjs_cloak_entries[] =
+{
+  JS_CFUNC_DEF ("addThread", 0, gumjs_cloak_add_thread),
+  JS_CFUNC_DEF ("removeThread", 0, gumjs_cloak_remove_thread),
+  JS_CFUNC_DEF ("hasThread", 0, gumjs_cloak_has_thread),
+
+  JS_CFUNC_DEF ("_addRange", 0, gumjs_cloak_add_range),
+  JS_CFUNC_DEF ("_removeRange", 0, gumjs_cloak_remove_range),
+  JS_CFUNC_DEF ("hasRangeContaining", 0, gumjs_cloak_has_range_containing),
+  JS_CFUNC_DEF ("_clipRange", 0, gumjs_cloak_clip_range),
+
+  JS_CFUNC_DEF ("addFileDescriptor", 0, gumjs_cloak_add_file_descriptor),
+  JS_CFUNC_DEF ("removeFileDescriptor", 0, gumjs_cloak_remove_file_descriptor),
+  JS_CFUNC_DEF ("hasFileDescriptor", 0, gumjs_cloak_has_file_descriptor),
+};
+
+void
+_gum_quick_cloak_init (GumQuickCloak * self,
+                       JSValue ns,
+                       GumQuickCore * core)
+{
+  JSContext * ctx = core->ctx;
+  JSValue obj;
+
+  self->core = core;
+
+  _gum_quick_core_store_module_data (core, "cloak", self);
+
+  obj = JS_NewObject (ctx);
+  JS_SetPropertyFunctionList (ctx, obj, gumjs_cloak_entries,
+      G_N_ELEMENTS (gumjs_cloak_entries));
+  JS_DefinePropertyValueStr (ctx, ns, "Cloak", obj, JS_PROP_C_W_E);
+}
+
+void
+_gum_quick_cloak_dispose (GumQuickCloak * self)
+{
+}
+
+void
+_gum_quick_cloak_finalize (GumQuickCloak * self)
+{
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_thread)
+{
+  GumThreadId thread_id;
+
+  if (!_gum_quick_args_parse (args, "Z", &thread_id))
+    return JS_EXCEPTION;
+
+  gum_cloak_add_thread (thread_id);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_thread)
+{
+  GumThreadId thread_id;
+
+  if (!_gum_quick_args_parse (args, "Z", &thread_id))
+    return JS_EXCEPTION;
+
+  gum_cloak_remove_thread (thread_id);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_thread)
+{
+  GumThreadId thread_id;
+
+  if (!_gum_quick_args_parse (args, "Z", &thread_id))
+    return JS_EXCEPTION;
+
+  return JS_NewBool (ctx, gum_cloak_has_thread (thread_id));
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_range)
+{
+  gpointer address;
+  gsize size;
+  GumMemoryRange range;
+
+  if (!_gum_quick_args_parse (args, "pZ", &address, &size))
+    return JS_EXCEPTION;
+
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  gum_cloak_add_range (&range);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_range)
+{
+  gpointer address;
+  gsize size;
+  GumMemoryRange range;
+
+  if (!_gum_quick_args_parse (args, "pZ", &address, &size))
+    return JS_EXCEPTION;
+
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  gum_cloak_remove_range (&range);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_range_containing)
+{
+  gpointer address;
+
+  if (!_gum_quick_args_parse (args, "p", &address))
+    return JS_EXCEPTION;
+
+  return JS_NewBool (ctx, gum_cloak_has_range_containing (
+        GUM_ADDRESS (address)));
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_clip_range)
+{
+  JSValue result;
+  gpointer address;
+  gsize size;
+  GumMemoryRange range;
+  GArray * visible;
+  guint i;
+
+  if (!_gum_quick_args_parse (args, "pZ", &address, &size))
+    return JS_EXCEPTION;
+
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  visible = gum_cloak_clip_range (&range);
+  if (visible == NULL)
+    return JS_NULL;
+
+  result = JS_NewArray (ctx);
+  for (i = 0; i != visible->len; i++)
+  {
+    GumMemoryRange * range;
+
+    range = &g_array_index (visible, GumMemoryRange, i);
+
+    JS_DefinePropertyValueUint32 (ctx, result, i,
+        _gum_quick_memory_range_new (ctx, range, core),
+        JS_PROP_C_W_E);
+  }
+
+  g_array_free (visible, TRUE);
+
+  return result;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_file_descriptor)
+{
+  gint fd;
+
+  if (!_gum_quick_args_parse (args, "i", &fd))
+    return JS_EXCEPTION;
+
+  gum_cloak_add_file_descriptor (fd);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_file_descriptor)
+{
+  gint fd;
+
+  if (!_gum_quick_args_parse (args, "i", &fd))
+    return JS_EXCEPTION;
+
+  gum_cloak_remove_file_descriptor (fd);
+
+  return JS_UNDEFINED;
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_file_descriptor)
+{
+  gint fd;
+
+  if (!_gum_quick_args_parse (args, "i", &fd))
+    return JS_EXCEPTION;
+
+  return JS_NewBool (ctx, gum_cloak_has_file_descriptor (fd));
+}

--- a/bindings/gumjs/gumquickcloak.h
+++ b/bindings/gumjs/gumquickcloak.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#ifndef __GUM_QUICK_CLOAK_H__
+#define __GUM_QUICK_CLOAK_H__
+
+#include "gumquickcore.h"
+
+G_BEGIN_DECLS
+
+typedef struct _GumQuickCloak GumQuickCloak;
+
+struct _GumQuickCloak
+{
+  GumQuickCore * core;
+};
+
+G_GNUC_INTERNAL void _gum_quick_cloak_init (GumQuickCloak * self,
+    JSValue ns, GumQuickCore * core);
+G_GNUC_INTERNAL void _gum_quick_cloak_dispose (GumQuickCloak * self);
+G_GNUC_INTERNAL void _gum_quick_cloak_finalize (GumQuickCloak * self);
+
+G_END_DECLS
+
+#endif

--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -8,6 +8,7 @@
 
 #include "gumquickapiresolver.h"
 #include "gumquickchecksum.h"
+#include "gumquickcloak.h"
 #include "gumquickcmodule.h"
 #include "gumquickcoderelocator.h"
 #include "gumquickcodewriter.h"
@@ -78,6 +79,7 @@ struct _GumQuickScript
   GumQuickCodeWriter code_writer;
   GumQuickCodeRelocator code_relocator;
   GumQuickStalker stalker;
+  GumQuickCloak cloak;
 
   GumScriptMessageHandler message_handler;
   gpointer message_handler_data;
@@ -166,6 +168,7 @@ struct _GumQuickWorker
   GumQuickInstruction instruction;
   GumQuickCodeWriter code_writer;
   GumQuickCodeRelocator code_relocator;
+  GumQuickCloak cloak;
 };
 
 enum _GumWorkerState
@@ -494,6 +497,7 @@ gum_quick_script_create_context (GumQuickScript * self,
       &self->code_writer, &self->instruction, core);
   _gum_quick_stalker_init (&self->stalker, global_obj, &self->code_writer,
       &self->instruction, core);
+  _gum_quick_cloak_init (&self->cloak, global_obj, core);
 
   JS_FreeValue (ctx, global_obj);
 
@@ -528,6 +532,7 @@ gum_quick_script_destroy_context (GumQuickScript * self)
 
     _gum_quick_scope_enter (&scope, core);
 
+    _gum_quick_cloak_dispose (&self->cloak);
     _gum_quick_stalker_dispose (&self->stalker);
     _gum_quick_code_relocator_dispose (&self->code_relocator);
     _gum_quick_code_writer_dispose (&self->code_writer);
@@ -570,6 +575,7 @@ gum_quick_script_destroy_context (GumQuickScript * self)
     core->current_scope = NULL;
   }
 
+  _gum_quick_cloak_finalize (&self->cloak);
   _gum_quick_stalker_finalize (&self->stalker);
   _gum_quick_code_relocator_finalize (&self->code_relocator);
   _gum_quick_code_writer_finalize (&self->code_writer);
@@ -1149,6 +1155,7 @@ _gum_quick_script_make_worker (GumQuickScript * self,
     _gum_quick_code_writer_init (&worker->code_writer, global_obj, core);
     _gum_quick_code_relocator_init (&worker->code_relocator, global_obj,
         &worker->code_writer, &worker->instruction, core);
+    _gum_quick_cloak_init (&worker->cloak, global_obj, core);
 
     core->current_scope = NULL;
   }

--- a/bindings/gumjs/gumv8cloak.cpp
+++ b/bindings/gumjs/gumv8cloak.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#include "gumv8cloak.h"
+
+#include "gumv8macros.h"
+
+#include <gum/gumcloak.h>
+
+#define GUMJS_MODULE_NAME Cloak
+
+using namespace v8;
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_thread)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_thread)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_thread)
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_range)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_range)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_range_containing)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_clip_range)
+
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_add_file_descriptor)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_remove_file_descriptor)
+GUMJS_DECLARE_FUNCTION (gumjs_cloak_has_file_descriptor)
+
+static const GumV8Function gumjs_cloak_functions[] =
+{
+  { "addThread", gumjs_cloak_add_thread },
+  { "removeThread", gumjs_cloak_remove_thread },
+  { "hasThread", gumjs_cloak_has_thread },
+
+  { "_addRange", gumjs_cloak_add_range },
+  { "_removeRange", gumjs_cloak_remove_range },
+  { "hasRangeContaining", gumjs_cloak_has_range_containing },
+  { "_clipRange", gumjs_cloak_clip_range },
+
+  { "addFileDescriptor", gumjs_cloak_add_file_descriptor },
+  { "removeFileDescriptor", gumjs_cloak_remove_file_descriptor },
+  { "hasFileDescriptor", gumjs_cloak_has_file_descriptor },
+
+  { NULL, NULL }
+};
+
+void
+_gum_v8_cloak_init (GumV8Cloak * self,
+                    GumV8Core * core,
+                    Local<ObjectTemplate> scope)
+{
+  auto isolate = core->isolate;
+
+  self->core = core;
+
+  auto module = External::New (isolate, self);
+
+  auto cloak = _gum_v8_create_module ("Cloak", scope, isolate);
+  _gum_v8_module_add (module, cloak, gumjs_cloak_functions, isolate);
+}
+
+void
+_gum_v8_cloak_realize (GumV8Cloak * self)
+{
+}
+
+void
+_gum_v8_cloak_dispose (GumV8Cloak * self)
+{
+}
+
+void
+_gum_v8_cloak_finalize (GumV8Cloak * self)
+{
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_thread)
+{
+  GumThreadId thread_id;
+  if (!_gum_v8_args_parse (args, "Z", &thread_id))
+    return;
+
+  gum_cloak_add_thread (thread_id);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_thread)
+{
+  GumThreadId thread_id;
+  if (!_gum_v8_args_parse (args, "Z", &thread_id))
+    return;
+
+  gum_cloak_remove_thread (thread_id);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_thread)
+{
+  GumThreadId thread_id;
+  if (!_gum_v8_args_parse (args, "Z", &thread_id))
+    return;
+
+  info.GetReturnValue ().Set (gum_cloak_has_thread (thread_id) == TRUE);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_range)
+{
+  gpointer address;
+  gsize size;
+  if (!_gum_v8_args_parse (args, "pZ", &address, &size))
+    return;
+
+  GumMemoryRange range;
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  gum_cloak_add_range (&range);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_range)
+{
+  gpointer address;
+  gsize size;
+  if (!_gum_v8_args_parse (args, "pZ", &address, &size))
+    return;
+
+  GumMemoryRange range;
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  gum_cloak_remove_range (&range);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_range_containing)
+{
+  gpointer address;
+  if (!_gum_v8_args_parse (args, "p", &address))
+    return;
+
+  info.GetReturnValue ().Set (gum_cloak_has_range_containing (
+      GUM_ADDRESS (address)) == TRUE);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_clip_range)
+{
+  gpointer address;
+  gsize size;
+  if (!_gum_v8_args_parse (args, "pZ", &address, &size))
+    return;
+
+  GumMemoryRange range;
+  range.base_address = GUM_ADDRESS (address);
+  range.size = size;
+
+  auto context = isolate->GetCurrentContext ();
+
+  GArray * visible = gum_cloak_clip_range (&range);
+  if (visible == NULL)
+  {
+    info.GetReturnValue ().SetNull ();
+    return;
+  }
+
+  auto result = Array::New (isolate, visible->len);
+  for (guint i = 0; i != visible->len; i++)
+  {
+    auto range = &g_array_index (visible, GumMemoryRange, i);
+    auto range_obj = Object::New (isolate);
+    _gum_v8_object_set_pointer (range_obj, "base", range->base_address, core);
+    _gum_v8_object_set_uint (range_obj, "size", range->size, core);
+    result->Set (context, i, range_obj).Check ();
+  }
+
+  info.GetReturnValue ().Set (result);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_add_file_descriptor)
+{
+  gint fd;
+  if (!_gum_v8_args_parse (args, "i", &fd))
+    return;
+
+  gum_cloak_add_file_descriptor (fd);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_remove_file_descriptor)
+{
+  gint fd;
+  if (!_gum_v8_args_parse (args, "i", &fd))
+    return;
+
+  gum_cloak_remove_file_descriptor (fd);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_cloak_has_file_descriptor)
+{
+  gint fd;
+  if (!_gum_v8_args_parse (args, "i", &fd))
+    return;
+
+  info.GetReturnValue ().Set (gum_cloak_has_file_descriptor (fd) == TRUE);
+}

--- a/bindings/gumjs/gumv8cloak.h
+++ b/bindings/gumjs/gumv8cloak.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+#ifndef __GUM_V8_CLOAK_H__
+#define __GUM_V8_CLOAK_H__
+
+#include "gumv8core.h"
+
+struct GumV8Cloak
+{
+  GumV8Core * core;
+};
+
+G_GNUC_INTERNAL void _gum_v8_cloak_init (GumV8Cloak * self,
+    GumV8Core * core, v8::Local<v8::ObjectTemplate> scope);
+G_GNUC_INTERNAL void _gum_v8_cloak_realize (GumV8Cloak * self);
+G_GNUC_INTERNAL void _gum_v8_cloak_dispose (GumV8Cloak * self);
+G_GNUC_INTERNAL void _gum_v8_cloak_finalize (GumV8Cloak * self);
+
+#endif

--- a/bindings/gumjs/gumv8script-priv.h
+++ b/bindings/gumjs/gumv8script-priv.h
@@ -9,6 +9,7 @@
 
 #include "gumv8apiresolver.h"
 #include "gumv8checksum.h"
+#include "gumv8cloak.h"
 #include "gumv8cmodule.h"
 #include "gumv8coderelocator.h"
 #include "gumv8codewriter.h"
@@ -95,6 +96,8 @@ struct _GumV8Script
   GumV8CodeWriter code_writer;
   GumV8CodeRelocator code_relocator;
   GumV8Stalker stalker;
+  GumV8Cloak cloak;
+
   v8::Global<v8::Context> * context;
   GumESProgram * program;
 

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -538,6 +538,7 @@ gum_v8_script_create_context (GumV8Script * self,
         &self->instruction, &self->core, global_templ);
     _gum_v8_stalker_init (&self->stalker, &self->code_writer,
         &self->instruction, &self->core, global_templ);
+    _gum_v8_cloak_init (&self->cloak, &self->core, global_templ);
 
     Local<Context> context (Context::New (isolate, NULL, global_templ));
     {
@@ -570,6 +571,7 @@ gum_v8_script_create_context (GumV8Script * self,
     _gum_v8_code_writer_realize (&self->code_writer);
     _gum_v8_code_relocator_realize (&self->code_relocator);
     _gum_v8_stalker_realize (&self->stalker);
+    _gum_v8_cloak_realize (&self->cloak);
 
     self->program = gum_v8_script_compile (self, isolate, context, error);
   }
@@ -1099,6 +1101,7 @@ gum_v8_script_destroy_context (GumV8Script * self)
   {
     ScriptScope scope (self);
 
+    _gum_v8_cloak_dispose (&self->cloak);
     _gum_v8_stalker_dispose (&self->stalker);
     _gum_v8_code_relocator_dispose (&self->code_relocator);
     _gum_v8_code_writer_dispose (&self->code_writer);
@@ -1131,6 +1134,7 @@ gum_v8_script_destroy_context (GumV8Script * self)
   delete self->context;
   self->context = nullptr;
 
+  _gum_v8_cloak_finalize (&self->cloak);
   _gum_v8_stalker_finalize (&self->stalker);
   _gum_v8_code_relocator_finalize (&self->code_relocator);
   _gum_v8_code_writer_finalize (&self->code_writer);

--- a/bindings/gumjs/meson.build
+++ b/bindings/gumjs/meson.build
@@ -88,6 +88,7 @@ if v8_dep.found()
     'gumv8instruction.cpp',
     'gumv8codewriter.cpp',
     'gumv8coderelocator.cpp',
+    'gumv8cloak.cpp',
   ]
   if sqlite_dep.found()
     gumjs_sources += 'gumv8database.cpp'

--- a/bindings/gumjs/meson.build
+++ b/bindings/gumjs/meson.build
@@ -46,6 +46,7 @@ if quickjs_dep.found()
     'gumquickinstruction.c',
     'gumquickcodewriter.c',
     'gumquickcoderelocator.c',
+    'gumquickcloak.c',
   ]
   if sqlite_dep.found()
     gumjs_sources += 'gumquickdatabase.c'

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -827,6 +827,33 @@ if (engine.SqliteDatabase !== undefined) {
   });
 }
 
+Object.defineProperties(Cloak, {
+  hasCurrentThread: {
+    enumerable: true,
+    value() {
+      return Cloak.hasThread(Process.getCurrentThreadId());
+    }
+  },
+  addRange: {
+    enumerable: true,
+    value(range) {
+      Cloak._addRange(range.base, range.size);
+    }
+  },
+  removeRange: {
+    enumerable: true,
+    value(range) {
+      Cloak._removeRange(range.base, range.size);
+    }
+  },
+  clipRange: {
+    enumerable: true,
+    value(range) {
+      return Cloak._clipRange(range.base, range.size);
+    }
+  },
+});
+
 function makeEnumerateApi(mod, name, arity) {
   const impl = mod['_' + name];
 

--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -10,6 +10,7 @@
 #include "gumarm64reader.h"
 #include "gumarm64relocator.h"
 #include "gumarm64writer.h"
+#include "gumcloak.h"
 #include "gumlibc.h"
 #include "gummemory.h"
 #ifdef HAVE_DARWIN
@@ -1012,11 +1013,17 @@ static void
 gum_interceptor_backend_create_thunks (GumInterceptorBackend * self)
 {
   gsize page_size, code_size;
+  GumMemoryRange range;
 
   page_size = gum_query_page_size ();
   code_size = page_size;
 
   self->thunks = gum_memory_allocate (NULL, code_size, page_size, GUM_PAGE_RW);
+
+  range.base_address = GUM_ADDRESS (self->thunks);
+  range.size = code_size;
+  gum_cloak_add_range (&range);
+
   gum_memory_patch_code (self->thunks, 1024,
       (GumMemoryPatchApplyFunc) gum_emit_thunks, self);
 }

--- a/gum/gumcloak.c
+++ b/gum/gumcloak.c
@@ -427,9 +427,11 @@ gum_cloak_has_range_containing (GumAddress address)
  * @range: the range to determine the visible parts of
  *
  * Determines how much of the given memory `range` is currently visible.
- * May return an empty array if the entire range is cloaked.
+ * May return an empty array if the entire range is cloaked, or NULL if it is
+ * entirely visible.
  *
- * Returns: (transfer full) (element-type Gum.MemoryRange): visible parts
+ * Returns: (transfer full) (element-type Gum.MemoryRange): NULL if all
+ * visible, or visible parts.
  */
 GArray *
 gum_cloak_clip_range (const GumMemoryRange * range)


### PR DESCRIPTION
This change adds the `Cloak` module, exposing the add / remove / query apis from `gumcloak.h`. This module is exposed to the Worker too.

There are 2 more loosely related changes:
- add a missing call to `gum_cloak_add_range` in Interceptor to cloak the thunks on arm64
- fix the docs of `gum_cloak_clip_range` to describe the actual semantics of the return value