### PR TITLE
linux: fix arm64 ucontext record parsing on Android

### DIFF
--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -2634,11 +2634,6 @@ gum_linux_unparse_ucontext (const GumCpuContext * ctx,
     if (head->magic == 0)
       break;
 
-    if (head->size < 16 || (head->size & 15) != 0)
-      break;
-    if (i + head->size > sizeof (mc->__reserved))
-      break;
-
     switch (head->magic)
     {
       case FPSIMD_MAGIC:


### PR DESCRIPTION
This fixes parsing of AArch64 ucontext extension records on Linux/arm64.

On Android 16 (arm64), we observed system_server crashes with frida-agent present in the backtrace.
The tombstone showed AArch64 extension records (e.g. ESR/SVE) with a record header size of 0x10,
indicating that `_aarch64_ctx.size` already includes the 16-byte header.

The previous walker advanced by “header fields + head->size”, which can double-count the header and
desynchronize the walk, potentially leading to out-of-bounds reads when iterating uc_mcontext.__reserved.

Fix:
- Treat `head->size` as the total record size (including the header) and advance by `head->size`.
- Add basic sanity checks (minimum size, alignment, and bounds) to avoid OOB on malformed/corrupted input.

Tested on:
- Pixel 10 Pro, Android 16 (SDK 36), arm64: spawn/attach no longer triggers the observed system_server crash.

Related: frida/frida#3620