### PR TITLE
fix/arm64: Handle fast interceptor patching limitations

### DIFF
--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -638,6 +638,21 @@ gum_interceptor_backend_prepare_trampoline (GumInterceptorBackend * self,
 
     ctx->trampoline_slice = gum_code_allocator_alloc_slice (self->allocator);
   }
+  else if (ctx->type == GUM_INTERCEPTOR_TYPE_FAST)
+  {
+    /*
+     * For fast interceptors, we must patch the target function to jump
+     * directly to the replacement function, instead of using a trampoline.
+     * This requires the jump instruction at the target site to reach the
+     * replacement function's address.
+     *
+     * However, if there are only 4 or 8 bytes of space available for patching,
+     * we cannot always emit a jump instruction that can reliably reach the
+     * replacement function (since the distance may be too far for short-range
+     * instructions). Therefore, we cannot proceed in this case.
+     */
+    return FALSE;
+  }
   else
   {
     GumAddressSpec spec;


### PR DESCRIPTION
Added a check in gum_interceptor_backend_prepare_trampoline to return FALSE for fast interceptors when there is insufficient space for a jump instruction to the replacement function. This ensures that patching is only attempted when it is feasible.