### PR TITLE
Ensure gum is itself an input to the gumjs devkit

### DIFF
--- a/bindings/gumjs/devkit/meson.build
+++ b/bindings/gumjs/devkit/meson.build
@@ -13,7 +13,7 @@ if cc.get_argument_syntax() == 'msvc'
 endif
 
 custom_target('gumjs-devkit',
-  input: gumjs,
+  input: [gum, gumjs],
   output: devkit_outputs,
   command: [
     mkdevkit,


### PR DESCRIPTION
This addresses a bug that _can_ result in gumjs being built before gum, and thus gumjs being incomplete (missing symbols).
This ensures that when building the gumjs devkit, gum is treated as an input.