### PR TITLE
darwin: accept __dyld_apis dyld section on macOS 26

### DIFF
--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -2823,8 +2823,8 @@ gum_find_tlv_get_addr (const GumDarwinSectionDetails * details,
   GumDarwinMapper * self = ctx->mapper;
 
   /* macOS 26+ uses __dyld_apis instead of __dyld4. */
-  if (strcmp (details->section_name, "__dyld4") != 0 &&
-      strcmp (details->section_name, "__dyld_apis") != 0)
+  if (strcmp (details->section_name, "__dyld_apis") != 0 &&
+      strcmp (details->section_name, "__dyld4") != 0)
     return TRUE;
 
   if (self->module->pointer_size == 4)


### PR DESCRIPTION
macOS 26 replaces libdyld’s __dyld4 section with __dyld_apis, causing
the mapper to fail with “Unsupported dyld version”.

This change accepts __dyld_apis in gum_find_tlv_get_addr().

Repro (macOS 26.2):
- dyld probe shows __dyld_apis, no __dyld4
- before patch: frida_injector_new() fails with “Unsupported dyld version”
- after patch: injection succeeds (sudo / SIP-disabled VM)

Refs: [frida/frida-core#<ISSUE>](https://github.com/frida/frida-core/issues/1210)