### PR TITLE
cpu-features: Ignore CET SS unless actively used

### DIFF
--- a/gum/gum.c
+++ b/gum/gum.c
@@ -732,9 +732,6 @@ gum_do_query_cpu_features (void)
   gboolean cpu_supports_cet_ss = FALSE;
   gboolean os_enabled_xsave = FALSE;
   guint a, b, c, d;
-#ifdef HAVE_WINDOWS
-  PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY pol;
-#endif
 
   if (gum_get_cpuid (7, &a, &b, &c, &d))
   {
@@ -749,16 +746,19 @@ gum_do_query_cpu_features (void)
     features |= GUM_CPU_AVX2;
 
 #ifdef HAVE_WINDOWS
-  if (cpu_supports_cet_ss &&
-      GetProcessMitigationPolicy (
-        GetCurrentProcess (),
-        ProcessUserShadowStackPolicy,
-        &pol,
-        sizeof pol
-      ) &&
-      !pol.EnableUserShadowStack)
   {
-    cpu_supports_cet_ss = FALSE;
+    PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY pol;
+
+    if (cpu_supports_cet_ss &&
+        GetProcessMitigationPolicy (
+          GetCurrentProcess (),
+          ProcessUserShadowStackPolicy,
+          &pol,
+          sizeof (pol)) &&
+        !pol.EnableUserShadowStack)
+    {
+      cpu_supports_cet_ss = FALSE;
+    }
   }
 #endif
 


### PR DESCRIPTION
Since #791 we are ensuring a proper call-ret discipline in the x86 interceptor, if we detect that the CPU is compatible with Intel CET shadow stacks. As discussed in #791, this has an unnecessary performance cost if the mitigation is not used by the current process. This extra patch thus ignores CET shadow stacks compatibility on Windows if we detect that the current process is not using the mitigation. It might be cleaner to move this code outside `gum_do_query_cpu_features`, but putting it there makes the patch very simple and atomic.