### PR TITLE
interceptor: Check lib prefix anyways in claiming grafts on arm64

### DIFF
--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -586,22 +586,28 @@ gum_compare_grafted_hook (const void * element_a,
 static gboolean
 gum_is_system_module (const gchar * path)
 {
-  static gboolean initialized = FALSE;
+  gboolean has_system_prefix;
+  static gboolean api_initialized = FALSE;
   static bool (* dsc_contains_path) (const char * path) = NULL;
 
-  if (!initialized)
+  has_system_prefix = g_str_has_prefix (path, "/System/") ||
+      g_str_has_prefix (path, "/usr/lib/") ||
+      g_str_has_prefix (path, "/Developer/") ||
+      g_str_has_prefix (path, "/private/preboot/");
+  if (has_system_prefix)
+    return TRUE;
+
+  if (!api_initialized)
   {
     dsc_contains_path =
         dlsym (RTLD_DEFAULT, "_dyld_shared_cache_contains_path");
-    initialized = TRUE;
+    api_initialized = TRUE;
   }
 
   if (dsc_contains_path != NULL)
     return dsc_contains_path (path);
 
-  return g_str_has_prefix (path, "/System/") ||
-      g_str_has_prefix (path, "/usr/lib/") ||
-      g_str_has_prefix (path, "/Developer/");
+  return FALSE;
 }
 
 #else


### PR DESCRIPTION
This change is needed because since iOS 17, Xcode can load the `/private/preboot/Cryptexes/OS/usr/lib/libLogRedirect.dylib` library (there’s also a macOS counterpart:
`/System/Cryptexes/OS/usr/lib/libLogRedirect.dylib`) which uses interposing for wrapping a bunch of commonly used (and commonly hooked) symbols.

Since those libraries are not in the dyld cache, Frida was flagging them as non-system libraries, making Interceptor fail loudly (instead of silently) if no direct import grafts were found in the loaded binaries for those symbols.

This change adds a check for `/private/preboot` prefix, and now the prefix check is in OR with the dyld cache one instead of being mutually exclusive.