### PR TITLE
interceptor: Add FORCE attach flag

### DIFF
--- a/gum/guminterceptor-priv.h
+++ b/gum/guminterceptor-priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  *
@@ -84,7 +84,7 @@ G_GNUC_INTERNAL void _gum_interceptor_backend_destroy (
 G_GNUC_INTERNAL gboolean _gum_interceptor_backend_claim_grafted_trampoline (
     GumInterceptorBackend * self, GumFunctionContext * ctx);
 G_GNUC_INTERNAL gboolean _gum_interceptor_backend_create_trampoline (
-    GumInterceptorBackend * self, GumFunctionContext * ctx);
+    GumInterceptorBackend * self, GumFunctionContext * ctx, gboolean overwrite);
 G_GNUC_INTERNAL void _gum_interceptor_backend_destroy_trampoline (
     GumInterceptorBackend * self, GumFunctionContext * ctx);
 G_GNUC_INTERNAL void _gum_interceptor_backend_activate_trampoline (

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -148,7 +148,7 @@ static GumReplaceReturn gum_interceptor_replace_with_type (
     gpointer replacement_function, gpointer replacement_data,
     gpointer * original_function);
 static GumFunctionContext * gum_interceptor_instrument (GumInterceptor * self,
-    GumInterceptorType type, gpointer function_address,
+    GumInterceptorType type, gpointer function_address, gboolean force,
     GumInstrumentationError * error);
 static void gum_interceptor_activate (GumInterceptor * self,
     GumFunctionContext * ctx, gpointer prologue);
@@ -366,7 +366,7 @@ gum_interceptor_attach (GumInterceptor * self,
   function_address = gum_interceptor_resolve (self, function_address);
 
   function_ctx = gum_interceptor_instrument (self, GUM_INTERCEPTOR_TYPE_DEFAULT,
-      function_address, &error);
+      function_address, (flags & GUM_ATTACH_FLAGS_FORCE) != 0, &error);
 
   if (function_ctx == NULL)
     goto instrumentation_error;
@@ -500,7 +500,7 @@ gum_interceptor_replace_with_type (GumInterceptor * self,
   function_address = gum_interceptor_resolve (self, function_address);
 
   function_ctx =
-      gum_interceptor_instrument (self, type, function_address, &error);
+      gum_interceptor_instrument (self, type, function_address, FALSE, &error);
 
   if (function_ctx == NULL)
     goto instrumentation_error;
@@ -819,6 +819,7 @@ static GumFunctionContext *
 gum_interceptor_instrument (GumInterceptor * self,
                             GumInterceptorType type,
                             gpointer function_address,
+                            gboolean force,
                             GumInstrumentationError * error)
 {
   GumFunctionContext * ctx;
@@ -853,7 +854,7 @@ gum_interceptor_instrument (GumInterceptor * self,
   }
   else
   {
-    if (!_gum_interceptor_backend_create_trampoline (self->backend, ctx))
+    if (!_gum_interceptor_backend_create_trampoline (self->backend, ctx, force))
       goto wrong_signature;
   }
 

--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2024 Francesco Tamagni <mrmacete@protonmail.ch>
  *
@@ -28,6 +28,7 @@ typedef enum
 {
   GUM_ATTACH_FLAGS_NONE        = 0,
   GUM_ATTACH_FLAGS_UNIGNORABLE = (1 << 0),
+  GUM_ATTACH_FLAGS_FORCE       = (1 << 1),
 } GumAttachFlags;
 
 typedef enum


### PR DESCRIPTION
This flag allows attaching an inline hook even when the target function is too small to safely patch.

When used, the interceptor may overwrite bytes past the end of the function, which can be safe in cases where padding or alignment separates adjacent code.