### PR TITLE
arm32-relocator: Fix B<cond> silently dropping condition code

### DIFF
--- a/gum/arch-arm/gumarmrelocator.c
+++ b/gum/arch-arm/gumarmrelocator.c
@@ -37,7 +37,7 @@ static gboolean gum_arm_relocator_rewrite_sub (GumArmRelocator * self,
 static gboolean gum_arm_relocator_rewrite_b (GumArmRelocator * self,
     cs_mode target_mode, GumCodeGenCtx * ctx);
 static gboolean gum_arm_relocator_rewrite_b_cond (GumArmRelocator * self,
-    cs_mode target_mode, GumCodeGenCtx * ctx);
+    GumCodeGenCtx * ctx);
 static gboolean gum_arm_relocator_rewrite_bl (GumArmRelocator * self,
     cs_mode target_mode, GumCodeGenCtx * ctx);
 
@@ -284,7 +284,7 @@ gum_arm_relocator_write_one (GumArmRelocator * self)
       if (gum_arm_branch_is_unconditional (insn))
         rewritten = gum_arm_relocator_rewrite_b (self, CS_MODE_ARM, &ctx);
       else
-        rewritten = gum_arm_relocator_rewrite_b_cond (self, CS_MODE_ARM, &ctx);
+        rewritten = gum_arm_relocator_rewrite_b_cond (self, &ctx);
       break;
     case ARM_INS_BX:
       rewritten = gum_arm_relocator_rewrite_b (self, CS_MODE_THUMB, &ctx);
