### PR TITLE
elf-module: fix maps not release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps/
 /gum/backend-darwin/helpers/build/
 /subprojects/*
+/.cache/

--- a/gum/gumelfmodule.c
+++ b/gum/gumelfmodule.c
@@ -553,7 +553,10 @@ gum_elf_module_load (GumElfModule * self,
       file = g_mapped_file_new (self->source_path, FALSE, &local_error);
       if (file != NULL)
       {
-        self->file_bytes = g_mapped_file_get_bytes (file);
+        GBytes * old_file_bytes = g_mapped_file_get_bytes (file);
+        gconstpointer file_data = g_bytes_get_data (old_file_bytes, &size);
+        self->file_bytes = g_bytes_new(file_data, size);
+        g_bytes_unref (old_file_bytes);
         g_mapped_file_unref (file);
 
         data = g_bytes_get_data (self->file_bytes, &size);


### PR DESCRIPTION
Frida did not release linker64 mmap after load,6efa800000 is frida create but not release
```cat /proc/12357/maps | grep linker
6efa800000-6efaa2d000 r--p 00000000 07:178 14                            /apex/com.android.runtime/bin/linker64
71be603000-71be663000 rw-p 00000000 00:00 0                              [anon:linker_alloc]
71c161a000-71c16da000 r--p 00000000 00:00 0                              [anon:linker_alloc]
71c176e000-71c17ce000 r--p 00000000 00:00 0                              [anon:linker_alloc]
71c1839000-71c1899000 r--p 00000000 00:00 0                              [anon:linker_alloc]
71c28ab000-71c28f3000 r--p 00000000 07:178 14                            /apex/com.android.runtime/bin/linker64
71c28f3000-71c28f4000 r-xp 00048000 07:178 14                            /apex/com.android.runtime/bin/linker64
71c28f4000-71c28f5000 rwxp 00049000 07:178 14                            /apex/com.android.runtime/bin/linker64
71c28f5000-71c2a34000 r-xp 0004a000 07:178 14                            /apex/com.android.runtime/bin/linker64
71c2a37000-71c2a41000 r--p 0018c000 07:178 14                            /apex/com.android.runtime/bin/linker64
71c2a43000-71c2a44000 rw-p 00198000 07:178 14                            /apex/com.android.runtime/bin/linker64
```