### PR TITLE
Fix v8 crashes on Apple mobile platforms (iOS/WatchOS/tvOS)

### DIFF
--- a/bindings/gumjs/gumv8scriptbackend.cpp
+++ b/bindings/gumjs/gumv8scriptbackend.cpp
@@ -243,6 +243,9 @@ gum_v8_script_backend_get_platform (GumV8ScriptBackend * self)
     if (gum_process_get_code_signing_policy () == GUM_CODE_SIGNING_REQUIRED)
     {
       g_string_append (flags, " --jitless");
+    } else {
+      // Keep turbo optimizations on platforms where JIT is allowed
+      g_string_append (flags, " --turbo-instruction-scheduling");
     }
 #endif // HAVE_IOS || HAVE_TVOS || HAVE_WATCHOS
 

--- a/bindings/gumjs/gumv8scriptbackend.cpp
+++ b/bindings/gumjs/gumv8scriptbackend.cpp
@@ -26,7 +26,6 @@
 #define GUM_V8_FLAGS \
     GUM_V8_PLATFORM_FLAGS \
     "--no-freeze-flags-after-init " \
-    "--turbo-instruction-scheduling " \
     "--use-strict " \
     "--expose-gc " \
     "--wasm-staging " \
@@ -236,10 +235,16 @@ gum_v8_script_backend_get_platform (GumV8ScriptBackend * self)
 
     flags = g_string_new (GUM_V8_FLAGS);
 
+    // Force --jitless on Apple mobile platforms (iOS/tvOS/watchOS) to prevent V8 deserializer
+    // crashes caused by JIT compilation restrictions and code signing policies on these platforms
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_WATCHOS)
+    g_string_append (flags, " --jitless");
+#else
     if (gum_process_get_code_signing_policy () == GUM_CODE_SIGNING_REQUIRED)
     {
       g_string_append (flags, " --jitless");
     }
+#endif // HAVE_IOS || HAVE_TVOS || HAVE_WATCHOS
 
     const gchar * extra_flags = g_getenv ("FRIDA_V8_EXTRA_FLAGS");
     if (extra_flags != NULL)


### PR DESCRIPTION
Since Frida 16.0 introduced snapshots, the v8 backend has been crashing on both jailed and jailbroken devices due to snapshots trying to use RWX memory.  E.g.:

-  https://github.com/frida/frida/issues/3561
- https://github.com/frida/frida/issues/2544
- https://github.com/frida/frida/issues/2449

Crash:
```
<--- Last few GCs --->

<--- JS stacktrace --->

#
# Fatal javascript OOM in Executable MemoryChunk allocation failed during deserialization.
#

(lldb) bt
* thread #7, name = 'gum-js-loop', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1071e8594)
  * frame #0: 0x00000001071e8594 FridaGadget.dylibv8::base::OS::Abort() + 32
    frame #1: 0x0000000106e9274c FridaGadget.dylibv8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) + 164
    frame #2: 0x0000000106e92680 FridaGadget.dylibv8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) + 608
    frame #3: 0x0000000106fa5c84 FridaGadget.dylibv8::internal::Heap::FatalProcessOutOfMemory(char const*) + 32
    frame #4: 0x0000000106fe7e94 FridaGadget.dylibv8::internal::MemoryAllocator::HandleAllocationFailure(v8::internal::Executability) + 72
    frame #5: 0x0000000106fe7e04 FridaGadget.dylibv8::internal::MemoryAllocator::AllocateAlignedMemory(unsigned long, unsigned long, unsigned long, v8::internal::Executability, void*, v8::internal::VirtualMemory*) + 404
    frame #6: 0x0000000106fe80a8 FridaGadget.dylibv8::internal::MemoryAllocator::AllocateUninitializedChunk(v8::internal::BaseSpace*, unsigned long, v8::internal::Executability, v8::internal::PageSize) + 116
    frame #7: 0x0000000106fe85f8 FridaGadget.dylibv8::internal::MemoryAllocator::AllocatePage(v8::internal::MemoryAllocator::AllocationMode, v8::internal::Space*, v8::internal::Executability) + 148
    frame #8: 0x0000000106ff65f0 FridaGadget.dylibv8::internal::PagedSpaceBase::TryExpandImpl() + 48
    frame #9: 0x0000000106ff7864 FridaGadget.dylibv8::internal::PagedSpaceBase::TryExpand(int, v8::internal::AllocationOrigin) + 52
    frame #10: 0x0000000106ff7508 FridaGadget.dylibv8::internal::PagedSpaceBase::RawRefillLabMain(int, v8::internal::AllocationOrigin) + 1360
    frame #11: 0x0000000106ff6fa4 FridaGadget.dylibv8::internal::PagedSpaceBase::RefillLabMain(int, v8::internal::AllocationOrigin) + 44
    frame #12: 0x0000000106f9e548 FridaGadget.dylibv8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) + 368
    frame #13: 0x0000000106f9ee1c FridaGadget.dylibv8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) + 56
    frame #14: 0x00000001071eca5c FridaGadget.dylibv8::internal::Heap::AllocateRawOrFail(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) + 724
    frame #15: 0x00000001071ec1cc FridaGadget.dylibv8::internal::Deserializer<v8::internal::Isolate>::Allocate(v8::internal::AllocationType, int, v8::internal::AllocationAlignment) + 36
    frame #16: 0x00000001071ea6dc FridaGadget.dylibv8::internal::Deserializer<v8::internal::Isolate>::ReadObject(v8::internal::SnapshotSpace) + 112
    frame #17: 0x00000001071ebb54 FridaGadget.dylibint v8::internal::Deserializer<v8::internal::Isolate>::ReadSingleBytecodeData<v8::internal::SlotAccessorForRootSlots>(unsigned char, v8::internal::SlotAccessorForRootSlots) + 240
```

For gadget, a workaround would be to set the code signing policy to `required`.

This change forces `--jitless` for said platforms and resolves the issue.