### PR TITLE
fix(stalker): account for pending literal pool size in is_out_of_space()

### DIFF
--- a/gum/backend-arm/gumstalker-arm.c
+++ b/gum/backend-arm/gumstalker-arm.c
@@ -2606,7 +2606,7 @@ gum_stalker_iterator_is_out_of_space (GumStalkerIterator * self)
   GumGeneratorContext * gc = self->generator_context;
   GumSlab * slab = &block->code_slab->slab;
   guint8 * cursor;
-  gsize capacity, snapshot_size;
+  gsize capacity, snapshot_size, pending_literals_size;
 
   cursor = gc->is_thumb
       ? gum_thumb_writer_cur (gc->thumb_writer)
@@ -2618,7 +2618,26 @@ gum_stalker_iterator_is_out_of_space (GumStalkerIterator * self)
       self->exec_context->stalker,
       gc->instruction->end - block->real_start);
 
-  return capacity < GUM_EXEC_BLOCK_MIN_CAPACITY + snapshot_size;
+  if (gc->is_thumb)
+  {
+    GumThumbWriter * tw = gc->thumb_writer;
+    gsize alignment_padding = sizeof (guint16);
+
+    pending_literals_size = (tw->literal_refs.data != NULL)
+        ? (tw->literal_refs.length * sizeof (guint32)) + alignment_padding
+        : 0;
+  }
+  else
+  {
+    GumArmWriter * aw = gc->arm_writer;
+
+    pending_literals_size = (aw->literal_refs.data != NULL)
+        ? aw->literal_refs.length * sizeof (guint32)
+        : 0;
+  }
+
+  return capacity < GUM_EXEC_BLOCK_MIN_CAPACITY + snapshot_size +
+      pending_literals_size;
 }
 
 void

--- a/gum/backend-arm64/gumstalker-arm64.c
+++ b/gum/backend-arm64/gumstalker-arm64.c
@@ -2924,16 +2924,22 @@ gum_stalker_iterator_is_out_of_space (GumStalkerIterator * self)
 {
   GumExecBlock * block = self->exec_block;
   GumSlab * slab = &block->code_slab->slab;
-  gsize capacity, snapshot_size;
+  GumArm64Writer * cw = self->generator_context->code_writer;
+  gsize capacity, snapshot_size, pending_literals_size;
 
   capacity = (guint8 *) gum_slab_end (slab) -
-      (guint8 *) gum_arm64_writer_cur (self->generator_context->code_writer);
+      (guint8 *) gum_arm64_writer_cur (cw);
 
   snapshot_size = gum_stalker_snapshot_space_needed_for (
       self->exec_context->stalker,
       self->generator_context->instruction->end - block->real_start);
 
-  return capacity < GUM_EXEC_BLOCK_MIN_CAPACITY + snapshot_size;
+  pending_literals_size = (cw->literal_refs.data != NULL)
+      ? cw->literal_refs.length * sizeof (guint64)
+      : 0;
+
+  return capacity < GUM_EXEC_BLOCK_MIN_CAPACITY + snapshot_size +
+      pending_literals_size;
 }
 
 void

--- a/tests/core/arch-arm/stalker-arm-fixture.c
+++ b/tests/core/arch-arm/stalker-arm-fixture.c
@@ -105,6 +105,8 @@
  */
 #define INVOKER_IMPL_OFFSET 24
 
+#define MANY_CALLOUTS_INSN_COUNT 1500
+
 typedef struct _TestArmStalkerFixture TestArmStalkerFixture;
 typedef struct _UnfollowTransformContext UnfollowTransformContext;
 typedef struct _InvalidationTransformContext InvalidationTransformContext;

--- a/tests/core/arch-arm/stalker-arm.c
+++ b/tests/core/arch-arm/stalker-arm.c
@@ -102,6 +102,8 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (thumb_callout)
   TESTENTRY (arm_transformer_should_be_able_to_replace_call_with_callout)
   TESTENTRY (arm_transformer_should_be_able_to_replace_jumpout_with_callout)
+  TESTENTRY (arm_many_callouts_should_not_overflow_literal_pool)
+  TESTENTRY (thumb_many_callouts_should_not_overflow_literal_pool)
   TESTENTRY (unfollow_should_be_allowed_before_first_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_first_transform)
   TESTENTRY (unfollow_should_be_allowed_after_first_transform)
