### PR TITLE
Add script cancellation support

### DIFF
--- a/bindings/gumjs/gumquickscript-priv.h
+++ b/bindings/gumjs/gumquickscript-priv.h
@@ -24,6 +24,9 @@ G_GNUC_INTERNAL void _gum_quick_worker_terminate (GumQuickWorker * self);
 G_GNUC_INTERNAL void _gum_quick_worker_post (GumQuickWorker * self,
     const gchar * message, GBytes * data);
 
+G_GNUC_INTERNAL void _gum_quick_script_dispose_cancelled_script (
+    GumQuickScript * self);
+
 G_GNUC_INTERNAL JSValue _gum_quick_script_rethrow_parse_error_with_decorations (
     GumQuickScript * self, JSContext * ctx, const gchar * name);
 

--- a/bindings/gumjs/gumquickscript.c
+++ b/bindings/gumjs/gumquickscript.c
@@ -56,6 +56,8 @@ struct _GumQuickScript
   GumQuickScriptBackend * backend;
 
   GumScriptState state;
+  GRecMutex cancellation_mutex;
+  gboolean is_cancelled;
   GSList * on_unload;
   JSRuntime * rt;
   JSContext * ctx;
@@ -242,6 +244,12 @@ static void gum_quick_script_complete_unload_task (GumQuickScript * self,
 static void gum_quick_script_try_unload (GumQuickScript * self);
 static void gum_quick_script_once_unloaded (GumQuickScript * self,
     GumUnloadNotifyFunc func, gpointer data, GDestroyNotify data_destroy);
+static void gum_quick_script_cancel (GumScript * script);
+
+static int gum_cancellable_interrupt_handler (JSRuntime * runtime,
+    void * opaque);
+static void gum_quick_register_interrupt_handler (GumQuickScript * script);
+static void gum_quick_remove_interrupt_handler (GumQuickScript * script);
 
 static void gum_quick_script_set_message_handler (GumScript * script,
     GumScriptMessageHandler handler, gpointer data,
@@ -327,6 +335,7 @@ gum_quick_script_iface_init (gpointer g_iface,
   iface->unload = gum_quick_script_unload;
   iface->unload_finish = gum_quick_script_unload_finish;
   iface->unload_sync = gum_quick_script_unload_sync;
+  iface->cancel = gum_quick_script_cancel;
 
   iface->set_message_handler = gum_quick_script_set_message_handler;
   iface->post = gum_quick_script_post;
@@ -354,6 +363,7 @@ gum_quick_script_dispose (GObject * object)
 
   gum_quick_script_set_message_handler (script, NULL, NULL, NULL);
 
+  g_rec_mutex_lock (&self->cancellation_mutex);
   if (self->state == GUM_SCRIPT_STATE_LOADED)
   {
     /* dispose() will be triggered again at the end of unload() */
@@ -367,6 +377,7 @@ gum_quick_script_dispose (GObject * object)
     g_clear_pointer (&self->main_context, g_main_context_unref);
     g_clear_pointer (&self->backend, g_object_unref);
   }
+  g_rec_mutex_unlock (&self->cancellation_mutex);
 
   G_OBJECT_CLASS (gum_quick_script_parent_class)->dispose (object);
 }
@@ -375,6 +386,8 @@ static void
 gum_quick_script_finalize (GObject * object)
 {
   GumQuickScript * self = GUM_QUICK_SCRIPT (object);
+
+  g_rec_mutex_clear (&self->cancellation_mutex);
 
   g_free (self->name);
   g_free (self->source);
@@ -533,6 +546,10 @@ gum_quick_script_create_context (GumQuickScript * self,
   g_bytes_unref (self->bytecode);
   self->bytecode = NULL;
 
+  g_rec_mutex_init (&self->cancellation_mutex);
+  self->is_cancelled = FALSE;
+  gum_quick_register_interrupt_handler (self);
+
   return TRUE;
 
 malformed_program:
@@ -597,6 +614,12 @@ gum_quick_script_destroy_context (GumQuickScript * self)
 
     JS_FreeContext (self->ctx);
     self->ctx = NULL;
+
+    gum_quick_remove_interrupt_handler (self);
+    self->is_cancelled = FALSE;
+    /* NOTE: cancellation_mutex is NOT cleared here.
+     * dispose() locks it after destroy_context runs (via unload),
+     * so it must remain valid until finalize(). */
 
     JS_FreeRuntime (self->rt);
     self->rt = NULL;
@@ -804,7 +827,27 @@ gum_quick_script_execute_entrypoints (GumQuickScript * self,
 
       result = JS_EvalFunction (ctx, g_array_index (entrypoints, JSValue, i));
       if (JS_IsException (result))
+      {
+        JSValue exception;
+        const char * error_str;
+
+        exception = JS_GetException (ctx);
+        error_str = JS_ToCString (ctx, exception);
+
+        if (error_str != NULL &&
+            strstr (error_str, "InternalError: interrupted") != NULL)
+        {
+          JS_FreeCString (ctx, error_str);
+          JS_FreeValue (ctx, exception);
+          JS_FreeValue (ctx, result);
+          break;
+        }
+
+        JS_FreeCString (ctx, error_str);
+        JS_Throw (ctx, exception);
+
         _gum_quick_scope_catch_and_emit (&scope);
+      }
 
       JS_FreeValue (ctx, result);
     }
@@ -895,6 +938,11 @@ gum_quick_script_complete_load_task (GumScriptTask * task)
 
   gum_script_task_return_pointer (task, NULL, NULL);
 
+  g_rec_mutex_lock (&self->cancellation_mutex);
+  if (self->is_cancelled)
+    _gum_quick_script_dispose_cancelled_script (self);
+  g_rec_mutex_unlock (&self->cancellation_mutex);
+
   g_object_unref (self);
 
   return G_SOURCE_REMOVE;
@@ -944,8 +992,13 @@ gum_quick_script_do_unload (GumScriptTask * task,
                             gpointer task_data,
                             GCancellable * cancellable)
 {
+  g_rec_mutex_lock (&self->cancellation_mutex);
   if (self->state != GUM_SCRIPT_STATE_LOADED)
+  {
+    g_rec_mutex_unlock (&self->cancellation_mutex);
     goto invalid_operation;
+  }
+  g_rec_mutex_unlock (&self->cancellation_mutex);
 
   self->state = GUM_SCRIPT_STATE_UNLOADING;
   gum_quick_script_once_unloaded (self,
@@ -1031,6 +1084,65 @@ gum_quick_script_once_unloaded (GumQuickScript * self,
   callback->data_destroy = data_destroy;
 
   self->on_unload = g_slist_append (self->on_unload, callback);
+}
+
+static void
+gum_quick_script_cancel (GumScript * script)
+{
+  GumQuickScript * self = GUM_QUICK_SCRIPT (script);
+
+  g_rec_mutex_lock (&self->cancellation_mutex);
+  self->is_cancelled = TRUE;
+  g_rec_mutex_unlock (&self->cancellation_mutex);
+}
+
+void
+_gum_quick_script_dispose_cancelled_script (GumQuickScript * self)
+{
+  g_rec_mutex_lock (&self->cancellation_mutex);
+  if (self->is_cancelled)
+    gum_quick_script_dispose ((GObject *) self);
+  g_rec_mutex_unlock (&self->cancellation_mutex);
+}
+
+static int
+gum_cancellable_interrupt_handler (JSRuntime * runtime,
+                                   void * opaque)
+{
+  GumQuickScript * script;
+  int rc = 0;
+
+  if (opaque == NULL)
+    return 0;
+
+  script = (GumQuickScript *) opaque;
+  g_object_ref (script);
+
+  g_rec_mutex_lock (&script->cancellation_mutex);
+  if (script->is_cancelled)
+    rc = 1;
+  g_rec_mutex_unlock (&script->cancellation_mutex);
+
+  g_object_unref (script);
+
+  return rc;
+}
+
+static void
+gum_quick_register_interrupt_handler (GumQuickScript * script)
+{
+  g_rec_mutex_lock (&script->cancellation_mutex);
+  g_assert (script->is_cancelled == FALSE);
+  g_rec_mutex_unlock (&script->cancellation_mutex);
+
+  JS_SetInterruptHandler (script->rt, gum_cancellable_interrupt_handler,
+      script);
+}
+
+static void
+gum_quick_remove_interrupt_handler (GumQuickScript * script)
+{
+  JS_SetInterruptHandler (script->rt, NULL, NULL);
 }
 
 static void

--- a/bindings/gumjs/gumscript.c
+++ b/bindings/gumjs/gumscript.c
@@ -60,6 +60,12 @@ gum_script_unload_sync (GumScript * self,
 }
 
 void
+gum_script_cancel (GumScript * self)
+{
+  GUM_SCRIPT_GET_IFACE (self)->cancel (self);
+}
+
+void
 gum_script_set_message_handler (GumScript * self,
                                 GumScriptMessageHandler handler,
                                 gpointer data,

--- a/bindings/gumjs/gumscript.h
+++ b/bindings/gumjs/gumscript.h
@@ -33,6 +33,7 @@ struct _GumScriptInterface
       GAsyncReadyCallback callback, gpointer user_data);
   void (* unload_finish) (GumScript * self, GAsyncResult * result);
   void (* unload_sync) (GumScript * self, GCancellable * cancellable);
+  void (* cancel) (GumScript * self);
 
   void (* set_message_handler) (GumScript * self,
       GumScriptMessageHandler handler, gpointer data,
@@ -57,6 +58,7 @@ GUM_API void gum_script_unload (GumScript * self, GCancellable * cancellable,
 GUM_API void gum_script_unload_finish (GumScript * self, GAsyncResult * result);
 GUM_API void gum_script_unload_sync (GumScript * self,
     GCancellable * cancellable);
+GUM_API void gum_script_cancel (GumScript * self);
 
 GUM_API void gum_script_set_message_handler (GumScript * self,
     GumScriptMessageHandler handler, gpointer data,

--- a/bindings/gumjs/gumv8script-priv.h
+++ b/bindings/gumjs/gumv8script-priv.h
@@ -78,6 +78,8 @@ struct _GumV8Script
   GumV8ScriptBackend * backend;
 
   GumScriptState state;
+  GRecMutex cancellation_mutex;
+  gboolean is_cancelled;
   GSList * on_unload;
   v8::Isolate * isolate;
   GumV8Core core;

--- a/bindings/gumjs/gumv8script.cpp
+++ b/bindings/gumjs/gumv8script.cpp
@@ -182,6 +182,7 @@ static void gum_v8_script_complete_unload_task (GumV8Script * self,
 static void gum_v8_script_try_unload (GumV8Script * self);
 static void gum_v8_script_once_unloaded (GumV8Script * self,
     GumUnloadNotifyFunc func, gpointer data, GDestroyNotify data_destroy);
+static void gum_v8_script_cancel (GumScript * script);
 
 static void gum_v8_script_set_message_handler (GumScript * script,
     GumScriptMessageHandler handler, gpointer data,
@@ -309,6 +310,7 @@ gum_v8_script_iface_init (gpointer g_iface,
   iface->unload = gum_v8_script_unload;
   iface->unload_finish = gum_v8_script_unload_finish;
   iface->unload_sync = gum_v8_script_unload_sync;
+  iface->cancel = gum_v8_script_cancel;
 
   iface->set_message_handler = gum_v8_script_set_message_handler;
   iface->post = gum_v8_script_post;
@@ -377,6 +379,7 @@ gum_v8_script_dispose (GObject * object)
 
   gum_v8_script_set_message_handler (script, NULL, NULL, NULL);
 
+  g_rec_mutex_lock (&self->cancellation_mutex);
   if (self->state == GUM_SCRIPT_STATE_LOADED)
   {
     /* dispose() will be triggered again at the end of unload() */
@@ -428,6 +431,7 @@ gum_v8_script_dispose (GObject * object)
     g_clear_pointer (&self->main_context, g_main_context_unref);
     g_clear_pointer (&self->backend, g_object_unref);
   }
+  g_rec_mutex_unlock (&self->cancellation_mutex);
 
   G_OBJECT_CLASS (gum_v8_script_parent_class)->dispose (object);
 }
@@ -436,6 +440,8 @@ static void
 gum_v8_script_finalize (GObject * object)
 {
   auto self = GUM_V8_SCRIPT (object);
+
+  g_rec_mutex_clear (&self->cancellation_mutex);
 
   g_cond_clear (&self->inspector_cond);
   g_mutex_clear (&self->inspector_mutex);
@@ -622,6 +628,9 @@ gum_v8_script_create_context (GumV8Script * self,
 
   g_free (self->source);
   self->source = NULL;
+
+  g_rec_mutex_init (&self->cancellation_mutex);
+  self->is_cancelled = FALSE;
 
   return TRUE;
 }
@@ -1180,6 +1189,11 @@ gum_v8_script_destroy_context (GumV8Script * self)
   delete self->context;
   self->context = nullptr;
 
+  self->is_cancelled = FALSE;
+  /* NOTE: cancellation_mutex is NOT cleared here.
+   * dispose() locks it after destroy_context runs (via unload),
+   * so it must remain valid until finalize(). */
+
   _gum_v8_profiler_finalize (&self->profiler);
   _gum_v8_sampler_finalize (&self->sampler);
   _gum_v8_cloak_finalize (&self->cloak);
@@ -1354,7 +1368,7 @@ gum_v8_script_execute_entrypoints (GumV8Script * self,
         auto result = code->Run (context);
         _gum_v8_ignore_result (result);
 
-        if (trycatch.HasCaught ())
+        if (trycatch.HasCaught () && !trycatch.HasTerminated ())
         {
           auto exception = trycatch.Exception ();
           trycatch.Reset ();
@@ -1427,6 +1441,11 @@ gum_v8_script_complete_load_task (GumScriptTask * task)
 
   gum_script_task_return_pointer (task, NULL, NULL);
 
+  g_rec_mutex_lock (&self->cancellation_mutex);
+  if (self->is_cancelled)
+    gum_v8_script_dispose ((GObject *) self);
+  g_rec_mutex_unlock (&self->cancellation_mutex);
+
   g_object_unref (self);
 
   return G_SOURCE_REMOVE;
@@ -1474,8 +1493,13 @@ gum_v8_script_do_unload (GumScriptTask * task,
                          gpointer task_data,
                          GCancellable * cancellable)
 {
+  g_rec_mutex_lock (&self->cancellation_mutex);
   if (self->state != GUM_SCRIPT_STATE_LOADED)
+  {
+    g_rec_mutex_unlock (&self->cancellation_mutex);
     goto invalid_operation;
+  }
+  g_rec_mutex_unlock (&self->cancellation_mutex);
 
   self->state = GUM_SCRIPT_STATE_UNLOADING;
   gum_v8_script_once_unloaded (self,
@@ -1558,6 +1582,19 @@ gum_v8_script_once_unloaded (GumV8Script * self,
   callback->data_destroy = data_destroy;
 
   self->on_unload = g_slist_append (self->on_unload, callback);
+}
+
+static void
+gum_v8_script_cancel (GumScript * script)
+{
+  auto self = GUM_V8_SCRIPT (script);
+
+  g_rec_mutex_lock (&self->cancellation_mutex);
+  self->is_cancelled = TRUE;
+  g_rec_mutex_unlock (&self->cancellation_mutex);
+
+  if (self->isolate != NULL)
+    self->isolate->TerminateExecution ();
 }
 
 static void

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -547,6 +547,10 @@ TESTLIST_BEGIN (script)
   TESTENTRY (exceptions_can_be_handled)
   TESTENTRY (debugger_can_be_enabled)
   TESTENTRY (cloaked_items_can_be_queried_added_and_removed)
+
+  TESTENTRY (script_can_be_cancelled)
+  TESTENTRY (script_cancel_is_idempotent)
+  TESTENTRY (script_cancel_during_load_should_auto_dispose)
 TESTLIST_END ()
 
 typedef int (* TargetFunctionInt) (int arg);
@@ -12632,4 +12636,74 @@ target_function_variable_sleepyness (guint n)
   gum_script_dummy_global_to_trick_optimizer += n;
 
   g_usleep (n);
+}
+
+TESTCASE (script_can_be_cancelled)
+{
+  COMPILE_AND_LOAD_SCRIPT ("send('hello');");
+  EXPECT_SEND_MESSAGE_WITH ("\"hello\"");
+  EXPECT_NO_MESSAGES ();
+
+  gum_script_cancel (fixture->script);
+
+  gum_script_unload_sync (fixture->script, NULL);
+  g_object_unref (fixture->script);
+  fixture->script = NULL;
+}
+
+TESTCASE (script_cancel_is_idempotent)
+{
+  COMPILE_AND_LOAD_SCRIPT ("send('hello');");
+  EXPECT_SEND_MESSAGE_WITH ("\"hello\"");
+  EXPECT_NO_MESSAGES ();
+
+  gum_script_cancel (fixture->script);
+  gum_script_cancel (fixture->script);
+
+  gum_script_unload_sync (fixture->script, NULL);
+  g_object_unref (fixture->script);
+  fixture->script = NULL;
+}
+
+static gpointer
+load_script_worker (gpointer data)
+{
+  GumScript * script = (GumScript *) data;
+
+  gum_script_load_sync (script, NULL);
+
+  return NULL;
+}
+
+TESTCASE (script_cancel_during_load_should_auto_dispose)
+{
+  GError * err = NULL;
+  GumScript * script;
+  GThread * worker;
+
+  /* Create a script with an infinite loop that can only exit via cancel. */
+  script = gum_script_backend_create_sync (fixture->backend, "testcase",
+      "while (true) {}",
+      NULL, NULL, &err);
+  g_assert_nonnull (script);
+  g_assert_null (err);
+
+  gum_script_set_message_handler (script,
+      test_script_fixture_store_message, fixture, NULL);
+
+  /* Start loading (and executing) on a worker thread — this blocks in the
+   * infinite loop until we interrupt it. */
+  worker = g_thread_new ("cancel-test-loader", load_script_worker, script);
+
+  /* Give the JS thread time to enter the loop. */
+  g_usleep (G_USEC_PER_SEC / 10);
+
+  /* Cancel from this thread — interrupts execution and triggers auto-dispose
+   * once the load task completes. */
+  gum_script_cancel (script);
+
+  /* Worker must return, proving the infinite loop was interrupted. */
+  g_thread_join (worker);
+
+  g_object_unref (script);
 }


### PR DESCRIPTION
Add `gum_script_cancel()` API that allows graceful termination of a running script from another thread.

**Implementation details:**

- **QuickJS:** Uses the engine's interrupt handler (`JS_SetInterruptHandler()`) to poll a per-script cancellation flag (`is_cancelled`) protected by a recursive mutex.
- **V8:** We use `Isolate::TerminateExecution()` directly and skip exceptions via a try-catch block.

**Key changes summary:**
- Add cancel vfunc to `GumScriptInterface`
- Protect dispose/unload state transitions with a per-script `GRecMutex`
- Move `cancellation_mutex` cleanup from `destroy_context()` to `finalize()` to prevent use-after-clear during dispose
- Auto-dispose the script if cancelled during load
- Handle interrupted/terminated exceptions in entrypoint execution
- Include 3 unit tests (run both on QJS and V8)

**Limitations:**

Only interrupts JavaScript execution. If a script is blocked in native code (e.g., a `NativeFunction` call or a blocking syscall), cancellation will take effect once control returns to the JS engine.

----

To quickly test only the added unit tests, do the following:
**QJS:**
```
> build/tests/gum-tests -p '/GumJS/Script/script_can_be_cancelled#QJS' -p '/GumJS/Script/script_cancel_is_idempotent#QJS' -p '/GumJS/Script/script_cancel_during_load_should_auto_dispose#QJS'
```

**V8:**
```
> build/tests/gum-tests -p '/GumJS/Script/script_can_be_cancelled#V8' -p '/GumJS/Script/script_cancel_is_idempotent#V8' -p '/GumJS/Script/script_cancel_during_load_should_auto_dispose#V8'
```