### PR TITLE
Fix `GUM_QUICKJS_BYTECODE_MAGIC`

### DIFF
--- a/bindings/gumjs/gumquickscriptbackend.c
+++ b/bindings/gumjs/gumquickscriptbackend.c
@@ -15,7 +15,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define GUM_QUICKJS_BYTECODE_MAGIC 0x02
+#if G_BYTE_ORDER == G_BIG_ENDIAN
+# define GUM_QUICKJS_BYTECODE_MAGIC 0x42
+#else
+# define GUM_QUICKJS_BYTECODE_MAGIC 0x02
+#endif
 
 typedef struct _GumCompileProgramOperation GumCompileProgramOperation;
 typedef struct _GumCreateScriptData GumCreateScriptData;


### PR DESCRIPTION
Seems (at least for armbe8) that this magic used to detect QuickJS bytecode is `0x42`, not `0x02`? I've not found any docs on the QJS bytecode format, so I'm unsure why the value is different on this target architecture.

Otherwise, we hit the assert [here](https://github.com/frida/frida-gum/blob/dc7e51f2c721a80b1f2aa6dc7f7ad780483e76e1/bindings/gumjs/gumquickscriptbackend.c#L1269) whenever our tests call `gum_script_load_sync`, since this assert doesn't cause any effect in release builds, this undetected error results in a hang since we never handle the exception and notify the caller that the task has been completed. This error should maybe handled rather than an assert?