### PR TITLE
memory: Optimize gum_memory_read for Linux/Android

### DIFF
--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -123,7 +123,6 @@ gum_memory_read (gconstpointer address,
   return result;
 }
 
-
 gboolean
 gum_memory_write (gpointer address,
                   const guint8 * bytes,

--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -43,9 +43,10 @@
 static gboolean gum_memory_get_protection (gconstpointer address, gsize n,
     gsize * size, GumPageProtection * prot);
 
-static gssize gum_libc_process_vm_readv (pid_t pid, const struct iovec * local_iov,
-    unsigned long liovcnt, const struct iovec * remote_iov, unsigned long riovcnt,
-    unsigned long flags);
+static gssize gum_libc_process_vm_readv (pid_t pid,
+    const struct iovec * local_iov, gulong liovcnt,
+    const struct iovec * remote_iov, gulong riovcnt,
+    gulong flags);
 
 gboolean
 gum_memory_is_readable (gconstpointer address,
@@ -311,10 +312,10 @@ gum_memory_get_protection (gconstpointer address,
 static gssize
 gum_libc_process_vm_readv (pid_t pid,
                            const struct iovec * local_iov,
-                           unsigned long liovcnt,
+                           gulong liovcnt,
                            const struct iovec * remote_iov,
-                           unsigned long riovcnt,
-                           unsigned long flags)
+                           gulong riovcnt,
+                           gulong flags)
 {
   return syscall (GUM_SYS_PROCESS_VM_READV, pid, local_iov, liovcnt, remote_iov,
       riovcnt, flags);

--- a/gum/backend-linux/gummemory-linux.c
+++ b/gum/backend-linux/gummemory-linux.c
@@ -18,6 +18,28 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+# define GUM_SYS_PROCESS_VM_READV  347
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+# define GUM_SYS_PROCESS_VM_READV  310
+#elif defined (HAVE_ARM)
+# define GUM_SYS_PROCESS_VM_READV  (__NR_SYSCALL_BASE + 376)
+#elif defined (HAVE_ARM64)
+# define GUM_SYS_PROCESS_VM_READV  270
+#elif defined (HAVE_MIPS)
+# if _MIPS_SIM == _MIPS_SIM_ABI32
+#  define GUM_SYS_PROCESS_VM_READV (__NR_Linux + 345)
+# elif _MIPS_SIM == _MIPS_SIM_ABI64
+#  define GUM_SYS_PROCESS_VM_READV (__NR_Linux + 304)
+# elif _MIPS_SIM == _MIPS_SIM_NABI32
+#  define GUM_SYS_PROCESS_VM_READV (__NR_Linux + 309)
+# else
+#  error Unexpected MIPS ABI
+# endif
+#else
+# error FIXME
+#endif
+
 static gboolean gum_memory_get_protection (gconstpointer address, gsize n,
     gsize * size, GumPageProtection * prot);
 
@@ -294,6 +316,6 @@ gum_libc_process_vm_readv (pid_t pid,
                            unsigned long riovcnt,
                            unsigned long flags)
 {
-  return syscall (SYS_process_vm_readv, pid, local_iov, liovcnt, remote_iov,
+  return syscall (GUM_SYS_PROCESS_VM_READV, pid, local_iov, liovcnt, remote_iov,
       riovcnt, flags);
 }

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -42,8 +42,8 @@
 #include <sys/socket.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/utsname.h>
 #include <sys/uio.h>
+#include <sys/utsname.h>
 #include <sys/wait.h>
 #ifdef HAVE_SYS_USER_H
 # include <sys/user.h>
@@ -2087,6 +2087,38 @@ gum_do_unset_hardware_watchpoint (GumThreadId thread_id,
 #endif
 }
 
+gboolean
+gum_linux_check_kernel_version (guint major,
+                                guint minor,
+                                guint micro)
+{
+  static gboolean initialized = FALSE;
+  static guint kern_major = G_MAXUINT;
+  static guint kern_minor = G_MAXUINT;
+  static guint kern_micro = G_MAXUINT;
+
+  if (!initialized)
+  {
+    struct utsname un;
+    G_GNUC_UNUSED int res;
+
+    res = uname (&un);
+    g_assert (res == 0);
+
+    sscanf (un.release, "%u.%u.%u", &kern_major, &kern_minor, &kern_micro);
+
+    initialized = TRUE;
+  }
+
+  if (kern_major > major)
+    return TRUE;
+
+  if (kern_major == major && kern_minor > minor)
+    return TRUE;
+
+  return kern_major == major && kern_minor == minor && kern_micro >= micro;
+}
+
 GumCpuType
 gum_linux_cpu_type_from_file (const gchar * path,
                               GError ** error)
@@ -3583,37 +3615,3 @@ gum_libc_syscall_4 (gsize n,
 
   return result;
 }
-
-gboolean
-gum_linux_check_kernel_version (guint major,
-                               guint minor,
-                               guint micro)
-{
-  static gboolean initialized = FALSE;
-  static guint kernel_major = G_MAXUINT;
-  static guint kernel_minor = G_MAXUINT;
-  static guint kernel_micro = G_MAXUINT;
-
-  if (!initialized)
-  {
-    struct utsname un;
-    G_GNUC_UNUSED int res;
-
-    res = uname (&un);
-    g_assert (res == 0);
-
-    /* Linux version string format: "X.Y.Z-extra" */
-    sscanf (un.release, "%u.%u.%u", &kernel_major, &kernel_minor, &kernel_micro);
-
-    initialized = TRUE;
-  }
-
-  if (kernel_major > major)
-    return TRUE;
-
-  if (kernel_major == major && kernel_minor > minor)
-    return TRUE;
-
-  return kernel_major == major && kernel_minor == minor && kernel_micro >= micro;
-}
-

--- a/gum/backend-linux/include/gum/gumlinux.h
+++ b/gum/backend-linux/include/gum/gumlinux.h
@@ -22,6 +22,8 @@ struct _GumLinuxNamedRange
   gsize size;
 };
 
+GUM_API gboolean gum_linux_check_kernel_version (guint major, guint minor,
+    guint micro);
 GUM_API GumCpuType gum_linux_cpu_type_from_file (const gchar * path,
     GError ** error);
 GUM_API GumCpuType gum_linux_cpu_type_from_pid (pid_t pid, GError ** error);


### PR DESCRIPTION
This PR optimizes the performance of gum_memory_read on Linux/Android platforms.

### Current Issues:
- gum_memory_read is significantly slow due to parsing memory maps on each call
- Memory.readVolatile using gum_memory_read is approximately 1000x slower than Memory.readByteArray

### Improvements:
- Implement process_vm_readv for safe self-process memory reading on Linux kernels >= 3.2
- Add kernel version detection to ensure compatibility

### Benchmark results
```
let memPtr = Memory.alloc(4096);
let start = Date.now();
for(let i = 0; i < 10000; i++) {
  Memory.readVolatile(memPtr, 4096);
}

let end = Date.now();
console.log(`readVolatile => elapsedTime: ${end - start} ms`);
start = Date.now();
for(let i = 0; i < 10000; i++) {
  Memory.readByteArray(memPtr, 4096);
}

end = Date.now();
console.log(`readByteArray => elapsedTime: ${end - start} ms`);
```

**Device:Android Pixel3a**

**frida-server:16.6.4**
readVolatile => elapsedTime: 49432 ms
readByteArray => elapsedTime: 31 ms

**this version**
readVolatile => elapsedTime: 45 ms
readByteArray => elapsedTime: 31 ms

