### PR TITLE
darwin: pass NULL envp to arm64 initializers

### DIFF
--- a/gum/backend-darwin/gumdarwinmapper.c
+++ b/gum/backend-darwin/gumdarwinmapper.c
@@ -1871,7 +1871,7 @@ gum_emit_arm64_init_pointer_calls (const GumDarwinInitPointersDetails * details,
   /* init (argc, argv, envp, apple, result) */
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X0, ARM64_REG_XZR);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X1, ARM64_REG_X21);
-  gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X2, ARM64_REG_X21);
+  gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X2, ARM64_REG_XZR);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X3, ARM64_REG_X22);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X4, ARM64_REG_XZR);
   gum_arm64_writer_put_ldr_reg_reg_offset (aw, ARM64_REG_X5, ARM64_REG_X19, 0);
@@ -1902,7 +1902,7 @@ gum_emit_arm64_init_offset_calls (const GumDarwinInitOffsetsDetails * details,
   /* init (argc, argv, envp, apple, result) */
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X0, ARM64_REG_XZR);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X1, ARM64_REG_X21);
-  gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X2, ARM64_REG_X21);
+  gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X2, ARM64_REG_XZR);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X3, ARM64_REG_X22);
   gum_arm64_writer_put_mov_reg_reg (aw, ARM64_REG_X4, ARM64_REG_XZR);
   gum_arm64_writer_put_ldr_reg_address (aw, ARM64_REG_X5,


### PR DESCRIPTION
## Summary

This changes the Darwin arm64 mapper to pass `NULL` for `envp` when invoking Mach-O initializers, while keeping the existing empty `argv`, `apple`, and `result` handling unchanged.

## Details

The current arm64 mapper passes the same synthetic `empty_strv` pointer for both `argv` and `envp`. This means `envp` is non-NULL and points into mapper-owned runtime data.

Most initializers ignore this value, but initializer-triggered runtime/framework paths may propagate argument registers or reinterpret them across callback boundaries. In those cases, a non-NULL synthetic `envp` can be treated as an arbitrary pointer instead of an absent environment, which may cause crashes during early attach.

Passing `NULL` better represents the absence of an injected-process environment and avoids exposing mapper-owned storage through `envp`.

## Testing

- Built a local iOS arm64e server with this change.
- Repeatedly attached to a local iOS arm64e test target that previously failed during early initializer execution.
- Confirmed repeated attach success after the change, with no new crash reports for that target during the validation loop.