### PR TITLE
gumjs: Fix crash in Module finalizers

### DIFF
--- a/bindings/gumjs/gumquickmodule.h
+++ b/bindings/gumjs/gumquickmodule.h
@@ -17,6 +17,9 @@ struct _GumQuickModule
 {
   GumQuickCore * core;
 
+  GPtrArray * pending_unrefs;
+  GSource * unref_source;
+
   JSClassID module_class;
   JSClassID module_map_class;
 };

--- a/bindings/gumjs/gumquickscript-priv.h
+++ b/bindings/gumjs/gumquickscript-priv.h
@@ -13,7 +13,20 @@
 
 G_BEGIN_DECLS
 
+typedef guint GumScriptState;
 typedef struct _GumQuickWorker GumQuickWorker;
+
+enum _GumScriptState
+{
+  GUM_SCRIPT_STATE_CREATED,
+  GUM_SCRIPT_STATE_LOADING,
+  GUM_SCRIPT_STATE_LOADED,
+  GUM_SCRIPT_STATE_UNLOADING,
+  GUM_SCRIPT_STATE_UNLOADED
+};
+
+G_GNUC_INTERNAL GumScriptState _gum_quick_script_get_state (
+    GumQuickScript * self);
 
 G_GNUC_INTERNAL GumQuickWorker * _gum_quick_script_make_worker (
     GumQuickScript * self, const gchar * url, JSValue on_message);

--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -34,7 +34,6 @@
 # include "gumquickdatabase.h"
 #endif
 
-typedef guint GumScriptState;
 typedef struct _GumUnloadNotifyCallback GumUnloadNotifyCallback;
 typedef void (* GumUnloadNotifyFunc) (GumQuickScript * self,
     gpointer user_data);
@@ -94,15 +93,6 @@ enum
   PROP_BYTECODE,
   PROP_MAIN_CONTEXT,
   PROP_BACKEND
-};
-
-enum _GumScriptState
-{
-  GUM_SCRIPT_STATE_CREATED,
-  GUM_SCRIPT_STATE_LOADING,
-  GUM_SCRIPT_STATE_LOADED,
-  GUM_SCRIPT_STATE_UNLOADING,
-  GUM_SCRIPT_STATE_UNLOADED
 };
 
 struct _GumUnloadNotifyCallback
@@ -1090,6 +1080,12 @@ gum_quick_emit_data_free (GumEmitData * d)
   g_object_unref (d->script);
 
   g_slice_free (GumEmitData, d);
+}
+
+GumScriptState
+_gum_quick_script_get_state (GumQuickScript * self)
+{
+  return self->state;
 }
 
 GumQuickWorker *

--- a/bindings/gumjs/gumv8module.h
+++ b/bindings/gumjs/gumv8module.h
@@ -16,6 +16,9 @@ struct GumV8Module
   GHashTable * values;
   GHashTable * maps;
 
+  GPtrArray * pending_unrefs;
+  GSource * unref_source;
+
   v8::Global<v8::FunctionTemplate> * klass;
 
   v8::Global<v8::Object> * import_value;

--- a/gum/backend-elf/gummodule-elf.h
+++ b/gum/backend-elf/gummodule-elf.h
@@ -31,8 +31,6 @@ struct _GumNativeModule
   GDestroyNotify create_handle_data_destroy;
   GDestroyNotify destroy_handle;
 
-  GMutex mutex;
-
   gpointer cached_handle;
   gboolean attempted_handle_creation;
 


### PR DESCRIPTION
Our QuickJS suspend/resume patch isn't elaborate enough to support usage from finalizers. Given that modules are created and destroyed in waves, however, it's probably a bit on the expensive side to suspend/resume JS execution during the destruction of each value. So to avoid both issues we defer the unref using an idle source.

The better longer term solution will probably be to introduce a ModuleObserver of sorts that integrates with the platform's runtime loader and manages the lifetime of each Module. This will also allow us to emit signals anytime a Module is added/removed, which is a feature that a lot of agents would benefit from.

Kudos to @mrmacete for reporting.