### PR TITLE
darwin: Update thread list pointer carving

### DIFF
--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1841,9 +1841,18 @@ gum_detect_pthread_basics (csh capstone,
         }
         case ARM64_INS_LDR:
         {
+          const uint8_t * ldr_location = code - insn->size;
           const arm64_op_mem * src = &arm64->operands[1].mem;
 
-          if (mach_port_offset == 0 &&
+          if (adrp_location != NULL &&
+              ldr_location - 4 == adrp_location &&
+              src->base == adrp_reg &&
+              src->index == ARM64_REG_INVALID &&
+              src->disp !=0)
+          {
+            accumulated_value += src->disp;
+          }
+          else if (mach_port_offset == 0 &&
               src->base != ARM64_REG_SP &&
               src->base != ARM64_REG_FP &&
               src->index == ARM64_REG_INVALID &&


### PR DESCRIPTION
On recent iOS versions, the thread list pointer within the `pthread_from_mach_thread_np` function is referenced via ADRP + LDR instead of ADRP + ADD.

```
            ;-- _pthread_from_mach_thread_np:
            0x20d7f1ee4      7f2303d5       pacibsp
            0x20d7f1ee8      f44fbea9       stp x20, x19, [sp, -0x20]!
            0x20d7f1eec      fd7b01a9       stp x29, x30, [sp, 0x10]
            0x20d7f1ef0      fd430091       add x29, sp, 0x10
            0x20d7f1ef4      f40300aa       mov x20, x0
            0x20d7f1ef8      e0b52df0       adrp x0, segment.cache_map.75    ;
            0x20d7f1efc      00100191       add x0, x0, 0x44                 ; this is the lock
            0x20d7f1f00      a100a052       mov w1, 0x50000
            0x20d7f1f04      3b22b594       bl stub._os_unfair_lock_lock_with_options
            0x20d7f1f08      e8b52df0       adrp x8, segment.cache_map.75    ;
            0x20d7f1f0c      131540f9       ldr x19, [x8, 0x28]              ; this is the list
        ╭─< 0x20d7f1f10      d30000b4       cbz x19, 0x20d7f1f28
       ╭──> 0x20d7f1f14      68fa40b9       ldr w8, [x19, 0xf8]              ; this is the port offset
       ╎│   0x20d7f1f18      1f01146b       cmp w8, w20
      ╭───< 0x20d7f1f1c      60000054       b.eq 0x20d7f1f28          
      │╎│   0x20d7f1f20      730a40f9       ldr x19, [x19, 0x10]
      │╰──< 0x20d7f1f24      93ffffb5       cbnz x19, 0x20d7f1f14  
      ╰─╰─> 0x20d7f1f28      e0b52df0       adrp x0, segment.cache_map.75    ;
            0x20d7f1f2c      00100191       add x0, x0, 0x44                 ; this is the lock again
            0x20d7f1f30      3422b594       bl stub._os_unfair_lock_unlock 
            0x20d7f1f34      e00313aa       mov x0, x19
            0x20d7f1f38      fd7b41a9       ldp x29, x30, [sp, 0x10]
            0x20d7f1f3c      f44fc2a8       ldp x20, x19, [sp], 0x20
            0x20d7f1f40      ff0f5fd6       retab
```

This resulted in having an invalid pointer in the spec (just the page-aligned part of it), causing segfault-like errors when calling `Process.enumerateThreads()`.