@@ -791,21 +791,29 @@ gum_arm_relocator_rewrite_b (GumArmRelocator * self,
 
 static gboolean
 gum_arm_relocator_rewrite_b_cond (GumArmRelocator * self,
-                                  cs_mode target_mode,
                                   GumCodeGenCtx * ctx)
 {
   const cs_arm_op * target = &ctx->detail->operands[0];
-  arm_cc inv_cc;
+  gsize unique_id = GPOINTER_TO_SIZE (ctx->output->code) << 1;
+  gconstpointer is_true = GSIZE_TO_POINTER (unique_id | 1);
+  gconstpointer is_false = GSIZE_TO_POINTER (unique_id | 0);
 
   if (target->type != ARM_OP_IMM)
     return FALSE;
 
-  inv_cc = (ctx->detail->cc & 1) ? ctx->detail->cc + 1 : ctx->detail->cc - 1;
-  gum_arm_writer_put_b_cond_imm (ctx->output, inv_cc, ctx->output->pc + 12);
+  gum_arm_writer_put_b_cond_label (ctx->output, ctx->detail->cc, is_true);
+  gum_arm_writer_put_b_label (ctx->output, is_false);
 
-  gum_arm_writer_put_ldr_reg_u32 (ctx->output, ARM_REG_PC,
-      (target_mode == CS_MODE_THUMB) ? target->imm | 1 : target->imm);
-  gum_arm_writer_flush (ctx->output);
+  gum_arm_writer_put_label (ctx->output, is_true);
+  gum_arm_writer_put_push_regs (ctx->output, 1, ARM_REG_R0);
+  gum_arm_writer_put_push_regs (ctx->output, 1, ARM_REG_R0);
+  gum_arm_writer_put_ldr_reg_address (ctx->output, ARM_REG_R0,
+      target->imm);
+  gum_arm_writer_put_str_reg_reg_offset (ctx->output, ARM_REG_R0,
+      ARM_REG_SP, 4);
+  gum_arm_writer_put_pop_regs (ctx->output, 2, ARM_REG_R0, ARM_REG_PC);
+
+  gum_arm_writer_put_label (ctx->output, is_false);
 
   return TRUE;
 }

--- a/gum/arch-arm/gumarmrelocator.c
+++ b/gum/arch-arm/gumarmrelocator.c
@@ -36,6 +36,8 @@ static gboolean gum_arm_relocator_rewrite_sub (GumArmRelocator * self,
     GumCodeGenCtx * ctx);
 static gboolean gum_arm_relocator_rewrite_b (GumArmRelocator * self,
     cs_mode target_mode, GumCodeGenCtx * ctx);
+static gboolean gum_arm_relocator_rewrite_b_cond (GumArmRelocator * self,
+    cs_mode target_mode, GumCodeGenCtx * ctx);
 static gboolean gum_arm_relocator_rewrite_bl (GumArmRelocator * self,
     cs_mode target_mode, GumCodeGenCtx * ctx);
 
@@ -279,7 +281,10 @@ gum_arm_relocator_write_one (GumArmRelocator * self)
       rewritten = gum_arm_relocator_rewrite_sub (self, &ctx);
       break;
     case ARM_INS_B:
-      rewritten = gum_arm_relocator_rewrite_b (self, CS_MODE_ARM, &ctx);
+      if (gum_arm_branch_is_unconditional (insn))
+        rewritten = gum_arm_relocator_rewrite_b (self, CS_MODE_ARM, &ctx);
+      else
+        rewritten = gum_arm_relocator_rewrite_b_cond (self, CS_MODE_ARM, &ctx);
       break;
     case ARM_INS_BX:
       rewritten = gum_arm_relocator_rewrite_b (self, CS_MODE_THUMB, &ctx);
@@ -781,6 +786,27 @@ gum_arm_relocator_rewrite_b (GumArmRelocator * self,
 
   gum_arm_writer_put_ldr_reg_address (ctx->output, ARM_REG_PC,
       (target_mode == CS_MODE_THUMB) ? target->imm | 1 : target->imm);
+  return TRUE;
+}
+
+static gboolean
+gum_arm_relocator_rewrite_b_cond (GumArmRelocator * self,
+                                  cs_mode target_mode,
+                                  GumCodeGenCtx * ctx)
+{
+  const cs_arm_op * target = &ctx->detail->operands[0];
+  arm_cc inv_cc;
+
+  if (target->type != ARM_OP_IMM)
+    return FALSE;
+
+  inv_cc = (ctx->detail->cc & 1) ? ctx->detail->cc + 1 : ctx->detail->cc - 1;
+  gum_arm_writer_put_b_cond_imm (ctx->output, inv_cc, ctx->output->pc + 12);
+
+  gum_arm_writer_put_ldr_reg_u32 (ctx->output, ARM_REG_PC,
+      (target_mode == CS_MODE_THUMB) ? target->imm | 1 : target->imm);
+  gum_arm_writer_flush (ctx->output);
+
   return TRUE;
 }
 

--- a/tests/core/arch-arm/armrelocator.c
+++ b/tests/core/arch-arm/armrelocator.c
@@ -589,14 +589,19 @@ TESTCASE (b_cond_imm_a1_positive_should_be_rewritten)
 {
   BranchScenario bs = {
     ARM_INS_B,
-    { 0x1a000001 }, 1,          /* bne pc + 4        */
+    { 0x1a000001 }, 1,          /* bne pc + 4           */
     {
-      0x0a000001,               /* beq is_false      */
-      0xe51ff004,               /* ldr pc, [pc, #-4] */
-      0xffffffff                /* <calculated PC    */
-                                /*  goes here>       */
-    }, 3,
-    2, 4,
+      0x1a000000,               /* bne is_true          */
+      0xea000004,               /* b   is_false         */
+      0xe92d0001,               /* push {r0}            */
+      0xe92d0001,               /* push {r0}            */
+      0xe59f0004,               /* ldr r0, [pc, #4]     */
+      0xe58d0004,               /* str r0, [sp, #4]     */
+      0xe8bd8001,               /* pop {r0, pc}         */
+      0xffffffff                /* <calculated PC       */
+                                /*  goes here>          */
+    }, 8,
+    7, 4,
     -1, -1
   };
   branch_scenario_execute (&bs, fixture);
@@ -606,14 +611,19 @@ TESTCASE (b_cond_imm_a1_negative_should_be_rewritten)
 {
   BranchScenario bs = {
     ARM_INS_B,
-    { 0x1affffff }, 1,          /* bne pc - 4        */
+    { 0x1affffff }, 1,          /* bne pc - 4           */
     {
-      0x0a000001,               /* beq is_false      */
-      0xe51ff004,               /* ldr pc, [pc, #-4] */
-      0xffffffff                /* <calculated PC    */
-                                /*  goes here>       */
-    }, 3,
-    2, -4,
+      0x1a000000,               /* bne is_true          */
+      0xea000004,               /* b   is_false         */
+      0xe92d0001,               /* push {r0}            */
+      0xe92d0001,               /* push {r0}            */
+      0xe59f0004,               /* ldr r0, [pc, #4]     */
+      0xe58d0004,               /* str r0, [sp, #4]     */
+      0xe8bd8001,               /* pop {r0, pc}         */
+      0xffffffff                /* <calculated PC       */
+                                /*  goes here>          */
+    }, 8,
+    7, -4,
     -1, -1
   };
   branch_scenario_execute (&bs, fixture);

--- a/tests/core/arch-arm/armrelocator.c
+++ b/tests/core/arch-arm/armrelocator.c
@@ -36,6 +36,8 @@ TESTLIST_BEGIN (armrelocator)
   TESTENTRY (pc_relative_sub_shift_reg_should_be_rewritten)
   TESTENTRY (b_imm_a1_positive_should_be_rewritten)
   TESTENTRY (b_imm_a1_negative_should_be_rewritten)
+  TESTENTRY (b_cond_imm_a1_positive_should_be_rewritten)
+  TESTENTRY (b_cond_imm_a1_negative_should_be_rewritten)
   TESTENTRY (bl_imm_a1_positive_should_be_rewritten)
   TESTENTRY (bl_imm_a1_negative_should_be_rewritten)
   TESTENTRY (blx_imm_a2_positive_should_be_rewritten)
@@ -578,6 +580,40 @@ TESTCASE (b_imm_a1_negative_should_be_rewritten)
                                 /*  goes here>       */
     }, 2,
     1, -4,
