### PR TITLE
Free slow slabs on Stalker context destroy

### DIFF
--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -2524,7 +2524,6 @@ gum_exec_ctx_free (GumExecCtx * ctx)
     slow_slab = next;
   }
 
-
   g_object_unref (ctx->sink);
   g_object_unref (ctx->transformer);
   g_clear_object (&ctx->observer);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -2475,6 +2475,7 @@ gum_exec_ctx_free (GumExecCtx * ctx)
   GumStalker * stalker = ctx->stalker;
   GumDataSlab * data_slab;
   GumCodeSlab * code_slab;
+  GumSlowSlab * slow_slab;
 
   gum_metal_hash_table_unref (ctx->mappings);
 
@@ -2507,6 +2508,22 @@ gum_exec_ctx_free (GumExecCtx * ctx)
 
     code_slab = next;
   }
+
+  slow_slab = ctx->slow_slab;
+  while (TRUE)
+  {
+    GumSlowSlab * next = (GumSlowSlab *) slow_slab->slab.next;
+    gboolean is_initial;
+
+    is_initial = next == NULL;
+    if (is_initial)
+      break;
+
+    gum_code_slab_free (&slow_slab->slab);
+
+    slow_slab = next;
+  }
+
 
   g_object_unref (ctx->sink);
   g_object_unref (ctx->transformer);


### PR DESCRIPTION
This fixes a memory leak. 

When using Stalker on Windows (x86-64) I observed commited memory bytes to raise linearly without actual physical memory consumption, eventually leading to "0xc000012d - Out of Virtual Memory" errors. With this change the commited memory remains stable in the stalked process. 

I didn't check the behavior with other backends.