### PR TITLE
darwin: Dispose module resolver indexes

### DIFF
--- a/gum/backend-darwin/gumdarwinmoduleresolver.c
+++ b/gum/backend-darwin/gumdarwinmoduleresolver.c
@@ -95,6 +95,10 @@ gum_darwin_module_resolver_dispose (GObject * object)
   self->load_data = NULL;
   self->load_data_destroy = NULL;
 
+  g_clear_pointer (&self->sorted_modules, g_ptr_array_unref);
+  g_clear_pointer (&self->module_by_name, g_hash_table_unref);
+  g_clear_pointer (&self->last_modules, g_ptr_array_unref);
+
   G_OBJECT_CLASS (gum_darwin_module_resolver_parent_class)->dispose (object);
 }
 


### PR DESCRIPTION
To avoid leaking native modules in scenarios where short-lived resolvers are used (for example on different tasks).