+    -1, -1
+  };
+  branch_scenario_execute (&bs, fixture);
+}
+
+TESTCASE (b_cond_imm_a1_positive_should_be_rewritten)
+{
+  BranchScenario bs = {
+    ARM_INS_B,
+    { 0x1a000001 }, 1,          /* bne pc + 4        */
+    {
+      0x0a000001,               /* beq is_false      */
+      0xe51ff004,               /* ldr pc, [pc, #-4] */
+      0xffffffff                /* <calculated PC    */
+                                /*  goes here>       */
+    }, 3,
+    2, 4,
+    -1, -1
+  };
+  branch_scenario_execute (&bs, fixture);
+}
+
+TESTCASE (b_cond_imm_a1_negative_should_be_rewritten)
+{
+  BranchScenario bs = {
+    ARM_INS_B,
+    { 0x1affffff }, 1,          /* bne pc - 4        */
+    {
+      0x0a000001,               /* beq is_false      */
+      0xe51ff004,               /* ldr pc, [pc, #-4] */
+      0xffffffff                /* <calculated PC    */
+                                /*  goes here>       */
+    }, 3,
+    2, -4,
     -1, -1
   };
   branch_scenario_execute (&bs, fixture);


### PR DESCRIPTION
# arm: fix conditional branch relocation

## Problem

`gumthumbrelocator` and `gumarm64relocator` both implement `rewrite_b_cond`
to correctly relocate conditional branches. 

`gumarmrelocator` has no equivalent: `rewrite_b` handles all `ARM_INS_B`
regardless of condition code and silently emits an unconditional `LDR PC, =target`, 
corrupting control flow.

## Fix

`write_one` now dispatches `ARM_INS_B` to a new
`gum_arm_relocator_rewrite_b_cond` when the condition code is not `AL`,
mirroring the approach used by `gumthumbrelocator` and `gumarm64relocator`:

Two test cases `b_cond_imm_a1_positive_should_be_rewritten` and
`b_cond_imm_a1_negative_should_be_rewritten` are added to
`tests/core/arch-arm/armrelocator.c`.

Fixes **#1095**