### PR TITLE
Fix: Stalker disrupts exclusive access by emitting a block event.

### DIFF
--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -2831,7 +2831,7 @@ gum_stalker_iterator_next (GumStalkerIterator * self,
 
   self->generator_context->instruction = instruction;
 
-  if (is_first_instruction && (self->exec_context->sink_mask & GUM_BLOCK) != 0)
+  if (is_first_instruction && (self->exec_context->sink_mask & GUM_BLOCK) != 0 && (self->exec_block->flags&GUM_EXEC_BLOCK_USES_EXCLUSIVE_ACCESS)==0)
   {
     gum_exec_block_write_block_event_code (self->exec_block, gc,
         GUM_CODE_INTERRUPTIBLE);
@@ -5445,7 +5445,7 @@ gum_exec_block_write_exec_event_code (GumExecBlock * block,
                                       GumCodeContext cc)
 {
   gum_exec_block_open_prolog (block, GUM_PROLOG_FULL, gc, gc->code_writer);
-
+  
   gum_arm64_writer_put_call_address_with_arguments (gc->code_writer,
       GUM_ADDRESS (gum_exec_ctx_emit_exec_event), 3,
       GUM_ARG_ADDRESS, GUM_ADDRESS (block->ctx),

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -2831,7 +2831,9 @@ gum_stalker_iterator_next (GumStalkerIterator * self,
 
   self->generator_context->instruction = instruction;
 
-  if (is_first_instruction && (self->exec_context->sink_mask & GUM_BLOCK) != 0 && (self->exec_block->flags&GUM_EXEC_BLOCK_USES_EXCLUSIVE_ACCESS)==0)
+  if (is_first_instruction &&
+     (self->exec_context->sink_mask & GUM_BLOCK) != 0 &&
+     (self->exec_block->flags&GUM_EXEC_BLOCK_USES_EXCLUSIVE_ACCESS)==0)
   {
     gum_exec_block_write_block_event_code (self->exec_block, gc,
         GUM_CODE_INTERRUPTIBLE);
@@ -5445,7 +5447,6 @@ gum_exec_block_write_exec_event_code (GumExecBlock * block,
                                       GumCodeContext cc)
 {
   gum_exec_block_open_prolog (block, GUM_PROLOG_FULL, gc, gc->code_writer);
-  
   gum_arm64_writer_put_call_address_with_arguments (gc->code_writer,
       GUM_ADDRESS (gum_exec_ctx_emit_exec_event), 3,
       GUM_ARG_ADDRESS, GUM_ADDRESS (block->ctx),

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2024 Alex Soler <asoler@nowsecure.com>
+ * Copyright (C) 2024 Sai Cao <1665673333@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -2833,7 +2834,7 @@ gum_stalker_iterator_next (GumStalkerIterator * self,
 
   if (is_first_instruction &&
      (self->exec_context->sink_mask & GUM_BLOCK) != 0 &&
-     (self->exec_block->flags&GUM_EXEC_BLOCK_USES_EXCLUSIVE_ACCESS)==0)
+     (self->exec_block->flags & GUM_EXEC_BLOCK_USES_EXCLUSIVE_ACCESS) == 0)
   {
     gum_exec_block_write_block_event_code (self->exec_block, gc,
         GUM_CODE_INTERRUPTIBLE);
@@ -5447,6 +5448,7 @@ gum_exec_block_write_exec_event_code (GumExecBlock * block,
                                       GumCodeContext cc)
 {
   gum_exec_block_open_prolog (block, GUM_PROLOG_FULL, gc, gc->code_writer);
+
   gum_arm64_writer_put_call_address_with_arguments (gc->code_writer,
       GUM_ADDRESS (gum_exec_ctx_emit_exec_event), 3,
       GUM_ARG_ADDRESS, GUM_ADDRESS (block->ctx),


### PR DESCRIPTION
Stalker generates the block event even when those blocks have exclusive access. This may disrupt the exclusive access when a user handles the block event.
It seems that the default stalker event sinker uses spinlocks, which can starve the following thread.

[check this issue](https://github.com/frida/frida/issues/2769)