### PR TITLE
Expose Cloak and Interceptor locks for usage in ThreadSuspendMonitor

### DIFF
--- a/gum/backend-arm/gumspinlock-arm.c
+++ b/gum/backend-arm/gumspinlock-arm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2021 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -33,6 +34,19 @@ gum_spinlock_acquire (GumSpinlock * spinlock)
   while (!g_atomic_int_compare_and_exchange (&self->is_held, FALSE, TRUE))
     ;
 #endif
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  GumSpinlockImpl * self = (GumSpinlockImpl *) spinlock;
+
+  if (self->is_held)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 void

--- a/gum/backend-arm64/gumspinlock-arm64.c
+++ b/gum/backend-arm64/gumspinlock-arm64.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -28,6 +29,19 @@ gum_spinlock_acquire (GumSpinlock * spinlock)
 
   while (__sync_lock_test_and_set (&self->is_held, 1))
     ;
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  GumSpinlockImpl * self = (GumSpinlockImpl *) spinlock;
+
+  if (self->is_held)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 void

--- a/gum/backend-mips/gumspinlock-mips.c
+++ b/gum/backend-mips/gumspinlock-mips.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -28,6 +29,19 @@ gum_spinlock_acquire (GumSpinlock * spinlock)
 
   while (__sync_lock_test_and_set (&self->is_held, 1))
     ;
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  GumSpinlockImpl * self = (GumSpinlockImpl *) spinlock;
+
+  if (self->is_held)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 void

--- a/gum/backend-x86/gumspinlock-amd64-msc.c
+++ b/gum/backend-x86/gumspinlock-amd64-msc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -28,6 +29,19 @@ gum_spinlock_acquire (GumSpinlock * spinlock)
 
   while (!g_atomic_int_compare_and_exchange (&self->is_held, FALSE, TRUE))
     ;
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  GumSpinlockImpl * self = (GumSpinlockImpl *) spinlock;
+
+  if (self->is_held)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 void

--- a/gum/backend-x86/gumspinlock-ia32-msc.c
+++ b/gum/backend-x86/gumspinlock-ia32-msc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -33,6 +34,19 @@ try_again:
 beach:
     ret;
   }
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  volatile guint32 is_held = *(guint32 *) spinlock;
+
+  if (is_held == 1)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 __declspec (naked) void

--- a/gum/backend-x86/gumspinlock-x86.c
+++ b/gum/backend-x86/gumspinlock-x86.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -28,6 +29,19 @@ gum_spinlock_acquire (GumSpinlock * spinlock)
 
   while (__sync_lock_test_and_set (&self->is_held, 1))
     ;
+}
+
+gboolean
+gum_spinlock_try_acquire (GumSpinlock * spinlock)
+{
+  GumSpinlockImpl * self = (GumSpinlockImpl *) spinlock;
+
+  if (self->is_held)
+    return FALSE;
+
+  gum_spinlock_acquire (spinlock);
+
+  return TRUE;
 }
 
 void

--- a/gum/gumcloak.c
+++ b/gum/gumcloak.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -734,4 +735,23 @@ gum_fd_compare (gconstpointer element_a,
   if (a < b)
     return -1;
   return 1;
+}
+
+void
+gum_cloak_with_lock_held (GumCloakLockedFunc func,
+                          gpointer user_data)
+{
+  gum_spinlock_acquire (&cloak_lock);
+  func (user_data);
+  gum_spinlock_release (&cloak_lock);
+}
+
+gboolean
+gum_cloak_is_locked (void)
+{
+  if (!gum_spinlock_try_acquire (&cloak_lock))
+    return TRUE;
+
+  gum_spinlock_release (&cloak_lock);
+  return FALSE;
 }

--- a/gum/gumcloak.h
+++ b/gum/gumcloak.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -19,6 +20,7 @@ typedef gboolean (* GumCloakFoundThreadFunc) (GumThreadId id,
 typedef gboolean (* GumCloakFoundRangeFunc) (const GumMemoryRange * range,
     gpointer user_data);
 typedef gboolean (* GumCloakFoundFDFunc) (gint fd, gpointer user_data);
+typedef void (* GumCloakLockedFunc) (gpointer user_data);
 
 GUM_API void gum_cloak_add_thread (GumThreadId id);
 GUM_API void gum_cloak_remove_thread (GumThreadId id);
@@ -38,6 +40,10 @@ GUM_API void gum_cloak_remove_file_descriptor (gint fd);
 GUM_API gboolean gum_cloak_has_file_descriptor (gint fd);
 GUM_API void gum_cloak_enumerate_file_descriptors (GumCloakFoundFDFunc func,
     gpointer user_data);
+
+GUM_API void gum_cloak_with_lock_held (GumCloakLockedFunc func,
+    gpointer user_data);
+GUM_API gboolean gum_cloak_is_locked (void);
 
 G_END_DECLS
 

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2008-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -807,6 +808,26 @@ gum_interceptor_restore (GumInvocationState * state)
   }
 
   g_array_set_size (stack, old_depth);
