### PR TITLE
Add Memory.queryProtection()

### DIFF
--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -384,12 +384,19 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_query_protection)
   GumPageProtection prot;
 
   if (!_gum_quick_args_parse (args, "p", &address))
-    return JS_EXCEPTION;
+    goto propagate_exception;
 
   if (!gum_memory_query_protection (address, &prot))
-    return JS_EXCEPTION;
+    goto query_failed;
 
   return _gum_quick_page_protection_new (ctx, prot);
+
+query_failed:
+  _gum_quick_throw_literal (ctx, "failed to query address");
+
+propagate_exception:
+  return JS_EXCEPTION;
+
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_patch_code)

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -78,6 +78,7 @@ struct _GumMemoryScanSyncContext
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_copy)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_protect)
+GUMJS_DECLARE_FUNCTION (gumjs_memory_query_protection)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_patch_code)
 static void gum_memory_patch_context_apply (gpointer mem,
     GumMemoryPatchContext * self);
@@ -169,6 +170,7 @@ static const JSCFunctionListEntry gumjs_memory_entries[] =
   JS_CFUNC_DEF ("_alloc", 0, gumjs_memory_alloc),
   JS_CFUNC_DEF ("copy", 0, gumjs_memory_copy),
   JS_CFUNC_DEF ("protect", 0, gumjs_memory_protect),
+  JS_CFUNC_DEF ("queryProtection", 0, gumjs_memory_query_protection),
   JS_CFUNC_DEF ("_patchCode", 0, gumjs_memory_patch_code),
   JS_CFUNC_DEF ("_checkCodePointer", 0, gumjs_memory_check_code_pointer),
 
@@ -374,6 +376,20 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_protect)
     success = TRUE;
 
   return JS_NewBool (ctx, success);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_memory_query_protection)
+{
+  gpointer address;
+  GumPageProtection prot;
+
+  if (!_gum_quick_args_parse (args, "p", &address))
+    return JS_EXCEPTION;
+
+  if (!gum_memory_query_protection (address, &prot))
+    return JS_EXCEPTION;
+
+  return _gum_quick_page_protection_new (ctx, prot);
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_patch_code)

--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -396,7 +396,6 @@ query_failed:
 
 propagate_exception:
   return JS_EXCEPTION;
-
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_patch_code)

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -360,18 +360,12 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_query_protection)
     return;
 
   if (!gum_memory_query_protection (address, &prot))
+  {
+    _gum_v8_throw_ascii_literal (isolate, "failed to query address");
     return;
+  }
 
-  gchar prot_str[4] = "---";
-
-  if ((prot & GUM_PAGE_READ) != 0)
-    prot_str[0] = 'r';
-  if ((prot & GUM_PAGE_WRITE) != 0)
-    prot_str[1] = 'w';
-  if ((prot & GUM_PAGE_EXECUTE) != 0)
-    prot_str[2] = 'x';
-
-  info.GetReturnValue ().Set (_gum_v8_string_new_ascii (isolate, prot_str));
+  info.GetReturnValue ().Set (_gum_v8_page_protection_new (isolate,  prot));
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_patch_code)

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -75,6 +75,7 @@ struct GumMemoryScanSyncContext
 GUMJS_DECLARE_FUNCTION (gumjs_memory_alloc)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_copy)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_protect)
+GUMJS_DECLARE_FUNCTION (gumjs_memory_query_protection)
 GUMJS_DECLARE_FUNCTION (gumjs_memory_patch_code)
 static void gum_memory_patch_context_apply (gpointer mem,
     GumMemoryPatchContext * self);
@@ -156,6 +157,7 @@ static const GumV8Function gumjs_memory_functions[] =
   { "_alloc", gumjs_memory_alloc },
   { "copy", gumjs_memory_copy },
   { "protect", gumjs_memory_protect },
+  { "queryProtection", gumjs_memory_query_protection },
   { "_patchCode", gumjs_memory_patch_code },
   { "_checkCodePointer", gumjs_memory_check_code_pointer },
 
@@ -347,6 +349,29 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_protect)
     success = true;
 
   info.GetReturnValue ().Set (success);
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_memory_query_protection)
+{
+  gpointer address;
+  GumPageProtection prot;
+
+  if (!_gum_v8_args_parse (args, "p", &address))
+    return;
+
+  if (!gum_memory_query_protection (address, &prot))
+    return;
+
+  gchar prot_str[4] = "---";
+
+  if ((prot & GUM_PAGE_READ) != 0)
+    prot_str[0] = 'r';
+  if ((prot & GUM_PAGE_WRITE) != 0)
+    prot_str[1] = 'w';
+  if ((prot & GUM_PAGE_EXECUTE) != 0)
+    prot_str[2] = 'x';
+
+  info.GetReturnValue ().Set (_gum_v8_string_new_ascii (isolate, prot_str));
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_memory_patch_code)

