### PR TITLE
Fix SIGSEGV when enumerating exports from APK-embedded libraries (ONLINE mode)

### DIFF
--- a/gum/gumelfmodule.c
+++ b/gum/gumelfmodule.c
@@ -550,6 +550,13 @@ gum_elf_module_load (GumElfModule * self,
       self->file_bytes = g_bytes_new_static (
           GSIZE_TO_POINTER (self->base_address), gum_query_page_size ());
     }
+    else if (self->source_mode == GUM_ELF_SOURCE_MODE_ONLINE &&
+             strstr (self->source_path, "!") != NULL)
+    {
+      self->file_bytes = g_bytes_new_static (
+          GSIZE_TO_POINTER (self->base_address),
+          G_MAXSIZE - self->base_address);
+    }
     else
 #endif
     if (!gum_maybe_extract_from_apk (self->source_path, &self->file_bytes))

--- a/gum/gumelfmodule.c
+++ b/gum/gumelfmodule.c
@@ -207,6 +207,8 @@ static gboolean gum_store_symtab_params (
     const GumElfDynamicEntryDetails * details, gpointer user_data);
 static gboolean gum_adjust_symtab_params (const GumElfSectionDetails * details,
     gpointer user_data);
+static gboolean gum_count_and_forward_symbol (
+    const GumElfSymbolDetails * details, gpointer user_data);
 static void gum_elf_module_enumerate_symbols_in_section (GumElfModule * self,
     GumElfSectionType section, GumFoundElfSymbolFunc func, gpointer user_data);
 static gboolean gum_emit_each_needed (const GumElfDynamicEntryDetails * details,
@@ -826,6 +828,22 @@ gum_elf_module_load_section_headers (GumElfModule * self,
   gconstpointer start, end, cursor;
   guint16 i;
 
+  /*
+   * When file data is backed by the process memory image (ONLINE mode with
+   * APK-embedded libraries or modules whose backing file couldn't be opened),
+   * section headers reside at file offsets that don't correspond to valid data
+   * in the mapped memory — the dynamic linker only maps PT_LOAD segments, not
+   * section headers. Skip section loading; exports, imports, and dynamic
+   * symbols remain available via program headers and dynamic entries.
+   */
+  if (self->source_mode == GUM_ELF_SOURCE_MODE_ONLINE &&
+      self->file_data ==
+          (gconstpointer) GSIZE_TO_POINTER (self->base_address) &&
+      self->file_size > self->mapped_size)
+  {
+    return TRUE;
+  }
+
   data = gum_elf_module_get_file_data (self, &size);
 
   n = self->ehdr.shnum;
@@ -1124,8 +1142,17 @@ gum_elf_module_try_get_fallback_elf_module (GumElfModule * self)
 
     if (self->source_mode == GUM_ELF_SOURCE_MODE_ONLINE)
     {
-      self->fallback_elf_module =
-          gum_elf_module_new_from_file (self->source_path, NULL);
+      /*
+       * Skip fallback file load for APK-embedded libraries — the path
+       * (e.g., "base.apk!/lib/libfoo.so") cannot be opened as a regular
+       * file, and extracting via minizip causes SIGSEGV due to Android's
+       * special APK file handling.
+       */
+      if (strstr (self->source_path, ".apk!") == NULL)
+      {
+        self->fallback_elf_module =
+            gum_elf_module_new_from_file (self->source_path, NULL);
+      }
     }
     else
     {
@@ -2060,13 +2087,46 @@ gum_adjust_symtab_params (const GumElfSectionDetails * details,
   return TRUE;
 }
 
+typedef struct {
+  GumFoundElfSymbolFunc func;
+  gpointer user_data;
+  guint count;
+} GumElfCountSymbolsContext;
+
+static gboolean
+gum_count_and_forward_symbol (const GumElfSymbolDetails * details,
+                              gpointer user_data)
+{
+  GumElfCountSymbolsContext * ctx = user_data;
+
+  ctx->count++;
+
+  return ctx->func (details, ctx->user_data);
+}
+
 void
 gum_elf_module_enumerate_symbols (GumElfModule * self,
                                   GumFoundElfSymbolFunc func,
                                   gpointer user_data)
 {
+  GumElfCountSymbolsContext ctx;
+
+  ctx.func = func;
+  ctx.user_data = user_data;
+  ctx.count = 0;
+
   gum_elf_module_enumerate_symbols_in_section (self, GUM_ELF_SECTION_SYMTAB,
-      func, user_data);
+      gum_count_and_forward_symbol, &ctx);
+
+  /*
+   * If no SYMTAB symbols were found (e.g., stripped binary or APK-embedded
+   * library where fallback file load was skipped), fall back to enumerating
+   * dynamic symbols from .dynsym via dynamic entries.
+   */
+  if (ctx.count == 0)
+  {
+    gum_elf_module_enumerate_dynamic_symbols (self, func, user_data);
+  }
 }
 
 static void


### PR DESCRIPTION
Hey @oleavr,

first of all: thank you for your amazing work on Frida 🙏 — it’s hugely appreciated :-)

I tried the recent changes from **#1094**, but on my side the crash still happens (now consistently in a different code-path). I also left details here, in case it helps for cross-reference:  
https://github.com/frida/frida-gum/pull/1094#issuecomment-3999398128

## Summary

On **Android 14 + Android 16 AVD** (Google APIs, arm64) with `com.android.chrome`, this still crashes:

```js
var m = Process.getModuleByName("libmonochrome_64.so");
m.enumerateExports();
```

It only reproduces when the module is **APK-embedded** (path contains `!`), e.g.:

```
.../TrichromeLibrary.apk!/lib/arm64-v8a/libmonochrome_64.so
```

The tombstone’s top frame points at `__fseeko64()`, which suggests we’re crashing in the **minizip APK extraction path**, i.e., not the in-memory ELF parsing path.

## Proposed fix in this PR

If we’re in **ONLINE** mode and the path contains `!`, we can **skip `gum_maybe_extract_from_apk()`** and use the already-mapped bytes at `base_address` directly:

```c
else if (self->source_mode == GUM_ELF_SOURCE_MODE_ONLINE &&
         strstr (self->source_path, "!") != NULL)
{
  self->file_bytes = g_bytes_new_static (
      GSIZE_TO_POINTER (self->base_address),
      G_MAXSIZE - self->base_address);
}
```

Rationale: for ONLINE mode, the in-memory module image is already available and sufficient for export enumeration; avoiding APK I/O also avoids the minizip `FILE*` crash entirely.

## Result

With the patch applied, `enumerateExports()` works reliably and returns a normal export list (example):

```js
[Android Emulator 5554::Chrome ]-> m
{
  "base": "0x71d6807000",
  "name": "libmonochrome_64.so",
  "path": ".../TrichromeLibrary.apk!/lib/arm64-v8a/libmonochrome_64.so",
  "size": 148017152,
    "version": null
}

[Android Emulator 5554::Chrome ]-> m.enumerateExports();
[
    {
        "address": "0x71d90d4888",
        "name": "Java_J_N__1V_1IJJO",
        "type": "function"
    },
    {
        "address": "0x71d90de080",
        "name": "Java_J_N__1V_1IOOOOOOO",
        "type": "function"
    },
    {
        "address": "0x71d90bc430",
        "name": "Java_J_N__1I_1J",
        "type": "function"
    },
  ...
]
```

<details>
<summary>Crash excerpt (before patch)</summary>

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000060
Cause: null pointer dereference
#00 pc ... /apex/com.android.runtime/lib64/bionic/libc.so (__fseeko64(...)+36)
#01 pc ... /memfd:frida-agent-64.so (deleted)
...
```

</details>

Thanks again :-)


All the best

Daniel