### PR TITLE
Fix #807: recv wait can deadlock on an application thread

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2020-2022 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
+ * Copyright (C) 2024 Simon Zuckerbraun <Simon_Zuckerbraun@trendmicro.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -2735,7 +2735,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_wait_for_event)
 
   g_mutex_lock (&self->event_mutex);
 
-  while (self->event_count == thread_data->event_count_last_seen && self->event_source_available)
+  while (self->event_count == thread_data->event_count_last_seen
+      && self->event_source_available)
   {
     if (called_from_js_thread)
     {

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -45,6 +45,7 @@ typedef guint8 GumQuickCodeTraps;
 typedef guint8 GumQuickReturnValueShape;
 typedef struct _GumQuickFFIFunction GumQuickFFIFunction;
 typedef struct _GumQuickCallbackContext GumQuickCallbackContext;
+typedef struct _GumQuickThreadData GumQuickThreadData;
 
 struct _GumQuickFlushCallback
 {
@@ -166,10 +167,6 @@ struct _GumQuickThreadData
 {
     guint event_count_last_seen;
 };
-
-typedef struct _GumQuickThreadData GumQuickThreadData;
-
-static GPrivate gum_quick_thread_data;
 
 static gboolean gum_quick_core_handle_crashed_js (GumExceptionDetails * details,
     gpointer user_data);
@@ -1380,6 +1377,8 @@ static const JSCFunctionListEntry gumjs_worker_entries[] =
   JS_CFUNC_DEF ("terminate", 0, gumjs_worker_terminate),
   JS_CFUNC_DEF ("post", 0, gumjs_worker_post),
 };
+
+static GPrivate gum_quick_thread_data;
 
 void
 _gum_quick_core_init (GumQuickCore * self,

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -389,7 +389,7 @@ static JSValue gum_quick_value_from_ffi (JSContext * ctx,
 static void gum_quick_core_setup_atoms (GumQuickCore * self);
 static void gum_quick_core_teardown_atoms (GumQuickCore * self);
 
-static GumQuickThreadData * get_gum_quick_thread_data ();
+static GumQuickThreadData * get_gum_quick_thread_data (void);
 
 static const JSCFunctionListEntry gumjs_root_entries[] =
 {
@@ -5847,7 +5847,8 @@ gum_quick_core_teardown_atoms (GumQuickCore * self)
 #undef GUM_TEARDOWN_ATOM
 }
 
-static GumQuickThreadData * get_gum_quick_thread_data ()
+static GumQuickThreadData *
+get_gum_quick_thread_data (void)
 {
   GumQuickThreadData * data = g_private_get (&gum_quick_thread_data);
 

--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -2723,7 +2723,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_wait_for_event)
   GumQuickScope scope = GUM_QUICK_SCOPE_INIT (self);
   GMainContext * context;
   gboolean called_from_js_thread;
-  GumQuickThreadData * thread_data = get_gum_quick_thread_data();
+  GumQuickThreadData * thread_data = get_gum_quick_thread_data ();
   gboolean event_source_available;
 
   _gum_quick_scope_perform_pending_io (self->current_scope);

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -389,7 +389,7 @@ static gboolean gum_v8_value_to_ffi_type (GumV8Core * core,
 static gboolean gum_v8_value_from_ffi_type (GumV8Core * core,
     Local<Value> * svalue, const GumFFIValue * value, const ffi_type * type);
 
-static GumV8ThreadData * get_gum_v8_thread_data();
+static GumV8ThreadData * get_gum_v8_thread_data ();
 
 static const GumV8Function gumjs_global_functions[] =
 {

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -1610,7 +1610,6 @@ GUMJS_DEFINE_FUNCTION (gumjs_set_incoming_message_callback)
 
 GUMJS_DEFINE_FUNCTION (gumjs_wait_for_event)
 {
-  GumV8ThreadData * thread_data = get_gum_v8_thread_data ();
   gboolean event_source_available;
 
   core->current_scope->PerformPendingIO ();
@@ -1618,6 +1617,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_wait_for_event)
   {
     ScriptUnlocker unlocker (core);
 
+    auto thread_data = get_gum_v8_thread_data ();
     auto context = gum_script_scheduler_get_js_context (core->scheduler);
     gboolean called_from_js_thread = g_main_context_is_owner (context);
 
@@ -4595,7 +4595,8 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
   return TRUE;
 }
 
-static GumV8ThreadData * get_gum_v8_thread_data ()
+static GumV8ThreadData *
+get_gum_v8_thread_data ()
 {
   GumV8ThreadData * data = (GumV8ThreadData *) g_private_get (&gum_v8_thread_data);
 

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -4604,7 +4604,7 @@ get_gum_v8_thread_data ()
   {
     data = g_new0 (GumV8ThreadData, 1);
     data->event_count_last_seen = 0;
-    g_private_set(&gum_v8_thread_data, (gpointer) data);
+    g_private_set (&gum_v8_thread_data, (gpointer) data);
   }
 
   return data;

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -5,6 +5,7 @@
  * Copyright (C) 2020-2022 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
+ * Copyright (C) 2024 Simon Zuckerbraun <Simon_Zuckerbraun@trendmicro.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -1623,7 +1623,8 @@ GUMJS_DEFINE_FUNCTION (gumjs_wait_for_event)
 
     g_mutex_lock (&core->event_mutex);
 
-    while (core->event_count == thread_data->event_count_last_seen && core->event_source_available)
+    while (core->event_count == thread_data->event_count_last_seen
+        && core->event_source_available)
     {
       if (called_from_js_thread)
       {
@@ -4598,7 +4599,8 @@ gum_v8_value_from_ffi_type (GumV8Core * core,
 static GumV8ThreadData *
 get_gum_v8_thread_data ()
 {
-  GumV8ThreadData * data = (GumV8ThreadData *) g_private_get (&gum_v8_thread_data);
+  GumV8ThreadData * data =
+      (GumV8ThreadData *) g_private_get (&gum_v8_thread_data);
 
   if (data == NULL)
   {

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -179,14 +179,10 @@ struct GumV8SourceMap
   GumV8Core * core;
 };
 
-struct _GumV8ThreadData
+struct GumV8ThreadData
 {
     guint event_count_last_seen;
 };
-
-typedef struct _GumV8ThreadData GumV8ThreadData;
-
-static GPrivate gum_v8_thread_data;
 
 static gboolean gum_v8_core_handle_crashed_js (GumExceptionDetails * details,
     gpointer user_data);
@@ -538,6 +534,8 @@ static const GumV8Function gumjs_source_map_functions[] =
 
   { NULL, NULL }
 };
+
+static GPrivate gum_v8_thread_data;
 
 void
 _gum_v8_core_init (GumV8Core * self,

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -24,6 +24,7 @@ TESTLIST_BEGIN (script)
   TESTENTRY (recv_may_specify_desired_message_type)
   TESTENTRY (recv_can_be_waited_for_from_an_application_thread)
   TESTENTRY (recv_can_be_waited_for_from_two_application_threads)
+  TESTENTRY (recv_wait_in_an_application_thread_should_not_deadlock)
   TESTENTRY (recv_can_be_waited_for_from_our_js_thread)
   TESTENTRY (recv_wait_in_an_application_thread_should_throw_on_unload)
   TESTENTRY (recv_wait_in_our_js_thread_should_throw_on_unload)
@@ -6123,6 +6124,72 @@ TESTCASE (message_can_be_received)
   EXPECT_NO_MESSAGES ();
   POST_MESSAGE ("{\"type\":\"ping\"}");
   EXPECT_SEND_MESSAGE_WITH ("\"pong\"");
+}
+
+TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
+{
+  GThread * worker_thread;
+  GumInvokeTargetContext ctx;
+
+  if (!g_test_slow ())
+  {
+    g_print ("<skipping, run in slow mode> ");
+    return;
+  }
+
+  COMPILE_AND_LOAD_SCRIPT(
+      "Interceptor.replace(" GUM_PTR_CONST ", new NativeCallback(function (arg) {"
+      "   let timeToRecv;"
+      "   let shouldExit = false;"
+      "   while (true) {"
+      "      recv(message => {"
+      "         if (message.type == 'stop') {"
+      "            shouldExit = true;"
+      "            return;"
+      "         }"
+      "         else if (message.type != 'waituntil') {"
+      "            throw new Error('Received unexpected message: ' + message.type); }"
+      "         timeToRecv = message.time;"
+      "      }).wait();"
+      "      if (shouldExit) {"
+      "         return 0;"
+      "      }"
+      "      while (Date.now() < timeToRecv) {};"
+      "      recv(message => {"
+      "         if (message.type != 'ping') {"
+      "            throw new Error('Received unexpected message: '  + message.type); }"
+      "      }).wait();"
+      "      send('pong');"
+      "   }"
+      "}, 'int', ['int']));", target_function_int);
+
+  ctx.script = fixture->script;
+  ctx.repeat_duration = 0;
+  ctx.started = 0;
+  ctx.finished = 0;
+  worker_thread = g_thread_new ("script-test-worker-thread",
+      invoke_target_function_int_worker, &ctx);
+  while (ctx.started == 0)
+    g_usleep(G_USEC_PER_SEC / 200);
+
+  for (int i = 0; i < 100; i++)
+  {
+    gint64 timeNow = g_get_real_time ();
+    gint64 timeToScheduleRecv = timeNow - (timeNow % (20 * 1000)) + 50 * 1000;
+    GString * msg = g_string_new (NULL);
+    g_string_printf (msg, "{\"type\":\"waituntil\", \"time\": %lld}", timeToScheduleRecv / 1000);
+    POST_MESSAGE (msg->str);
+    g_string_free (msg, true);
+    gint64 timeToPost = timeToScheduleRecv + i;
+    while (g_get_real_time () < timeToPost) {}
+    POST_MESSAGE ("{\"type\":\"ping\"}");
+    EXPECT_SEND_MESSAGE_WITH ("\"pong\"");
+  }
+
+  POST_MESSAGE ("{\"type\":\"stop\"}" );
+
+  g_thread_join (worker_thread);
+  g_assert_cmpint (ctx.finished, == , 1);
 }
 
 TESTCASE (message_can_be_received_with_data)

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -7,6 +7,7 @@
  * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
  * Copyright (C) 2024 Hillel Pinto <hillelpinto3@gmail.com>
  * Copyright (C) 2024 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2024 Simon Zuckerbraun <Simon_Zuckerbraun@trendmicro.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6137,7 +6137,7 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
     return;
   }
 
-  COMPILE_AND_LOAD_SCRIPT(
+  COMPILE_AND_LOAD_SCRIPT (
       "Interceptor.replace(" GUM_PTR_CONST ", new NativeCallback(function (arg) {"
       "   let timeToRecv;"
       "   let shouldExit = false;"
@@ -6170,7 +6170,7 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
   worker_thread = g_thread_new ("script-test-worker-thread",
       invoke_target_function_int_worker, &ctx);
   while (ctx.started == 0)
-    g_usleep(G_USEC_PER_SEC / 200);
+    g_usleep (G_USEC_PER_SEC / 200);
 
   for (int i = 0; i < 100; i++)
   {
@@ -6181,7 +6181,7 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
     POST_MESSAGE (msg->str);
     g_string_free (msg, true);
     gint64 timeToPost = timeToScheduleRecv + i;
-    while (g_get_real_time () < timeToPost) {}
+    while (g_get_real_time () < timeToPost);
     POST_MESSAGE ("{\"type\":\"ping\"}");
     EXPECT_SEND_MESSAGE_WITH ("\"pong\"");
   }

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -6138,7 +6138,7 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
   }
 
   COMPILE_AND_LOAD_SCRIPT (
-      "Interceptor.replace(" GUM_PTR_CONST ", new NativeCallback(function (arg) {"
+      "Interceptor.replace(" GUM_PTR_CONST ", new NativeCallback((arg) => {"
       "   let timeToRecv;"
       "   let shouldExit = false;"
       "   while (true) {"
@@ -6148,7 +6148,8 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
       "            return;"
       "         }"
       "         else if (message.type != 'waituntil') {"
-      "            throw new Error('Received unexpected message: ' + message.type); }"
+      "            throw new Error("
+      "                'Received unexpected message: ' + message.type); }"
       "         timeToRecv = message.time;"
       "      }).wait();"
       "      if (shouldExit) {"
@@ -6157,7 +6158,8 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
       "      while (Date.now() < timeToRecv) {};"
       "      recv(message => {"
       "         if (message.type != 'ping') {"
-      "            throw new Error('Received unexpected message: '  + message.type); }"
+      "            throw new Error("
+      "                'Received unexpected message: '  + message.type); }"
       "      }).wait();"
       "      send('pong');"
       "   }"
@@ -6175,9 +6177,11 @@ TESTCASE (recv_wait_in_an_application_thread_should_not_deadlock)
   for (int i = 0; i < 100; i++)
   {
     gint64 timeNow = g_get_real_time ();
-    gint64 timeToScheduleRecv = timeNow - (timeNow % (20 * 1000)) + 50 * 1000;
+    gint64 timeToScheduleRecv =
+        timeNow - (timeNow % (20 * 1000)) + 50 * 1000;
     GString * msg = g_string_new (NULL);
-    g_string_printf (msg, "{\"type\":\"waituntil\", \"time\": %lld}", timeToScheduleRecv / 1000);
+    g_string_printf (msg, "{\"type\":\"waituntil\", \"time\": %lld}",
+        timeToScheduleRecv / 1000);
     POST_MESSAGE (msg->str);
     g_string_free (msg, true);
     gint64 timeToPost = timeToScheduleRecv + i;


### PR DESCRIPTION
This is a fix for #807 : recv wait can deadlock on an application thread.

See the issue description for a discussion of the root cause.

The proposed fix here operates by introducing a thread-local variable, `event_count_last_seen`. After entering the mutex, which ensures a stable reading of `core->event_count`, the thread enters the wait for `event_cond` only if `core->event_count` is equal to `event_count_last_seen`. In this way, we can guarantee that we won't begin waiting on `event_cond` at a time when the event we need has already been broadcast, which would produce the deadlock.