### PR TITLE
control-flow graph: Refine public naming

### DIFF
--- a/bindings/gumjs/gumquickcontrolflowgraph.c
+++ b/bindings/gumjs/gumquickcontrolflowgraph.c
@@ -41,11 +41,11 @@ GUMJS_DECLARE_FINALIZER (gumjs_control_flow_graph_finalize)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_entrypoint)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_entry_block)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_blocks)
-GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_block_containing)
+GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_find_block_containing)
 GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_dominates)
 GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_enumerate_dominating_sites)
 static gboolean gum_quick_collect_dominating_site (gconstpointer site,
-    gsize window, GumQuickDominatingSitesContext * dc);
+    gsize capacity, GumQuickDominatingSitesContext * dc);
 
 static JSValue gum_quick_basic_block_new (JSContext * ctx,
     GumQuickControlFlowGraph * parent, JSValue cfg,
@@ -71,8 +71,8 @@ static const JSCFunctionListEntry gumjs_control_flow_graph_entries[] =
   JS_CGETSET_DEF ("entrypoint", gumjs_control_flow_graph_get_entrypoint, NULL),
   JS_CGETSET_DEF ("entryBlock", gumjs_control_flow_graph_get_entry_block, NULL),
   JS_CGETSET_DEF ("blocks", gumjs_control_flow_graph_get_blocks, NULL),
-  JS_CFUNC_DEF ("blockContaining", 0,
-      gumjs_control_flow_graph_block_containing),
+  JS_CFUNC_DEF ("findBlockContaining", 0,
+      gumjs_control_flow_graph_find_block_containing),
   JS_CFUNC_DEF ("dominates", 0, gumjs_control_flow_graph_dominates),
   JS_CFUNC_DEF ("enumerateDominatingSites", 0,
       gumjs_control_flow_graph_enumerate_dominating_sites),
@@ -267,7 +267,7 @@ GUMJS_DEFINE_GETTER (gumjs_control_flow_graph_get_blocks)
   return result;
 }
 
-GUMJS_DEFINE_FUNCTION (gumjs_control_flow_graph_block_containing)
+GUMJS_DEFINE_FUNCTION (gumjs_control_flow_graph_find_block_containing)
 {
   GumQuickControlFlowGraph * parent;
   GumQuickControlFlowGraphValue * self;
@@ -282,7 +282,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_control_flow_graph_block_containing)
   if (!_gum_quick_args_parse (args, "p", &address))
     return JS_EXCEPTION;
 
-  index = gum_control_flow_graph_find_block (self->handle, address);
+  index = gum_control_flow_graph_find_block_containing (self->handle, address);
   if (index == GUM_CONTROL_FLOW_GRAPH_NO_BLOCK)
     return JS_NULL;
 
@@ -335,7 +335,7 @@ GUMJS_DEFINE_FUNCTION (gumjs_control_flow_graph_enumerate_dominating_sites)
 
 static gboolean
 gum_quick_collect_dominating_site (gconstpointer site,
-                                   gsize window,
+                                   gsize capacity,
                                    GumQuickDominatingSitesContext * dc)
 {
   JSContext * ctx = dc->ctx;
@@ -346,8 +346,8 @@ gum_quick_collect_dominating_site (gconstpointer site,
   JS_DefinePropertyValue (ctx, element, GUM_QUICK_CORE_ATOM (core, address),
       _gum_quick_native_pointer_new (ctx, (gpointer) site, core),
       JS_PROP_C_W_E);
-  JS_DefinePropertyValueStr (ctx, element, "window",
-      JS_NewInt64 (ctx, window), JS_PROP_C_W_E);
+  JS_DefinePropertyValueStr (ctx, element, "capacity",
+      JS_NewInt64 (ctx, capacity), JS_PROP_C_W_E);
 
   JS_DefinePropertyValueUint32 (ctx, dc->elements, dc->n++, element,
       JS_PROP_C_W_E);
@@ -543,7 +543,7 @@ GUMJS_DEFINE_GETTER (gumjs_basic_block_get_instructions)
   i = 0;
   for (address = start; address != end; )
   {
-    const cs_insn * insn = gum_control_flow_graph_find_instruction (
+    const cs_insn * insn = gum_control_flow_graph_find_instruction_containing (
         self->handle, GSIZE_TO_POINTER (address));
 
     JS_DefinePropertyValueUint32 (ctx, result, i++,

--- a/bindings/gumjs/gumv8controlflowgraph.cpp
+++ b/bindings/gumjs/gumv8controlflowgraph.cpp
@@ -45,11 +45,11 @@ GUMJS_DECLARE_CONSTRUCTOR (gumjs_control_flow_graph_construct)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_entrypoint)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_entry_block)
 GUMJS_DECLARE_GETTER (gumjs_control_flow_graph_get_blocks)
-GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_block_containing)
+GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_find_block_containing)
 GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_dominates)
 GUMJS_DECLARE_FUNCTION (gumjs_control_flow_graph_enumerate_dominating_sites)
 static gboolean gum_v8_collect_dominating_site (gconstpointer site,
-    gsize window, GumV8DominatingSitesContext * dc);
+    gsize capacity, GumV8DominatingSitesContext * dc);
 static GumV8ControlFlowGraphValue * gum_v8_control_flow_graph_value_new (
     Local<Object> wrapper, GumControlFlowGraph * handle,
     gconstpointer entrypoint, GumV8ControlFlowGraph * module);
