### PR TITLE
darwin: Ensure page plan on allocated code pages

### DIFF
--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -50,6 +50,7 @@ static gboolean gum_try_alloc_in_range_if_near_enough (
 static gboolean gum_try_suggest_allocation_base (const GumMemoryRange * range,
     const GumAllocNearContext * ctx, gpointer * allocation_base);
 static gint gum_page_protection_to_bsd (GumPageProtection prot);
+static gboolean gum_page_is_freshly_allocated (gpointer page, gsize size);
 
 void
 _gum_memory_backend_init (void)
@@ -891,6 +892,11 @@ gum_memory_is_codesign_out_of_the_way (gpointer page)
   vm_address_t writable_address;
   vm_prot_t cur_prot, max_prot;
 
+  size = gum_query_page_size ();
+
+  if (gum_page_is_freshly_allocated (page, size))
+    return FALSE;
+
   task = mach_task_self ();
 
   /* TODO: Implement shim. */
@@ -905,7 +911,6 @@ gum_memory_is_codesign_out_of_the_way (gpointer page)
     return FALSE;
   }
 
-  size = gum_query_page_size ();
   writable_address = 0;
   if (vm_remap (task, &writable_address, size, 0, VM_FLAGS_ANYWHERE, task,
       GPOINTER_TO_SIZE (page), FALSE, &cur_prot, &max_prot,
@@ -920,6 +925,21 @@ gum_memory_is_codesign_out_of_the_way (gpointer page)
   mach_vm_deallocate (task, writable_address, size);
 
   return result;
+}
+
+static gboolean
+gum_page_is_freshly_allocated (gpointer page,
+                               gsize size)
+{
+  guint8 vec = 0;
+
+  /* TODO: Implement shim. */
+  if (mincore (page, size, (char *)&vec) != 0)
+    return FALSE;
+
+  return (vec & MINCORE_ANONYMOUS) &&
+      ((vec & (MINCORE_INCORE | MINCORE_REFERENCED |
+          MINCORE_MODIFIED | MINCORE_PAGED_OUT)) == 0);
 }
 
 void

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -934,7 +934,7 @@ gum_page_is_freshly_allocated (gpointer page,
   guint8 vec = 0;
 
   /* TODO: Implement shim. */
-  if (mincore (page, size, (char *)&vec) != 0)
+  if (mincore (page, size, (char *) &vec) != 0)
     return FALSE;
 
   return (vec & MINCORE_ANONYMOUS) &&

--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2025 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2025-2026 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */


### PR DESCRIPTION
Before this change, `gum_memory_is_codesign_out_of_the_way` always returned TRUE for freshly allocated memory, and those pages didn't end up in the page plan when debugger mappings are enforced.

On older devices this is not a problem, but on more recent SoCs page plans are needed for these too in order to avoid failing for missing codesign at execution time. This left `Interceptor` and `Memory.patchCode` non-functional on iOS 26+ for more recent apple devices.

This change introduces the `gum_page_is_freshly_allocated` function to explicitly detect pages in such state (by using `mincore`) and ensure they get included in the page plan.