### PR TITLE
Add FreeBSD x86 (32-bit) support

### DIFF
--- a/gum/backend-freebsd/gummoduleregistry-freebsd.c
+++ b/gum/backend-freebsd/gummoduleregistry-freebsd.c
@@ -158,8 +158,10 @@ gum_find_dlopen_object (const struct r_debug * dbg)
   text.base_address += GUM_ADDRESS (dbg->r_ldbase);
   g_object_unref (elf);
 
-#if defined (HAVE_I386)
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   setup_flags_arg = gum_match_pattern_new_from_string ("41 81 e7 03 01 00 00");
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  setup_flags_arg = gum_match_pattern_new_from_string ("81 e7 03 01 00 00");
 #elif defined (HAVE_ARM64)
   setup_flags_arg = gum_match_pattern_new_from_string ("68 20 80 52");
 #else

--- a/gum/backend-freebsd/gummoduleregistry-freebsd.c
+++ b/gum/backend-freebsd/gummoduleregistry-freebsd.c
@@ -147,8 +147,13 @@ gum_find_dlopen_object (const struct r_debug * dbg)
   GumMatchPattern * setup_flags_arg;
   gpointer location;
 
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  elf = gum_elf_module_new_from_memory ("/libexec/ld-elf32.so.1",
+      GUM_ADDRESS (dbg->r_ldbase), NULL);
+#else
   elf = gum_elf_module_new_from_memory ("/libexec/ld-elf.so.1",
       GUM_ADDRESS (dbg->r_ldbase), NULL);
