### PR TITLE
gumjs-interceptor: Ensure consistent onLeave call

### DIFF
--- a/bindings/gumjs/gumquickinterceptor.c
+++ b/bindings/gumjs/gumquickinterceptor.c
@@ -949,14 +949,21 @@ gum_quick_js_call_listener_on_leave (GumInvocationListener * listener,
   if (!JS_IsNull (self->on_leave))
   {
     GumQuickScope scope;
+    gboolean has_on_enter;
     GumQuickInvocationContext * jic;
     GumQuickInvocationRetval * retval;
 
     _gum_quick_scope_enter (&scope, parent->core);
 
-    jic = !JS_IsNull (self->on_enter) ? state->jic : NULL;
+    has_on_enter = !JS_IsNull (self->on_enter);
+    jic = has_on_enter ? state->jic : NULL;
     if (jic == NULL)
     {
+      if (has_on_enter)
+      {
+        _gum_quick_scope_leave (&scope);
+        return;
+      }
       jic = _gum_quick_interceptor_obtain_invocation_context (parent);
     }
     _gum_quick_invocation_context_reset (jic, ic);

--- a/bindings/gumjs/gumv8interceptor.cpp
+++ b/bindings/gumjs/gumv8interceptor.cpp
@@ -928,17 +928,21 @@ gum_v8_js_call_listener_on_leave (GumInvocationListener * listener,
   if (self->on_leave != nullptr)
   {
     ScriptScope scope (core->script);
+
+    auto jic = (self->on_enter != nullptr) ? state->jic : NULL;
+    if (jic == NULL)
+    {
+      if (self->on_enter != nullptr)
+        return;
+      jic = _gum_v8_interceptor_obtain_invocation_context (module);
+    }
+    _gum_v8_invocation_context_reset (jic, ic);
+
     auto isolate = core->isolate;
     auto context = isolate->GetCurrentContext ();
 
     auto on_leave = Local<Function>::New (isolate, *self->on_leave);
 
-    auto jic = (self->on_enter != nullptr) ? state->jic : NULL;
-    if (jic == NULL)
-    {
-      jic = _gum_v8_interceptor_obtain_invocation_context (module);
-    }
-    _gum_v8_invocation_context_reset (jic, ic);
     auto recv = Local<Object>::New (isolate, *jic->object);
 
     auto retval = gum_v8_interceptor_obtain_invocation_return_value (module);


### PR DESCRIPTION
Avoid calling `onLeave` when `onEnter` is present but hasn't been called yet. This can happen when attaching the listeners mid-call.

In that scenario, calling `onLeave` with a fresh invocation context could result in unexpectedly uninitialised properties leading to unpredictable behaviour.

This change guarantees that when both `onEnter` and `onLeave` are present, `onLeave` is only called back after `onEnter` actually happened.