@@ -81,7 +81,7 @@ static const GumV8Property gumjs_control_flow_graph_values[] =
 
 static const GumV8Function gumjs_control_flow_graph_functions[] =
 {
-  { "blockContaining", gumjs_control_flow_graph_block_containing },
+  { "findBlockContaining", gumjs_control_flow_graph_find_block_containing },
   { "dominates", gumjs_control_flow_graph_dominates },
   { "enumerateDominatingSites",
       gumjs_control_flow_graph_enumerate_dominating_sites },
@@ -227,14 +227,15 @@ GUMJS_DEFINE_CLASS_GETTER (gumjs_control_flow_graph_get_blocks,
   info.GetReturnValue ().Set (result);
 }
 
-GUMJS_DEFINE_CLASS_METHOD (gumjs_control_flow_graph_block_containing,
+GUMJS_DEFINE_CLASS_METHOD (gumjs_control_flow_graph_find_block_containing,
                            GumV8ControlFlowGraphValue)
 {
   gpointer address;
   if (!_gum_v8_args_parse (args, "p", &address))
     return;
 
-  guint index = gum_control_flow_graph_find_block (self->handle, address);
+  guint index =
+      gum_control_flow_graph_find_block_containing (self->handle, address);
   if (index == GUM_CONTROL_FLOW_GRAPH_NO_BLOCK)
   {
     info.GetReturnValue ().SetNull ();
@@ -276,7 +277,7 @@ GUMJS_DEFINE_CLASS_METHOD (gumjs_control_flow_graph_enumerate_dominating_sites,
 
 static gboolean
 gum_v8_collect_dominating_site (gconstpointer site,
-                                gsize window,
+                                gsize capacity,
                                 GumV8DominatingSitesContext * dc)
 {
   auto core = dc->module->core;
@@ -285,7 +286,7 @@ gum_v8_collect_dominating_site (gconstpointer site,
 
   auto element = Object::New (isolate);
   _gum_v8_object_set_pointer (element, "address", (gpointer) site, core);
-  _gum_v8_object_set_uint (element, "window", window, core);
+  _gum_v8_object_set_uint (element, "capacity", capacity, core);
 
   dc->elements->Set (context, dc->n++, element).Check ();
 
@@ -419,8 +420,8 @@ GUMJS_DEFINE_CLASS_GETTER (gumjs_basic_block_get_instructions,
   guint i = 0;
   for (GumAddress address = start; address != end; )
   {
-    auto insn = gum_control_flow_graph_find_instruction (self->handle,
-        GSIZE_TO_POINTER (address));
+    auto insn = gum_control_flow_graph_find_instruction_containing (
+        self->handle, GSIZE_TO_POINTER (address));
 
     result->Set (context, i++,
         _gum_v8_instruction_new (module->instruction->capstone, insn, FALSE,

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -437,7 +437,7 @@ static gboolean gum_linux_find_start_impl (GumLinuxPThreadSpec * spec);
 #if defined (HAVE_I386)
 static gpointer gum_linux_find_dominating_start_hook (gpointer call_site);
 static gboolean gum_linux_try_use_dominating_site (gconstpointer site,
-    gsize window, gpointer user_data);
+    gsize capacity, gpointer user_data);
 #endif
 static gboolean gum_linux_is_call (cs_insn * insn);
 static gboolean gum_linux_create_thread (GumLinuxThreadCtx * ctx,
@@ -3787,7 +3787,7 @@ gum_linux_find_dominating_start_hook (gpointer call_site)
 
 static gboolean
 gum_linux_try_use_dominating_site (gconstpointer site,
-                                   gsize window,
+                                   gsize capacity,
                                    gpointer user_data)
 {
   GumDominatingHookSite * ctx = user_data;
@@ -3795,14 +3795,14 @@ gum_linux_try_use_dominating_site (gconstpointer site,
   const cs_detail * detail;
   uint8_t i;
 
-  if (window < GUM_START_HOOK_REDIRECT_SIZE)
+  if (capacity < GUM_START_HOOK_REDIRECT_SIZE)
     return TRUE;
 
   if ((const guint8 *) site + GUM_START_HOOK_REDIRECT_SIZE >
       (const guint8 *) ctx->call_site)
     return TRUE;
 
-  insn = gum_control_flow_graph_find_instruction (ctx->cfg, site);
+  insn = gum_control_flow_graph_find_instruction_containing (ctx->cfg, site);
   detail = insn->detail;
   for (i = 0; i != detail->groups_count; i++)
   {

--- a/gum/gumcontrolflowgraph.c
+++ b/gum/gumcontrolflowgraph.c
@@ -265,10 +265,10 @@ gum_control_flow_graph_enumerate_dominating_sites (
     for (i = boundaries->len; i != 0; i--)
     {
       GumAddress site = g_array_index (boundaries, GumAddress, i - 1);
-      gsize window =
+      gsize capacity =
           gum_control_flow_graph_next_branch_target (self, site) - site;
 
-      if (!func (GSIZE_TO_POINTER (site), window, user_data))
+      if (!func (GSIZE_TO_POINTER (site), capacity, user_data))
       {
         g_array_free (boundaries, TRUE);
         return;
@@ -300,7 +300,7 @@ gum_control_flow_graph_get_entry_block (GumControlFlowGraph * self)
 }
 
 guint
-gum_control_flow_graph_find_block (GumControlFlowGraph * self,
+gum_control_flow_graph_find_block_containing (GumControlFlowGraph * self,
                                    gconstpointer address)
 {
   return gum_control_flow_graph_block_index_for_address (self,
@@ -359,7 +359,7 @@ gum_control_flow_graph_get_block_predecessors (GumControlFlowGraph * self,
 }
 
 const cs_insn *
-gum_control_flow_graph_find_instruction (GumControlFlowGraph * self,
+gum_control_flow_graph_find_instruction_containing (GumControlFlowGraph * self,
                                          gconstpointer address)
 {
   const GumControlFlowGraphInsn * insn =

--- a/gum/gumcontrolflowgraph.h
+++ b/gum/gumcontrolflowgraph.h
@@ -37,7 +37,7 @@ typedef gboolean (* GumControlFlowGraphFindRangeFunc) (gconstpointer address,
 /**
  * GumFoundDominatingSiteFunc:
  * @site: instruction-aligned address that dominates the target
- * @window: number of contiguous bytes at @site with no incoming branch and
+ * @capacity: number of contiguous bytes at @site with no incoming branch and
  *          within a single range — how much may be overwritten by a redirect
  *          without another control-flow edge landing inside it
  * @user_data: data passed to the dominating-site enumerator
@@ -45,7 +45,7 @@ typedef gboolean (* GumControlFlowGraphFindRangeFunc) (gconstpointer address,
  * Returns: %TRUE to keep enumerating, %FALSE to stop
  */
 typedef gboolean (* GumFoundDominatingSiteFunc) (gconstpointer site,
-    gsize window, gpointer user_data);
+    gsize capacity, gpointer user_data);
 
 GUM_API GumControlFlowGraph * gum_control_flow_graph_new (gconstpointer entry,
     cs_arch arch, cs_mode mode, GumControlFlowGraphFindRangeFunc find_range,
@@ -70,8 +70,8 @@ GUM_API guint gum_control_flow_graph_get_num_blocks (
     GumControlFlowGraph * self);
 GUM_API guint gum_control_flow_graph_get_entry_block (
     GumControlFlowGraph * self);
-GUM_API guint gum_control_flow_graph_find_block (GumControlFlowGraph * self,
-    gconstpointer address);
+GUM_API guint gum_control_flow_graph_find_block_containing (
+    GumControlFlowGraph * self, gconstpointer address);
 GUM_API void gum_control_flow_graph_get_block_bounds (
     GumControlFlowGraph * self, guint index, GumAddress * start,
     GumAddress * end);
@@ -82,7 +82,7 @@ GUM_API guint gum_control_flow_graph_get_block_successors (
 GUM_API guint gum_control_flow_graph_get_block_predecessors (
     GumControlFlowGraph * self, guint index, const guint ** predecessors);
 
-GUM_API const cs_insn * gum_control_flow_graph_find_instruction (
+GUM_API const cs_insn * gum_control_flow_graph_find_instruction_containing (
     GumControlFlowGraph * self, gconstpointer address);
 
 G_END_DECLS

--- a/tests/core/controlflowgraph.c
+++ b/tests/core/controlflowgraph.c
@@ -32,13 +32,13 @@ struct _GumTestCode
 struct _GumCollectedSites
 {
   gconstpointer sites[16];
-  gsize windows[16];
+  gsize capacities[16];
   guint n;
 };
 
 static gboolean gum_test_find_range (gconstpointer address,
     GumMemoryRange * range, gpointer user_data);
-static gboolean gum_test_collect_site (gconstpointer site, gsize window,
+static gboolean gum_test_collect_site (gconstpointer site, gsize capacity,
     gpointer user_data);
 
 /*
@@ -79,9 +79,9 @@ TESTCASE (single_range_dominators_and_sites)
       gum_test_collect_site, &sites);
 
   g_assert_cmpuint (sites.n, ==, 3);
-  g_assert_true (sites.sites[0] == code + 0x09 && sites.windows[0] == 3);
-  g_assert_true (sites.sites[1] == code + 0x03 && sites.windows[1] == 6);
-  g_assert_true (sites.sites[2] == code + 0x00 && sites.windows[2] == 9);
+  g_assert_true (sites.sites[0] == code + 0x09 && sites.capacities[0] == 3);
+  g_assert_true (sites.sites[1] == code + 0x03 && sites.capacities[1] == 6);
+  g_assert_true (sites.sites[2] == code + 0x00 && sites.capacities[2] == 9);
 
   gum_control_flow_graph_free (cfg);
 }
@@ -173,13 +173,13 @@ gum_test_find_range (gconstpointer address,
 
 static gboolean
 gum_test_collect_site (gconstpointer site,
-                       gsize window,
+                       gsize capacity,
                        gpointer user_data)
 {
   GumCollectedSites * collected = user_data;
 
   collected->sites[collected->n] = site;
-  collected->windows[collected->n] = window;
+  collected->capacities[collected->n] = capacity;
   collected->n++;
 
   return TRUE;

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -8202,7 +8202,7 @@ TESTCASE (cfg_can_be_built)
       "const entry = cfg.entryBlock;"
       "send(entry !== null);"
       "send(cfg.blocks.length > 0);"
-      "send(cfg.blockContaining(entry.start).start.equals(entry.start));"
+      "send(cfg.findBlockContaining(entry.start).start.equals(entry.start));"
       "send(cfg.dominates(entry.start, entry.start));"
       "const insns = entry.instructions;"
       "send(insns.length > 0);"
@@ -8228,7 +8228,7 @@ TESTCASE (cfg_dominating_sites_can_be_enumerated)
       "const sites = cfg.enumerateDominatingSites(entry.start);"
       "send(sites.length > 0);"
       "send(sites[0].address.equals(entry.start));"
-      "send(typeof sites[0].window === 'number');",
+      "send(typeof sites[0].capacity === 'number');",
       gum_get_answer_to_life_universe_and_everything);
   EXPECT_SEND_MESSAGE_WITH ("true");
   EXPECT_SEND_MESSAGE_WITH ("true");


### PR DESCRIPTION
Follow-up naming cleanup for the recently-landed control-flow graph API,
before any of it ships in a release.

- Rename the block/instruction lookups to `find_block_containing()` and
  `find_instruction_containing()`, and the JS `blockContaining()` to
  `findBlockContaining()`, matching the `find*` convention used for
  nullable lookups elsewhere in the API.
- Rename the dominating-site `window` to `capacity`, aligning with the
  existing `GumRedirectWriteDetails` terminology for how many bytes a
  redirect may occupy.

No released API is affected. All gum tests pass locally (QJS + V8 + core).