### PR TITLE
stalker-x86: Skip AVX2 ymm save on Win7 WoW64

### DIFF
--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -1018,6 +1018,52 @@ beach:
   }
 }
 
+gboolean
+_gum_windows_is_win7_wow64 (void)
+{
+  static gsize initialized = FALSE;
+  static gboolean is_win7_wow64;
+
+  if (g_once_init_enter (&initialized))
+  {
+    GumIsWow64ProcessFunc is_wow64_process;
+    HMODULE kernel32 = GetModuleHandleW (L"kernel32.dll");
+
+    is_win7_wow64 = FALSE;
+
+    is_wow64_process = (GumIsWow64ProcessFunc)
+        GetProcAddress (kernel32, "IsWow64Process");
+    if (is_wow64_process != NULL)
+    {
+      BOOL is_wow64 = FALSE;
+
+      if (is_wow64_process (GetCurrentProcess (), &is_wow64) && is_wow64)
+      {
+        NTSTATUS (WINAPI * rtl_get_version) (PRTL_OSVERSIONINFOW info);
+        RTL_OSVERSIONINFOW info = { 0, };
+
+        rtl_get_version = (NTSTATUS (WINAPI *) (PRTL_OSVERSIONINFOW))
+            GetProcAddress (GetModuleHandleW (L"ntdll.dll"), "RtlGetVersion");
+
+        info.dwOSVersionInfoSize = sizeof (info);
+
+        /* Win7 / Server 2008 R2 = NT 6.1 */
+        if (rtl_get_version != NULL &&
+            rtl_get_version (&info) == 0 &&
+            info.dwMajorVersion == 6 &&
+            info.dwMinorVersion == 1)
+        {
+          is_win7_wow64 = TRUE;
+        }
+      }
+    }
+
+    g_once_init_leave (&initialized, TRUE);
+  }
+
+  return is_win7_wow64;
+}
+
 gchar *
 gum_windows_query_thread_name (HANDLE thread)
 {

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -14,6 +14,7 @@
 #include "gummemory.h"
 #include "gumx86relocator.h"
 #include "gumspinlock.h"
+#include "gumprocess-priv.h"
 #include "gumstalker-priv.h"
 #ifdef HAVE_WINDOWS
 # include "gumexceptor.h"
@@ -3635,7 +3636,16 @@ gum_exec_ctx_write_prolog_helper (GumExecCtx * ctx,
   gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 512);
   gum_x86_writer_put_bytes (cw, fxsave, sizeof (fxsave));
 
-  if ((ctx->stalker->cpu_features & GUM_CPU_AVX2) != 0)
+  /*
+   * Skip the YMM upper-half save on Windows 7 32-bit (WoW64) processes.
+   * The AVX2 save/restore corrupts the wow64 transition layer's per-thread
+   * state when emitted from a JIT page on that OS, causing the next
+   * syscall to fault. The lower 128 bits of YMM are still preserved by
+   * fxsave, and the Windows x86 ABI does not preserve the upper halves
+   * across calls.
+   */
+  if ((ctx->stalker->cpu_features & GUM_CPU_AVX2) != 0 &&
+      !_gum_windows_is_win7_wow64 ())
   {
     gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 0x100);
     gum_x86_writer_put_bytes (cw, upper_ymm_saver, sizeof (upper_ymm_saver));
@@ -3696,7 +3706,8 @@ gum_exec_ctx_write_epilog_helper (GumExecCtx * ctx,
           : GUM_FULL_PROLOG_RETURN_OFFSET,
       GUM_X86_XAX);
 
-  if ((ctx->stalker->cpu_features & GUM_CPU_AVX2) != 0)
+  if ((ctx->stalker->cpu_features & GUM_CPU_AVX2) != 0 &&
+      !_gum_windows_is_win7_wow64 ())
   {
     gum_x86_writer_put_bytes (cw, upper_ymm_restorer,
         sizeof (upper_ymm_restorer));

--- a/gum/gumprocess-priv.h
+++ b/gum/gumprocess-priv.h
@@ -20,6 +20,12 @@ G_GNUC_INTERNAL gboolean _gum_process_collect_main_module (GumModule * module,
 G_GNUC_INTERNAL void _gum_process_enumerate_ranges (GumPageProtection prot,
     GumFoundRangeFunc func, gpointer user_data);
 
+#ifdef HAVE_WINDOWS
+G_GNUC_INTERNAL gboolean _gum_windows_is_win7_wow64 (void);
+#else
+# define _gum_windows_is_win7_wow64() FALSE
+#endif
+
 #if defined (HAVE_I386)
 G_GNUC_INTERNAL void _gum_x86_set_breakpoint (gsize * dr7, gsize * dr0,
     guint breakpoint_id, GumAddress address);


### PR DESCRIPTION
Hi @oleavr! Long time no chat :) I've been working on a project that leverages the stalker infrastructure and found a bug with how stalker's AVX2 instructions work on win7 64 bit/WoW64. 

On Windows 7 running a 32-bit (WoW64) process, executing the AVX2 ymm save/restore vextracti128/vinserti128) emitted into Stalker's prolog/epilog from a JIT RWX page corrupts wow64cpu state. TEB64 fields are zeroed (NtTib.Self at +0x30, PEB pointer at +0x60, Win32ThreadInfo at +0x78, and TlsSlots[0] / WOW64_TLS_STACKPTR64 at +0x1480), causing the next wow64 syscall to fault inside wow64cpu!CpupReturnFromSimulatedCode while reading `mov rsp, [r12+0x1480]` as zero.

The bug is wow64cpu-specific to NT 6.1: Win7 32-bit native, Win10/11 WoW64, and 64-bit processes are unaffected as far as I can tell. fxsave already preserves the lower 128 bits of YMM, and the Windows x86 ABI does not preserve YMM upper halves across calls, so omitting the save is safe (I think).

All that said I'm not really sure the right way to test this. I was thinking we could ensure that those bytes aren't emitted in the stalker's memory pages but there's not an easy way to see the pages the stalker uses and byte scanning feels flakey at best. I'm open to ideas! 

Anecdotally this fix seems to be exactly what fixes my stalking pipeline when running 32 bit programs on win 7 64 bit. 

LMK what you think! 🚀 Thank you!