@@ -177,6 +179,10 @@ static void replace_call_with_callout (GumStalkerIterator * iterator,
 static void replace_jumpout_with_callout (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static void callout_set_cool (GumCpuContext * cpu_context, gpointer user_data);
+static void add_callout_for_every_instruction (GumStalkerIterator * iterator,
+    GumStalkerOutput * output, gpointer user_data);
+static void bump_num_callouts (GumCpuContext * cpu_context,
+    gpointer user_data);
 static void unfollow_during_transform (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static void test_invalidation_for_current_thread_with_target (GumAddress target,
@@ -2830,6 +2836,90 @@ callout_set_cool (GumCpuContext * cpu_context,
                   gpointer user_data)
 {
   cpu_context->r[0] = 0xc001;
+}
+
+TESTCASE (arm_many_callouts_should_not_overflow_literal_pool)
+{
+  gint num_callouts = 0;
+  guint32 * code;
+  GumArmWriter cw;
+  guint i;
+  GumAddress func;
+
+  fixture->transformer = gum_stalker_transformer_make_from_callback (
+      add_callout_for_every_instruction, &num_callouts, NULL);
+  fixture->sink->mask = GUM_NOTHING;
+
+  code = g_malloc ((MANY_CALLOUTS_INSN_COUNT + 1) * sizeof (guint32));
+  gum_arm_writer_init (&cw, code);
+  for (i = 0; i != MANY_CALLOUTS_INSN_COUNT; i++)
+    gum_arm_writer_put_add_reg_u16 (&cw, ARM_REG_R0, 1);
+  gum_arm_writer_put_ret (&cw);
+  gum_arm_writer_flush (&cw);
+
+  func = test_arm_stalker_fixture_dup_code (fixture, code,
+      gum_arm_writer_offset (&cw));
+
+  gum_arm_writer_clear (&cw);
+  g_free (code);
+
+  FOLLOW_AND_INVOKE (func);
+
+  g_assert_cmpint (num_callouts, >=, MANY_CALLOUTS_INSN_COUNT);
+}
+
+TESTCASE (thumb_many_callouts_should_not_overflow_literal_pool)
+{
+  gint num_callouts = 0;
+  guint16 * code;
+  GumThumbWriter cw;
+  guint i;
+  GumAddress func;
+
+  fixture->transformer = gum_stalker_transformer_make_from_callback (
+      add_callout_for_every_instruction, &num_callouts, NULL);
+  fixture->sink->mask = GUM_NOTHING;
+
+  code = g_malloc ((MANY_CALLOUTS_INSN_COUNT + 1) * sizeof (guint16));
+  gum_thumb_writer_init (&cw, code);
+  for (i = 0; i != MANY_CALLOUTS_INSN_COUNT; i++)
+    gum_thumb_writer_put_add_reg_imm (&cw, ARM_REG_R0, 1);
+  gum_thumb_writer_put_bx_reg (&cw, ARM_REG_LR);
+  gum_thumb_writer_flush (&cw);
+
+  func = test_arm_stalker_fixture_dup_code (fixture, (guint32 *) code,
+      gum_thumb_writer_offset (&cw));
+
+  gum_thumb_writer_clear (&cw);
+  g_free (code);
+
+  FOLLOW_AND_INVOKE (func + 1);
+
+  g_assert_cmpint (num_callouts, >=, MANY_CALLOUTS_INSN_COUNT);
+}
+
+static void
+add_callout_for_every_instruction (GumStalkerIterator * iterator,
+                                   GumStalkerOutput * output,
+                                   gpointer user_data)
+{
+  gint * num_callouts = user_data;
+
+  while (gum_stalker_iterator_next (iterator, NULL))
+  {
+    gum_stalker_iterator_put_callout (iterator, bump_num_callouts,
+        num_callouts, NULL);
+    gum_stalker_iterator_keep (iterator);
+  }
+}
+
+static void
+bump_num_callouts (GumCpuContext * cpu_context,
+                   gpointer user_data)
+{
+  gint * num_callouts = user_data;
+
+  (*num_callouts)++;
 }
 
 TESTCASE (unfollow_should_be_allowed_before_first_transform)

--- a/tests/core/arch-arm64/stalker-arm64-fixture.c
+++ b/tests/core/arch-arm64/stalker-arm64-fixture.c
@@ -33,6 +33,8 @@
 #define NTH_EXEC_EVENT_LOCATION(N) \
     (gum_fake_event_sink_get_nth_event_as_exec (fixture->sink, N)->location)
 
+#define MANY_CALLOUTS_INSN_COUNT 1500
+
 typedef struct _TestArm64StalkerFixture
 {
   GumStalker * stalker;

--- a/tests/core/arch-arm64/stalker-arm64.c
+++ b/tests/core/arch-arm64/stalker-arm64.c
@@ -34,6 +34,7 @@ TESTLIST_BEGIN (stalker)
   TESTENTRY (transformer_should_be_able_to_skip_call)
   TESTENTRY (transformer_should_be_able_to_replace_call_with_callout)
   TESTENTRY (transformer_should_be_able_to_replace_tailjump_with_callout)
+  TESTENTRY (many_callouts_should_not_overflow_literal_pool)
   TESTENTRY (unfollow_should_be_allowed_before_first_transform)
   TESTENTRY (unfollow_should_be_allowed_mid_first_transform)
   TESTENTRY (unfollow_should_be_allowed_after_first_transform)
@@ -132,6 +133,10 @@ static void replace_call_with_callout (GumStalkerIterator * iterator,
 static void replace_jmp_with_callout (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static void callout_set_cool (GumCpuContext * cpu_context, gpointer user_data);
+static void add_callout_for_every_instruction (GumStalkerIterator * iterator,
+    GumStalkerOutput * output, gpointer user_data);
+static void bump_num_callouts (GumCpuContext * cpu_context,
+    gpointer user_data);
 static void unfollow_during_transform (GumStalkerIterator * iterator,
     GumStalkerOutput * output, gpointer user_data);
 static gboolean test_is_finished (void);
@@ -649,6 +654,62 @@ callout_set_cool (GumCpuContext * cpu_context,
                   gpointer user_data)
 {
   cpu_context->x[0] = 0xc001;
+}
+
+TESTCASE (many_callouts_should_not_overflow_literal_pool)
+{
+  gint num_callouts = 0;
+  guint32 * code;
+  GumArm64Writer cw;
+  guint i;
+  StalkerTestFunc func;
+  gint ret;
+
+  fixture->transformer = gum_stalker_transformer_make_from_callback (
+      add_callout_for_every_instruction, &num_callouts, NULL);
+  fixture->sink->mask = GUM_NOTHING;
+
+  code = g_malloc ((MANY_CALLOUTS_INSN_COUNT + 1) * sizeof (guint32));
+  gum_arm64_writer_init (&cw, code);
+  for (i = 0; i != MANY_CALLOUTS_INSN_COUNT; i++)
+    gum_arm64_writer_put_add_reg_reg_imm (&cw, ARM64_REG_X0, ARM64_REG_X0, 1);
+  gum_arm64_writer_put_ret (&cw);
+  gum_arm64_writer_flush (&cw);
+
+  func = (StalkerTestFunc) test_arm64_stalker_fixture_dup_code (fixture, code,
+      gum_arm64_writer_offset (&cw));
+
+  gum_arm64_writer_clear (&cw);
+  g_free (code);
+
+  ret = test_arm64_stalker_fixture_follow_and_invoke (fixture, func, 0);
+
+  g_assert_cmpint (ret, ==, MANY_CALLOUTS_INSN_COUNT);
+  g_assert_cmpint (num_callouts, >=, MANY_CALLOUTS_INSN_COUNT);
+}
+
+static void
+add_callout_for_every_instruction (GumStalkerIterator * iterator,
+                                   GumStalkerOutput * output,
+                                   gpointer user_data)
+{
+  gint * num_callouts = user_data;
+
+  while (gum_stalker_iterator_next (iterator, NULL))
+  {
+    gum_stalker_iterator_put_callout (iterator, bump_num_callouts,
+        num_callouts, NULL);
+    gum_stalker_iterator_keep (iterator);
+  }
+}
+
+static void
+bump_num_callouts (GumCpuContext * cpu_context,
+                   gpointer user_data)
+{
+  gint * num_callouts = user_data;
+
+  (*num_callouts)++;
 }
 
 TESTCASE (unfollow_should_be_allowed_before_first_transform)


### PR DESCRIPTION
## Summary

When `putCallout()` is used on every instruction in a large branchless basic block (~1500+ instructions), each callout adds literal references to the code writer. The `gum_stalker_iterator_is_out_of_space()` check did not account for these pending literal pool bytes, allowing the pool to overflow past `slab_end` during flush and corrupt adjacent memory.

This manifests as SIGILL or SIGBUS crashes on ARM64 and ARM32 targets.

## Root Cause

In both ARM64 and ARM32 stalker backends, `is_out_of_space()` calculates remaining capacity as:

```c
capacity = slab_end - current_code_pointer;
return capacity < MIN_CAPACITY + snapshot_size;
```

But when the block is eventually flushed, `commit_literals()` writes the literal pool **at the current code pointer**, consuming `literal_refs.length * sizeof(guint64) + 4` bytes (ARM64) or `literal_refs.length * sizeof(guint32) + 4` bytes (ARM32). This space was never reserved, so with enough pending literals the pool overflows past `slab_end`.

## Fix

Include the pending literal pool size in the capacity check:

```c
pending_pool_size = cw->literal_refs.length * sizeof(guint64) + 4;
return capacity < MIN_CAPACITY + snapshot_size + pending_pool_size;
```

This causes blocks to split earlier when the literal pool grows large, preventing the overflow.

## Testing

Added regression tests for all affected architectures:
- **ARM64**: `many_callouts_should_not_overflow_literal_pool` — 1500 ADD instructions with a callout on every instruction
- **ARM32 (ARM mode)**: `arm_many_callouts_should_not_overflow_literal_pool`
- **ARM32 (Thumb mode)**: `thumb_many_callouts_should_not_overflow_literal_pool`

Verified locally on macOS ARM64:
- **Without fix**: test crashes with SIGILL (exit 132)
- **With fix**: test passes, all 46 Stalker tests pass with zero regressions

CI results on fork (armbe8 emulator confirms ARM32 fix works):
- native (linux-x86_64, linux-x86, windows-x86, windows-x86_64): ✅
- emulator (armbe8 — ARM32 BE, runs gum-tests in QEMU): ✅
- mobile (android-arm, android-arm64, android-x86, android-x86_64): ✅ (compile)
- manylinux (armhf, arm64, x86, x86_64): ✅

Closes https://github.com/frida/frida-gum/issues/1115
