### PR TITLE
exceptor: Add SA_ONSTACK flag the POSIX backend

### DIFF
--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -252,7 +252,10 @@ gum_exceptor_backend_attach (GumExceptorBackend * self)
 
   action.sa_sigaction = gum_exceptor_backend_on_signal;
   sigemptyset (&action.sa_mask);
-  action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_ONSTACK;
+  action.sa_flags = SA_SIGINFO | SA_NODEFER;
+#ifdef SA_ONSTACK
+  action.sa_flags |= SA_ONSTACK;
+#endif
   for (i = 0; i != G_N_ELEMENTS (handled_signals); i++)
   {
     gint sig = handled_signals[i];

--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -252,7 +252,7 @@ gum_exceptor_backend_attach (GumExceptorBackend * self)
 
   action.sa_sigaction = gum_exceptor_backend_on_signal;
   sigemptyset (&action.sa_mask);
-  action.sa_flags = SA_SIGINFO | SA_NODEFER;
+  action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_ONSTACK;
   for (i = 0; i != G_N_ELEMENTS (handled_signals); i++)
   {
     gint sig = handled_signals[i];


### PR DESCRIPTION
Add the SA_ONSTACK flag to handle situations where and alternative signal stack has been configured using `sigaltstack`. In the situations where no alternative stack was configured, this behaves as if the flag has not been set.