### PR TITLE
gumjs: Extend Memory.alloc() to specify protection

### DIFF
--- a/bindings/gumjs/gumquickmemory.c
+++ b/bindings/gumjs/gumquickmemory.c
@@ -175,9 +175,10 @@ gumjs_get_parent_module (GumQuickCore * core)
 GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
 {
   gsize size, page_size;
+  GumPageProtection prot;
   GumAddressSpec spec;
 
-  if (!_gum_quick_args_parse (args, "ZpZ", &size, &spec.near_address,
+  if (!_gum_quick_args_parse (args, "ZmpZ", &size, &prot, &spec.near_address,
       &spec.max_distance))
     return JS_EXCEPTION;
 
@@ -196,7 +197,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
           "size must be a multiple of page size");
     }
 
-    result = gum_try_alloc_n_pages_near (size / page_size, GUM_PAGE_RW, &spec);
+    result = gum_try_alloc_n_pages_near (size / page_size, prot, &spec);
     if (result == NULL)
     {
       return _gum_quick_throw_literal (ctx,
@@ -209,13 +210,19 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
   {
     if ((size % page_size) != 0)
     {
+      if ((prot & GUM_PAGE_EXECUTE) != 0)
+      {
+        return _gum_quick_throw_literal (ctx,
+            "size must be a multiple of page size");
+      }
+
       return _gum_quick_native_resource_new (ctx, g_malloc0 (size), g_free,
           core);
     }
     else
     {
       return _gum_quick_native_resource_new (ctx,
-          gum_alloc_n_pages (size / page_size, GUM_PAGE_RW), gum_free_pages,
+          gum_alloc_n_pages (size / page_size, prot), gum_free_pages,
           core);
     }
   }

--- a/bindings/gumjs/gumv8memory.cpp
+++ b/bindings/gumjs/gumv8memory.cpp
@@ -132,8 +132,9 @@ _gum_v8_memory_finalize (GumV8Memory * self)
 GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
 {
   gsize size;
+  GumPageProtection prot;
   GumAddressSpec spec;
-  if (!_gum_v8_args_parse (args, "ZpZ", &size, &spec.near_address,
+  if (!_gum_v8_args_parse (args, "ZmpZ", &size, &prot, &spec.near_address,
       &spec.max_distance))
     return;
 
@@ -157,7 +158,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
           "size must be a multiple of page size");
     }
 
-    result = gum_try_alloc_n_pages_near (size / page_size, GUM_PAGE_RW, &spec);
+    result = gum_try_alloc_n_pages_near (size / page_size, prot, &spec);
     if (result == NULL)
     {
       return _gum_v8_throw_ascii_literal (isolate,
@@ -170,12 +171,18 @@ GUMJS_DEFINE_FUNCTION (gumjs_memory_alloc)
   {
     if ((size % page_size) != 0)
     {
+      if ((prot & GUM_PAGE_EXECUTE) != 0)
+      {
+        return _gum_v8_throw_ascii_literal (isolate,
+            "size must be a multiple of page size");
+      }
+
       res = _gum_v8_native_resource_new (g_malloc0 (size), size, g_free, core);
     }
     else
     {
       res = _gum_v8_native_resource_new (
-          gum_alloc_n_pages (size / page_size, GUM_PAGE_RW), size,
+          gum_alloc_n_pages (size / page_size, prot), size,
           gum_free_pages, core);
     }
   }

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -161,11 +161,11 @@ Object.defineProperties(Kernel, {
 Object.defineProperties(Memory, {
   alloc: {
     enumerable: true,
-    value: function (size, { near, maxDistance } = {}) {
+    value: function (size, { near, maxDistance, protection } = {}) {
       if (near !== undefined && maxDistance === undefined)
         throw new Error('missing maxDistance option');
 
-      return Memory._alloc(size, near ?? NULL, maxDistance ?? 0);
+      return Memory._alloc(size, protection ?? "rw", near ?? NULL, maxDistance ?? 0);
     }
   },
   dup: {


### PR DESCRIPTION
Add the optional `protection` field to the existing options object. If not specified, it falls back to `"rw"` to be consistent with the current behaviour.

In this way it's possible to allocate page-aligned executable memory even in scenarios where memory can't be flipped from rw to rx (like on non-jailbroken iOS 26+).