### PR TITLE
gumjs: Add NativePointer#writeVolatile()

### DIFF
--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2010-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2025 Kenjiro Ichise <ichise@doranekosystems.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -703,31 +704,14 @@ GUMJS_DEFINE_FUNCTION (gum_v8_memory_write_volatile)
 {
   gpointer address;
   GBytes * bytes;
-  gconstpointer data;
-  gsize size;
-
   if (!_gum_v8_args_parse (args, "pB", &address, &bytes))
     return;
 
-  data = g_bytes_get_data (bytes, &size);
+  gsize size;
+  auto data = g_bytes_get_data (bytes, &size);
 
-  if (size == 0)
-  {
-    g_bytes_unref (bytes);
-    info.GetReturnValue ().Set (TRUE);
-    return;
-  }
-
-  if (!gum_memory_write (address, (guint8 *) data, size))
-  {
-    g_bytes_unref (bytes);
+  if (!gum_memory_write (address, (const guint8 *) data, size))
     _gum_v8_throw_ascii_literal (isolate, "memory write failed");
-    return;
-  }
-
-  g_bytes_unref (bytes);
-
-  info.GetReturnValue ().Set (TRUE);
 }
 
 static void

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -190,6 +190,7 @@ TESTLIST_BEGIN (script)
     TESTENTRY (ansi_string_can_be_allocated_in_code_page_936)
     TESTENTRY (ansi_string_can_be_allocated_in_code_page_1252)
 #endif
+    TESTENTRY (write_to_unaccessible_memory_can_be_performed_safely)
     TESTENTRY (invalid_read_results_in_exception)
     TESTENTRY (invalid_write_results_in_exception)
     TESTENTRY (invalid_read_write_execute_results_in_exception)
@@ -9341,6 +9342,20 @@ TESTCASE (ansi_string_can_be_allocated_in_code_page_1252)
 }
 
 #endif
+
+TESTCASE (write_to_unaccessible_memory_can_be_performed_safely)
+{
+  guint8 buf[3] = { 0x13, 0x37, 0x42 };
+
+  COMPILE_AND_LOAD_SCRIPT (GUM_PTR_CONST ".writeVolatile([0x12, 0x27]);", buf);
+  EXPECT_NO_MESSAGES ();
+  g_assert_cmphex (buf[0], ==, 0x12);
+  g_assert_cmphex (buf[1], ==, 0x27);
+  g_assert_cmphex (buf[2], ==, 0x42);
+
+  COMPILE_AND_LOAD_SCRIPT ("ptr(1234).writeVolatile([0x12, 0x27]);");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: memory write failed");
+}
 
 TESTCASE (invalid_read_results_in_exception)
 {


### PR DESCRIPTION
https://frida.re/news/2025/01/27/frida-16-6-6-released/
This PR implements the Memory.writeVolatile API that was previously documented but not implemented. 