### PR TITLE
cpu-context: implement neon on linux/arm64

### DIFF
--- a/gum/backend-linux/gumandroid.c
+++ b/gum/backend-linux/gumandroid.c
@@ -11,7 +11,6 @@
 #include "gum/gumlinux.h"
 
 #include <dlfcn.h>
-#include <elf.h>
 #include <link.h>
 #include <pthread.h>
 #include <string.h>

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -2459,6 +2459,29 @@ gum_linux_parse_ucontext (const ucontext_t * uc,
   ctx->lr = mc->regs[30];
 
   memset (ctx->v, 0, sizeof (ctx->v));
+
+  // Reading extra contexts, NEON in this case
+  // Please refer to asm/sigcontext.h for reference
+  for (i = 0; i < sizeof (mc->__reserved); ) {
+    struct _aarch64_ctx * head = (struct _aarch64_ctx *) &mc->__reserved[i];
+
+    if (head->magic == 0)
+      break;
+
+    switch (head->magic)
+    {
+      case FPSIMD_MAGIC: 
+      {
+        struct fpsimd_context * fpsimd = (struct fpsimd_context *) head;
+
+        memcpy (&ctx->v, &fpsimd->vregs, sizeof (ctx->v));
+        
+        break;
+      }
+    }
+
+    i += 4 + 4 + 8 + head->size;
+  }
 #elif defined (HAVE_MIPS)
   const greg_t * gr = uc->uc_mcontext.gregs;
 
@@ -2604,6 +2627,29 @@ gum_linux_unparse_ucontext (const GumCpuContext * ctx,
     mc->regs[i] = ctx->x[i];
   mc->regs[29] = ctx->fp;
   mc->regs[30] = ctx->lr;
+
+  // Overwrites fpsimd_context, if it's not present it's a no-op
+  // If behavior is incorrect, please open an issue
+  for (i = 0; i < sizeof (mc->__reserved); ) {
+    struct _aarch64_ctx * head = (struct _aarch64_ctx *) &mc->__reserved[i];
+
+    if (head->magic == 0)
+      break;
+
+    switch (head->magic)
+    {
+      case FPSIMD_MAGIC: 
+      {
+        struct fpsimd_context * fpsimd = (struct fpsimd_context *) head;
+
+        memcpy (&fpsimd->vregs, &ctx->v, sizeof (ctx->v));
+
+        break;
+      }
+    }
+
+    i += 4 + 4 + 8 + head->size;
+  }
 #elif defined (HAVE_MIPS)
   greg_t * gr = uc->uc_mcontext.gregs;
 

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -2460,9 +2460,8 @@ gum_linux_parse_ucontext (const ucontext_t * uc,
 
   memset (ctx->v, 0, sizeof (ctx->v));
 
-  // Reading extra contexts, NEON in this case
-  // Please refer to asm/sigcontext.h for reference
-  for (i = 0; i < sizeof (mc->__reserved); ) {
+  for (i = 0; i != sizeof (mc->__reserved); )
+  {
     struct _aarch64_ctx * head = (struct _aarch64_ctx *) &mc->__reserved[i];
 
     if (head->magic == 0)
@@ -2470,12 +2469,12 @@ gum_linux_parse_ucontext (const ucontext_t * uc,
 
     switch (head->magic)
     {
-      case FPSIMD_MAGIC: 
+      case FPSIMD_MAGIC:
       {
         struct fpsimd_context * fpsimd = (struct fpsimd_context *) head;
 
         memcpy (&ctx->v, &fpsimd->vregs, sizeof (ctx->v));
-        
+
         break;
       }
     }
@@ -2628,9 +2627,8 @@ gum_linux_unparse_ucontext (const GumCpuContext * ctx,
   mc->regs[29] = ctx->fp;
   mc->regs[30] = ctx->lr;
 
-  // Overwrites fpsimd_context, if it's not present it's a no-op
-  // If behavior is incorrect, please open an issue
-  for (i = 0; i < sizeof (mc->__reserved); ) {
+  for (i = 0; i != sizeof (mc->__reserved); )
+  {
     struct _aarch64_ctx * head = (struct _aarch64_ctx *) &mc->__reserved[i];
 
     if (head->magic == 0)
@@ -2638,7 +2636,7 @@ gum_linux_unparse_ucontext (const GumCpuContext * ctx,
 
     switch (head->magic)
     {
-      case FPSIMD_MAGIC: 
+      case FPSIMD_MAGIC:
       {
         struct fpsimd_context * fpsimd = (struct fpsimd_context *) head;
 

--- a/gum/backend-linux/include/gum/gumandroid.h
+++ b/gum/backend-linux/include/gum/gumandroid.h
@@ -9,6 +9,7 @@
 
 #include "gumelfmodule.h"
 #include "gumprocess.h"
+#include <elf.h>
 
 G_BEGIN_DECLS
 

--- a/gum/backend-linux/include/gum/gumandroid.h
+++ b/gum/backend-linux/include/gum/gumandroid.h
@@ -9,7 +9,6 @@
 
 #include "gumelfmodule.h"
 #include "gumprocess.h"
-#include <elf.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Hi,
This PR adds support to reading vector registers on aarch64 linux. I've tested it on Android 15 and works great.
It can be easily extended in future in order to implement other registers or bigger vector variants.

I've moved elf.h include from gumandroid.c to gumandroid.h as my IDE had problems with reading it via gumandroid.c, however the final effect should be the same.

I've omitted fpsr and fpcr as they don't seem to be used on other platforms.