--- a/bindings/gumjs/gumv8value.cpp
+++ b/bindings/gumjs/gumv8value.cpp
@@ -1713,16 +1713,10 @@ _gum_v8_object_set_page_protection (Local<Object> object,
                                     GumPageProtection prot,
                                     GumV8Core * core)
 {
-  gchar prot_str[4] = "---";
-
-  if ((prot & GUM_PAGE_READ) != 0)
-    prot_str[0] = 'r';
-  if ((prot & GUM_PAGE_WRITE) != 0)
-    prot_str[1] = 'w';
-  if ((prot & GUM_PAGE_EXECUTE) != 0)
-    prot_str[2] = 'x';
-
-  return _gum_v8_object_set_ascii (object, key, prot_str, core);
+  return _gum_v8_object_set (object,
+      key,
+      _gum_v8_page_protection_new (core->isolate, prot),
+      core);
 }
 
 GArray *
@@ -1809,6 +1803,22 @@ _gum_v8_memory_range_get (Local<Value> value,
   range->base_address = GUM_ADDRESS (base);
   range->size = size_value.As<Number> ()->Uint32Value (context).ToChecked ();
   return TRUE;
+}
+
+v8::Local<v8::String>
+_gum_v8_page_protection_new (v8::Isolate * isolate,
+                             GumPageProtection prot)
+{
+  gchar prot_str[4] = "---";
+
+  if ((prot & GUM_PAGE_READ) != 0)
+    prot_str[0] = 'r';
+  if ((prot & GUM_PAGE_WRITE) != 0)
+    prot_str[1] = 'w';
+  if ((prot & GUM_PAGE_EXECUTE) != 0)
+    prot_str[2] = 'x';
+
+  return _gum_v8_string_new_ascii (isolate, prot_str);
 }
 
 gboolean

