### PR TITLE
Fix: preserved thread's system error over NativeCallback invocations

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -4433,6 +4433,7 @@ gum_quick_native_callback_invoke (ffi_cif * cif,
 {
   GumQuickNativeCallback * self = user_data;
   GumQuickCore * core = self->core;
+  gint saved_system_error;
   guintptr return_address = 0;
   guintptr stack_pointer = 0;
   guintptr frame_pointer = 0;
@@ -4447,6 +4448,8 @@ gum_quick_native_callback_invoke (ffi_cif * cif,
   int argc, i;
   JSValue * argv;
   JSValue result;
+
+  saved_system_error = gum_thread_get_system_error ();
 
 #if defined (HAVE_I386) && defined (_MSC_VER)
   return_address = GPOINTER_TO_SIZE (_ReturnAddress ());
@@ -4556,6 +4559,8 @@ gum_quick_native_callback_invoke (ffi_cif * cif,
   JS_FreeValue (ctx, self->wrapper);
 
   _gum_quick_scope_leave (&scope);
+
+  gum_thread_set_system_error (saved_system_error);
 }
 
 GUMJS_DEFINE_FINALIZER (gumjs_callback_context_finalize)

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -3434,6 +3434,7 @@ gum_v8_native_callback_invoke (ffi_cif * cif,
                                void ** args,
                                void * user_data)
 {
+  GumV8SystemErrorPreservationScope error_scope;
   guintptr return_address = 0;
   guintptr stack_pointer = 0;
   guintptr frame_pointer = 0;

--- a/bindings/gumjs/gumv8core.h
+++ b/bindings/gumjs/gumv8core.h
@@ -159,6 +159,23 @@ struct GumV8NativeCallback
   GumV8Core * core;
 };
 
+class GumV8SystemErrorPreservationScope
+{
+public:
+  GumV8SystemErrorPreservationScope ()
+    : saved_error (gum_thread_get_system_error ())
+  {
+  }
+
+  ~GumV8SystemErrorPreservationScope ()
+  {
+    gum_thread_set_system_error (saved_error);
+  }
+
+private:
+  gint saved_error;
+};
+
 G_GNUC_INTERNAL void _gum_v8_core_init (GumV8Core * self,
     GumV8Script * script, const gchar * runtime_source_map,
     GumV8MessageEmitter message_emitter, GumScriptScheduler * scheduler,

--- a/bindings/gumjs/gumv8stalker.cpp
+++ b/bindings/gumjs/gumv8stalker.cpp
@@ -70,23 +70,6 @@ struct GumV8CallProbe
   GumV8Stalker * module;
 };
 
-class GumV8SystemErrorPreservationScope
-{
-public:
-  GumV8SystemErrorPreservationScope ()
-    : saved_error (gum_thread_get_system_error ())
-  {
-  }
-
-  ~GumV8SystemErrorPreservationScope ()
-  {
-    gum_thread_set_system_error (saved_error);
-  }
-
-private:
-  gint saved_error;
-};
-
 static gboolean gum_v8_stalker_on_flush_timer_tick (GumV8Stalker * self);
 
 GUMJS_DECLARE_GETTER (gumjs_stalker_get_trust_threshold)


### PR DESCRIPTION
Fix for #789 : NativeCallback unable to leave thread's last error unchanged 

Though JavaScript function wrapped as a NativeCallback allows both inspecting and altering the current thread's system error, it wasn't possible to leave the system error as-is. Unless replaced by a value unequal to the original, the system error was being forced to 0 upon return from the NativeCallback. Fixed and tests added.