+}
+
+void
+gum_interceptor_with_lock_held (GumInterceptor * self,
+                                GumInterceptorLockedFunc func,
+                                gpointer user_data)
+{
+  GUM_INTERCEPTOR_LOCK (self);
+  func (user_data);
+  GUM_INTERCEPTOR_UNLOCK (self);
+}
+
+gboolean
+gum_interceptor_is_locked (GumInterceptor * self)
+{
+  if (!g_rec_mutex_trylock (&self->mutex))
+    return TRUE;
+
+  GUM_INTERCEPTOR_UNLOCK (self);
+  return FALSE;
 }
 
 gpointer

--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2008-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -19,6 +20,7 @@ GUM_DECLARE_FINAL_TYPE (GumInterceptor, gum_interceptor, GUM, INTERCEPTOR,
 
 typedef GArray GumInvocationStack;
 typedef guint GumInvocationState;
+typedef void (* GumInterceptorLockedFunc) (gpointer user_data);
 
 typedef enum
 {
@@ -75,6 +77,10 @@ GUM_API gpointer gum_invocation_stack_translate (GumInvocationStack * self,
 
 GUM_API void gum_interceptor_save (GumInvocationState * state);
 GUM_API void gum_interceptor_restore (GumInvocationState * state);
+
+GUM_API void gum_interceptor_with_lock_held (GumInterceptor * self,
+    GumInterceptorLockedFunc func, gpointer user_data);
+GUM_API gboolean gum_interceptor_is_locked (GumInterceptor * self);
 
 G_END_DECLS
 

--- a/gum/gumspinlock.h
+++ b/gum/gumspinlock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -23,6 +24,7 @@ struct _GumSpinlock
 void gum_spinlock_init (GumSpinlock * spinlock);
 
 void gum_spinlock_acquire (GumSpinlock * spinlock);
+gboolean gum_spinlock_try_acquire (GumSpinlock * spinlock);
 void gum_spinlock_release (GumSpinlock * spinlock);
 
 G_END_DECLS

--- a/gum/gumspinlock.h
+++ b/gum/gumspinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2010-2024 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -8,7 +8,7 @@
 #ifndef __GUM_SPINLOCK_H__
 #define __GUM_SPINLOCK_H__
 
-#include <glib.h>
+#include <gum/gumdefs.h>
 
 #define GUM_SPINLOCK_INIT { NULL }
 
@@ -21,11 +21,11 @@ struct _GumSpinlock
   gpointer data;
 };
 
-void gum_spinlock_init (GumSpinlock * spinlock);
+GUM_API void gum_spinlock_init (GumSpinlock * spinlock);
 
-void gum_spinlock_acquire (GumSpinlock * spinlock);
-gboolean gum_spinlock_try_acquire (GumSpinlock * spinlock);
-void gum_spinlock_release (GumSpinlock * spinlock);
+GUM_API void gum_spinlock_acquire (GumSpinlock * spinlock);
+GUM_API gboolean gum_spinlock_try_acquire (GumSpinlock * spinlock);
+GUM_API void gum_spinlock_release (GumSpinlock * spinlock);
 
 G_END_DECLS
 

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -387,9 +387,13 @@ namespace Gum {
 		public bool has_file_descriptor (int fd);
 		public void enumerate_file_descriptors (Gum.Cloak.FoundFDFunc func);
 
+		public void with_lock_held (Gum.Cloak.LockedFunc func);
+		public bool is_locked ();
+
 		public delegate bool FoundThreadFunc (Gum.ThreadId id);
 		public delegate bool FoundRangeFunc (Gum.MemoryRange range);
 		public delegate bool FoundFDFunc (int fd);
+		public delegate void LockedFunc ();
 	}
 
 	public struct CpuContext {

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -154,6 +154,11 @@ namespace Gum {
 
 		public void ignore_other_threads ();
 		public void unignore_other_threads ();
+
+		public void with_lock_held (Gum.Interceptor.LockedFunc func);
+		public bool is_locked ();
+
+		public delegate void LockedFunc ();
 	}
 
 	[CCode (type_cname = "GumInvocationListenerInterface")]


### PR DESCRIPTION
This also adds `gum_spinlock_try_acquire` which has the same semantics as `g_rec_mutex_trylock`.