--- a/bindings/gumjs/gumv8value.h
+++ b/bindings/gumjs/gumv8value.h
@@ -162,6 +162,8 @@ G_GNUC_INTERNAL GArray * _gum_v8_memory_ranges_get (v8::Local<v8::Value> value,
 G_GNUC_INTERNAL gboolean _gum_v8_memory_range_get (v8::Local<v8::Value> value,
     GumMemoryRange * range, GumV8Core * core);
 
+G_GNUC_INTERNAL v8::Local<v8::String> _gum_v8_page_protection_new (
+    v8::Isolate * isolate, GumPageProtection prot);
 G_GNUC_INTERNAL gboolean _gum_v8_page_protection_get (
     v8::Local<v8::Value> prot_val, GumPageProtection * prot,
     GumV8Core * core);

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -253,6 +253,14 @@ gum_memory_is_readable (gconstpointer address,
   return is_readable;
 }
 
+gboolean
+gum_memory_query_protection (gconstpointer address,
+                             GumPageProtection * prot)
+{
+  return gum_darwin_query_protection (mach_task_self (), GUM_ADDRESS (address),
+      prot);
+}
+
 guint8 *
 gum_memory_read (gconstpointer address,
                  gsize len,

--- a/gum/backend-freebsd/gummemory-freebsd.c
+++ b/gum/backend-freebsd/gummemory-freebsd.c
@@ -53,6 +53,18 @@ gum_memory_is_writable (gconstpointer address,
   return size >= len && (prot & GUM_PAGE_WRITE) != 0;
 }
 
+gboolean
+gum_memory_query_protection (gconstpointer address,
+                             GumPageProtection * prot)
+{
+  gsize size;
+
+  if (!gum_memory_get_protection (address, 1, &size, prot))
+    return FALSE;
+
+  return size >= 1;
+}
+
 guint8 *
 gum_memory_read (gconstpointer address,
                  gsize len,

--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -45,6 +45,18 @@ gum_memory_is_writable (gconstpointer address,
   return size >= len && (prot & GUM_PAGE_WRITE) != 0;
 }
 
+gboolean
+gum_memory_query_protection (gconstpointer address,
+                             GumPageProtection * prot)
+{
+  gsize size;
+
+  if (!gum_memory_get_protection (address, 1, &size, prot))
+    return FALSE;
+
+  return size >= 1;
+}
+
 guint8 *
 gum_memory_read (gconstpointer address,
                  gsize len,

--- a/gum/backend-qnx/gummemory-qnx.c
+++ b/gum/backend-qnx/gummemory-qnx.c
@@ -46,6 +46,18 @@ gum_memory_is_writable (gconstpointer address,
   return size >= len && (prot & GUM_PAGE_WRITE) != 0;
 }
 
+gboolean
+gum_memory_query_protection (gconstpointer address,
+                             GumPageProtection * prot)
+{
+  gsize size;
+
+  if (!gum_memory_get_protection (address, 1, &size, prot))
+    return FALSE;
+
+  return size >= 1;
+}
+
 guint8 *
 gum_memory_read (gconstpointer address,
                  gsize len,

--- a/gum/backend-windows/gummemory-windows.c
+++ b/gum/backend-windows/gummemory-windows.c
@@ -53,12 +53,7 @@ gboolean
 gum_memory_query_protection (gconstpointer address,
                              GumPageProtection * prot)
 {
-  gsize size;
-
-  if (!gum_memory_get_protection (address, 1, &size, prot))
-    return FALSE;
-
-  return size >= 1;
+  return gum_memory_get_protection (address, 1, prot);
 }
 
 guint8 *

--- a/gum/backend-windows/gummemory-windows.c
+++ b/gum/backend-windows/gummemory-windows.c
@@ -49,6 +49,18 @@ gum_memory_is_readable (gconstpointer address,
   return (prot & GUM_PAGE_READ) != 0;
 }
 
+gboolean
+gum_memory_query_protection (gconstpointer address,
+                             GumPageProtection * prot)
+{
+  gsize size;
+
+  if (!gum_memory_get_protection (address, 1, &size, prot))
+    return FALSE;
+
+  return size >= 1;
+}
+
 guint8 *
 gum_memory_read (gconstpointer address,
                  gsize len,

--- a/gum/gummemory.h
+++ b/gum/gummemory.h
@@ -90,6 +90,8 @@ GUM_API guint gum_query_page_size (void);
 GUM_API gboolean gum_query_is_rwx_supported (void);
 GUM_API GumRwxSupport gum_query_rwx_support (void);
 GUM_API gboolean gum_memory_is_readable (gconstpointer address, gsize len);
+GUM_API gboolean gum_memory_query_protection (gconstpointer address,
+    GumPageProtection * prot);
 GUM_API guint8 * gum_memory_read (gconstpointer address, gsize len,
     gsize * n_bytes_read);
 GUM_API gboolean gum_memory_write (gpointer address, const guint8 * bytes,

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -115,6 +115,7 @@ TESTLIST_BEGIN (script)
     TESTENTRY (memory_can_be_copied)
     TESTENTRY (memory_can_be_duped)
     TESTENTRY (memory_can_be_protected)
+    TESTENTRY (memory_protection_can_be_queried)
     TESTENTRY (code_can_be_patched)
     TESTENTRY (s8_can_be_read)
     TESTENTRY (s8_can_be_written)
@@ -8134,6 +8135,31 @@ TESTCASE (memory_can_be_protected)
   gum_try_read_and_write_at (buf, 0, &exception_on_read, &exception_on_write);
   g_assert_true (exception_on_read);
   g_assert_true (exception_on_write);
+
+  gum_free_pages (buf);
+}
+
+TESTCASE (memory_protection_can_be_queried)
+{
+  gpointer buf;
+
+  buf = gum_alloc_n_pages (1, GUM_PAGE_RW);
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const x = " GUM_PTR_CONST ";"
+      "send(Memory.queryProtection(x) === 'rw-');"
+      "Memory.protect(x, 1, 'r--');"
+      "send(Memory.queryProtection(x) === 'r--');"
+      "Memory.protect(x, 1, 'r-x');"
+      "send(Memory.queryProtection(x) === 'r-x');"
+      "Memory.protect(x, 1, 'rw-');"
+      "send(Memory.queryProtection(x) === 'rw-');",
+      buf);
+
+  EXPECT_SEND_MESSAGE_WITH ("true");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+  EXPECT_SEND_MESSAGE_WITH ("true");
 
   gum_free_pages (buf);
 }


### PR DESCRIPTION
This change adds `gum_memory_query_protection` which takes an address and returns the current protection for the page which contains it.

It is accessible from js bindings through `Memory.queryProtection()`.

On the Darwin backend it's a thin wrapper on top of `gum_darwin_query_protection`, on all other platforms it relies instead on the respective private implementations of `gum_memory_get_protection`.