+#endif
   gum_elf_module_enumerate_segments (elf, gum_find_text_range, &text);
   text.base_address += GUM_ADDRESS (dbg->r_ldbase);
   g_object_unref (elf);

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -758,6 +758,19 @@ gum_freebsd_parse_ucontext (const ucontext_t * uc,
   ctx->rdx = mc->mc_rdx;
   ctx->rcx = mc->mc_rcx;
   ctx->rax = mc->mc_rax;
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  const mcontext_t * mc = &uc->uc_mcontext;
+
+  ctx->eip = mc->mc_eip;
+
+  ctx->edi = mc->mc_edi;
+  ctx->esi = mc->mc_esi;
+  ctx->ebp = mc->mc_ebp;
+  ctx->esp = mc->mc_esp;
+  ctx->ebx = mc->mc_ebx;
+  ctx->edx = mc->mc_edx;
+  ctx->ecx = mc->mc_ecx;
+  ctx->eax = mc->mc_eax;
 #elif defined (HAVE_ARM64)
   const struct gpregs * gp = &uc->uc_mcontext.mc_gpregs;
   gsize i;
@@ -806,6 +819,19 @@ gum_freebsd_unparse_ucontext (const GumCpuContext * ctx,
   mc->mc_rdx = ctx->rdx;
   mc->mc_rcx = ctx->rcx;
   mc->mc_rax = ctx->rax;
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  mcontext_t * mc = &uc->uc_mcontext;
+
+  mc->mc_eip = ctx->eip;
+
+  mc->mc_edi = ctx->edi;
+  mc->mc_esi = ctx->esi;
+  mc->mc_ebp = ctx->ebp;
+  mc->mc_esp = ctx->esp;
+  mc->mc_ebx = ctx->ebx;
+  mc->mc_edx = ctx->edx;
+  mc->mc_ecx = ctx->ecx;
+  mc->mc_eax = ctx->eax;
 #elif defined (HAVE_ARM64)
   struct gpregs * gp = &uc->uc_mcontext.mc_gpregs;
   gsize i;
@@ -849,6 +875,17 @@ gum_freebsd_parse_regs (const struct reg * regs,
   ctx->rdx = regs->r_rdx;
   ctx->rcx = regs->r_rcx;
   ctx->rax = regs->r_rax;
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  ctx->eip = regs->r_eip;
+
+  ctx->edi = regs->r_edi;
+  ctx->esi = regs->r_esi;
+  ctx->ebp = regs->r_ebp;
+  ctx->esp = regs->r_esp;
+  ctx->ebx = regs->r_ebx;
+  ctx->edx = regs->r_edx;
+  ctx->ecx = regs->r_ecx;
+  ctx->eax = regs->r_eax;
 #elif defined (HAVE_ARM64)
   gsize i;
 
@@ -888,6 +925,17 @@ gum_freebsd_unparse_regs (const GumCpuContext * ctx,
   regs->r_rdx = ctx->rdx;
   regs->r_rcx = ctx->rcx;
   regs->r_rax = ctx->rax;
+#elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 4
+  regs->r_eip = ctx->eip;
+
+  regs->r_edi = ctx->edi;
+  regs->r_esi = ctx->esi;
+  regs->r_ebp = ctx->ebp;
+  regs->r_esp = ctx->esp;
+  regs->r_ebx = ctx->ebx;
+  regs->r_edx = ctx->edx;
+  regs->r_ecx = ctx->ecx;
+  regs->r_eax = ctx->eax;
 #elif defined (HAVE_ARM64)
   gsize i;
 

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -5060,6 +5060,19 @@ gum_exec_block_virtualize_sysenter_insn (GumExecBlock * block,
   const gsize store_ret_addr_offset = 0x04 + 2;
   const gsize load_continuation_addr_offset = 0x0a + 1;
   const gsize saved_ret_addr_offset = 0x19;
+#elif defined (HAVE_FREEBSD) // FIXME: i don't know how works sysenter
+  guint8 code[] = {
+    /* 00 */ 0x8b, 0x54, 0x24, 0x0c,             /* mov edx, [esp + 12]   */
+    /* 04 */ 0x89, 0x15, 0xaa, 0xaa, 0xaa, 0xaa, /* mov [0xaaaaaaaa], edx */
+    /* 0a */ 0xba, 0xbb, 0xbb, 0xbb, 0xbb,       /* mov edx, 0xbbbbbbbb   */
+    /* 0f */ 0x89, 0x54, 0x24, 0x0c,             /* mov [esp + 12], edx   */
+    /* 13 */ 0x8b, 0x54, 0x24, 0x04,             /* mov edx, [esp + 4]    */
+    /* 17 */ 0x0f, 0x34,                         /* sysenter              */
+    /* 19 */ 0xcc, 0xcc, 0xcc, 0xcc              /* <saved ret-addr here> */
+  };
+  const gsize store_ret_addr_offset = 0x04 + 2;
+  const gsize load_continuation_addr_offset = 0x0a + 1;
+  const gsize saved_ret_addr_offset = 0x19;
 #endif
   gpointer * saved_ret_addr;
   gpointer continuation;

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -6723,7 +6723,7 @@ gum_find_thread_exit_implementation (void)
   GumAddress result;
   GumModule * libthr;
 
-  libthr = gum_process_find_module_by_name ("/lib/libthr.so.3");
+  libthr = gum_process_find_module_by_name ("libthr.so.3");
   g_assert (libthr != NULL);
   result = gum_module_find_export_by_name (libthr, "_pthread_exit");
   g_object_unref (libthr);


### PR DESCRIPTION
This PR adds initial support for FreeBSD x86 (32-bit). The changes are minimal and seem to work, though further testing is needed.

## Motivation

I needed FreeBSD x86 support for a LibAFL-based fuzzer, which wasn't available in Frida.

## Implementation Notes

- Added basic FreeBSD x86 (32-bit) support
- Changes are minimal and focused on making the fuzzer work
- Not all Frida functionality has been tested

## Limitations

- No CI setup for FreeBSD x86 release builds
- Comprehensive testing not performed (only fuzzer use-case verified)
- The implementation works for my specific needs, but might need polishing

## Future Work

If this PR isn't mergeable in its current form, I hope it can serve as a starting point for anyone needing FreeBSD x86 support in the future. The code works perfectly for my fuzzing requirements.