### PR TITLE
iOS 16 support - stalker-arm64: Refresh code_available after helper pass

### DIFF
--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -3961,6 +3961,10 @@ gum_exec_block_maybe_create_new_code_slabs (GumExecCtx * ctx)
   gum_exec_ctx_add_slow_slab (ctx, gum_slab_end (&ctx->code_slab->slab));
 
   gum_exec_ctx_ensure_inline_helpers_reachable (ctx);
+  /* Updating available code space matters if ensure_inline_helpers_reachable
+   * advances the code slab cursor/size but the caller reuses the previous
+   * code availability calculation. */
+  code_available = gum_slab_available (&ctx->code_slab->slab);
 }
 
 static void


### PR DESCRIPTION
@oleavr addressing the issue https://github.com/frida/frida/issues/3719 part 1/2

## Problem

  `gum_exec_block_maybe_create_new_code_slabs` invokes
  `gum_exec_ctx_ensure_inline_helpers_reachable` after allocating new code
  and slow slabs. That helper can advance the code slab cursor, but the
  caller continues to use its previously-computed `code_available` value,
  which is now stale. Any subsequent logic that budgets against
  `code_available` will operate on an out-of-date figure.

  ## Fix

  Refresh `code_available` from `gum_slab_available(&ctx->code_slab->slab)`
  immediately after the helper reachability pass, so downstream budgeting
  reflects the true remaining space.

  ## Testing

  - Builds clean on macOS arm64 with `MACOS_CERTID=- make` in the top-level
    frida tree, which drives the full gum + frida-core + gumjs build.
  - The refreshed-value path is exercised by the existing
    `stalker-arm64` test suite on arm64 hosts.