### PR TITLE
memory: Make regex patterns raw

### DIFF
--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -576,8 +576,8 @@ gum_match_pattern_new_from_regex (const gchar * regex_str)
   GumMatchPattern * pattern;
   GRegex * regex;
 
-  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE | G_REGEX_RAW, G_REGEX_MATCH_NOTEMPTY,
-      NULL);
+  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE | G_REGEX_RAW,
+      G_REGEX_MATCH_NOTEMPTY, NULL);
   if (regex == NULL)
     return NULL;
 

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -576,7 +576,7 @@ gum_match_pattern_new_from_regex (const gchar * regex_str)
   GumMatchPattern * pattern;
   GRegex * regex;
 
-  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE, G_REGEX_MATCH_NOTEMPTY,
+  regex = g_regex_new (regex_str, G_REGEX_OPTIMIZE | G_REGEX_RAW, G_REGEX_MATCH_NOTEMPTY,
       NULL);
   if (regex == NULL)
     return NULL;

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -8137,6 +8137,22 @@ TESTCASE (memory_can_be_scanned_with_match_pattern_object)
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=0 size=11\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=13 size=11\"");
   EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
+
+  haystack2[7] = 0xd1;
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const pattern = new MatchPattern(/Hello/.toString());"
+      "Memory.scan(" GUM_PTR_CONST ", 33, pattern, {"
+        "onMatch(address, size) {"
+        "  send('onMatch offset=' + address.sub(" GUM_PTR_CONST
+             ").toInt32() + ' size=' + size);"
+        "},"
+        "onComplete() {"
+        "  send('onComplete');"
+        "}"
+      "});", haystack2, haystack2);
+  EXPECT_SEND_MESSAGE_WITH ("\"onMatch offset=0 size=5\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"onComplete\"");
 }
 
 TESTCASE (memory_can_be_scanned_synchronously)


### PR DESCRIPTION
According to the docs of `g_regex_new` about the `G_REGEX_RAW` flag: "Usually strings must be valid UTF-8 strings, using this flag they are considered as a raw sequence of bytes."

The "strings" this refers to are the haystacks we then pass to `g_regex_match_full` when searching.

Without the flag, memory search with regex patterns can get interrupted before the range is over, when "invalid" bytes are encountered, resulting in false negatives.