### PR TITLE
Add Process.findThreadById()

### DIFF
--- a/bindings/gumjs/gumquickprocess.c
+++ b/bindings/gumjs/gumquickprocess.c
@@ -118,6 +118,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_process_get_home_dir)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_tmp_dir)
 GUMJS_DECLARE_FUNCTION (gumjs_process_is_debugger_attached)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_current_thread_id)
+GUMJS_DECLARE_FUNCTION (gumjs_process_find_thread_by_id)
 GUMJS_DECLARE_FUNCTION (gumjs_process_enumerate_threads)
 static gboolean gum_collect_thread (const GumThreadDetails * details,
     GPtrArray * threads);
@@ -203,6 +204,7 @@ static const JSCFunctionListEntry gumjs_process_entries[] =
   JS_CFUNC_DEF ("getTmpDir", 0, gumjs_process_get_tmp_dir),
   JS_CFUNC_DEF ("isDebuggerAttached", 0, gumjs_process_is_debugger_attached),
   JS_CFUNC_DEF ("getCurrentThreadId", 0, gumjs_process_get_current_thread_id),
+  JS_CFUNC_DEF ("findThreadById", 0, gumjs_process_find_thread_by_id),
   JS_CFUNC_DEF ("enumerateThreads", 0, gumjs_process_enumerate_threads),
   JS_CFUNC_DEF ("attachThreadObserver", 0,
       gumjs_process_attach_thread_observer),
@@ -398,6 +400,33 @@ GUMJS_DEFINE_FUNCTION (gumjs_process_is_debugger_attached)
 GUMJS_DEFINE_FUNCTION (gumjs_process_get_current_thread_id)
 {
   return JS_NewInt64 (ctx, gum_process_get_current_thread_id ());
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_process_find_thread_by_id)
+{
+  GumThreadId thread_id;
+  GumQuickScope scope = GUM_QUICK_SCOPE_INIT (core);
+  GumThreadDetails * details;
+  JSValue result;
+
+  if (!_gum_quick_args_parse (args, "Z", &thread_id))
+    return JS_EXCEPTION;
+
+  _gum_quick_scope_suspend (&scope);
+
+  details = gum_process_find_thread_by_id (thread_id, GUM_THREAD_FLAGS_ALL);
+
+  _gum_quick_scope_resume (&scope);
+
+  if (details == NULL)
+    return JS_NULL;
+
+  result = _gum_quick_thread_new (ctx, details,
+      gumjs_get_parent_module (core)->thread);
+
+  gum_thread_details_free (details);
+
+  return result;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_process_enumerate_threads)

--- a/bindings/gumjs/gumv8process.cpp
+++ b/bindings/gumjs/gumv8process.cpp
@@ -108,6 +108,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_process_get_home_dir)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_tmp_dir)
 GUMJS_DECLARE_FUNCTION (gumjs_process_is_debugger_attached)
 GUMJS_DECLARE_FUNCTION (gumjs_process_get_current_thread_id)
+GUMJS_DECLARE_FUNCTION (gumjs_process_find_thread_by_id)
 GUMJS_DECLARE_FUNCTION (gumjs_process_enumerate_threads)
 static gboolean gum_collect_thread (const GumThreadDetails * details,
     GPtrArray * threads);
@@ -188,6 +189,7 @@ static const GumV8Function gumjs_process_functions[] =
   { "getTmpDir", gumjs_process_get_tmp_dir },
   { "isDebuggerAttached", gumjs_process_is_debugger_attached },
   { "getCurrentThreadId", gumjs_process_get_current_thread_id },
+  { "findThreadById", gumjs_process_find_thread_by_id },
   { "enumerateThreads", gumjs_process_enumerate_threads },
   { "attachThreadObserver", gumjs_process_attach_thread_observer },
   { "_runOnThread", gumjs_process_run_on_thread },
@@ -389,6 +391,30 @@ GUMJS_DEFINE_FUNCTION (gumjs_process_is_debugger_attached)
 GUMJS_DEFINE_FUNCTION (gumjs_process_get_current_thread_id)
 {
   info.GetReturnValue ().Set ((uint32_t) gum_process_get_current_thread_id ());
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_process_find_thread_by_id)
+{
+  GumThreadId thread_id;
+  if (!_gum_v8_args_parse (args, "Z", &thread_id))
+    return;
+
+  GumThreadDetails * details;
+  {
+    ScriptUnlocker unlocker (core);
+
+    details = gum_process_find_thread_by_id (thread_id, GUM_THREAD_FLAGS_ALL);
+  }
+
+  if (details == NULL)
+  {
+    info.GetReturnValue ().SetNull ();
+    return;
+  }
+
+  info.GetReturnValue ().Set (_gum_v8_thread_new (details, module->thread));
+
+  gum_thread_details_free (details);
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_process_enumerate_threads)

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -334,6 +334,15 @@ Object.defineProperties(Process, {
       return range;
     }
   },
+  getFunctionRange: {
+    enumerable: true,
+    value: function (address) {
+      const range = Process.findFunctionRange(address);
+      if (range === null)
+        throw new Error(`unable to find function containing ${address}`);
+      return range;
+    }
+  },
 });
 
 Object.defineProperties(Thread, {

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -284,6 +284,15 @@ Object.defineProperties(ModuleMap.prototype, {
 makeEnumerateRanges(Process);
 
 Object.defineProperties(Process, {
+  getThreadById: {
+    enumerable: true,
+    value: function (id) {
+      const thread = Process.findThreadById(id);
+      if (thread === null)
+        throw new Error(`unable to find thread with id ${id}`);
+      return thread;
+    }
+  },
   runOnThread: {
     enumerable: true,
     value: function (threadId, callback) {

--- a/bindings/gumjs/runtime/core.js
+++ b/bindings/gumjs/runtime/core.js
@@ -257,7 +257,7 @@ Object.defineProperties(ModuleMap.prototype, {
     value: function (address) {
       const details = this.find(address);
       if (details === null)
-        throw new Error('unable to find module containing ' + address);
+        throw new Error(`unable to find module containing ${address}`);
       return details;
     }
   },
@@ -266,7 +266,7 @@ Object.defineProperties(ModuleMap.prototype, {
     value: function (address) {
       const name = this.findName(address);
       if (name === null)
-        throw new Error('unable to find module containing ' + address);
+        throw new Error(`unable to find module containing ${address}`);
       return name;
     }
   },
@@ -275,7 +275,7 @@ Object.defineProperties(ModuleMap.prototype, {
     value: function (address) {
       const path = this.findPath(address);
       if (path === null)
-        throw new Error('unable to find module containing ' + address);
+        throw new Error(`unable to find module containing ${address}`);
       return path;
     }
   },
@@ -312,7 +312,7 @@ Object.defineProperties(Process, {
     value: function (address) {
       const module = Process.findModuleByAddress(address);
       if (module === null)
-        throw new Error('unable to find module containing ' + address);
+        throw new Error(`unable to find module containing ${address}`);
       return module;
     }
   },
@@ -321,7 +321,7 @@ Object.defineProperties(Process, {
     value: function (name) {
       const module = Process.findModuleByName(name);
       if (module === null)
-        throw new Error("unable to find module '" + name + "'");
+        throw new Error(`unable to find module '${name}'`);
       return module;
     }
   },
@@ -330,7 +330,7 @@ Object.defineProperties(Process, {
     value: function (address) {
       const range = Process.findRangeByAddress(address);
       if (range === null)
-        throw new Error('unable to find range containing ' + address);
+        throw new Error(`unable to find range containing ${address}`);
       return range;
     }
   },

--- a/gum/backend-barebone/gumprocess-barebone.c
+++ b/gum/backend-barebone/gumprocess-barebone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2025-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -37,6 +37,13 @@ gboolean
 gum_process_has_thread (GumThreadId thread_id)
 {
   return FALSE;
+}
+
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  return NULL;
 }
 
 gboolean

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -259,6 +259,100 @@ beach:
   return found;
 }
 
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  GumThreadDetails * details;
+
+  details = g_slice_new0 (GumThreadDetails);
+  details->id = thread_id;
+
+  if ((flags & (GUM_THREAD_FLAGS_NAME |
+                GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE |
+                GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER)) != 0)
+  {
+    const GumDarwinPThreadSpec * spec;
+    GumDarwinPThreadIter iter;
+    pthread_t pth;
+    gboolean found = FALSE;
+
+    spec = gum_darwin_query_pthread_spec ();
+
+    gum_darwin_lock_pthread_list (spec);
+
+    gum_darwin_pthread_iter_init (&iter, spec);
+    while (gum_darwin_pthread_iter_next (&iter, &pth))
+    {
+      gpointer start_routine;
+
+      if (gum_darwin_query_pthread_port (pth, spec) != thread_id)
+        continue;
+
+      found = TRUE;
+
+      if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
+      {
+        const gchar * name = gum_darwin_query_pthread_name (pth, spec);
+        if (name != NULL)
+        {
+          details->name = g_strdup (name);
+          details->flags |= GUM_THREAD_FLAGS_NAME;
+        }
+      }
+
+      start_routine = gum_darwin_query_pthread_start_routine (pth, spec);
+      if (start_routine != NULL)
+      {
+        if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE) != 0)
+        {
+          details->entrypoint.routine = GUM_ADDRESS (start_routine);
+          details->flags |= GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE;
+        }
+
+        if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER) != 0)
+        {
+          details->entrypoint.parameter = GUM_ADDRESS (
+              gum_darwin_query_pthread_start_parameter (pth, spec));
+          details->flags |= GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER;
+        }
+      }
+
+      break;
+    }
+
+    gum_darwin_unlock_pthread_list (spec);
+
+    if (!found)
+      goto query_failed;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
+  {
+    if (!gum_darwin_query_thread_state (thread_id, &details->state))
+      goto query_failed;
+    details->flags |= GUM_THREAD_FLAGS_STATE;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
+  {
+    if (!gum_darwin_query_thread_cpu_context (thread_id, &details->cpu_context))
+      goto query_failed;
+    details->flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
+  }
+
+  if (flags == GUM_THREAD_FLAGS_NONE && !gum_process_has_thread (thread_id))
+    goto query_failed;
+
+  return details;
+
+query_failed:
+  {
+    gum_thread_details_free (details);
+    return NULL;
+  }
+}
+
 gboolean
 gum_process_modify_thread (GumThreadId thread_id,
                            GumModifyThreadFunc func,

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2022-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -57,6 +57,9 @@ static void gum_store_cpu_context (GumThreadId thread_id,
 
 static gchar * gum_query_program_path_for_target (int target, GError ** error);
 
+static struct kinfo_proc * gum_query_threads (guint * count);
+static void gum_thread_details_from_proc (GumThreadDetails * thread,
+    const struct kinfo_proc * p, GumThreadFlags flags);
 static GumThreadState gum_thread_state_from_proc (const struct kinfo_proc * p);
 static GumPageProtection gum_page_protection_from_vmentry (int native_prot);
 
@@ -133,6 +136,36 @@ gboolean
 gum_process_has_thread (GumThreadId thread_id)
 {
   return thr_kill (thread_id, 0) == 0;
+}
+
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  GumThreadDetails * result = NULL;
+  struct kinfo_proc * threads;
+  guint n, i;
+
+  threads = gum_query_threads (&n);
+  if (threads == NULL)
+    return NULL;
+
+  for (i = 0; i != n; i++)
+  {
+    const struct kinfo_proc * p = &threads[i];
+    GumThreadDetails thread = { 0, };
+
+    if (p->ki_tid != thread_id)
+      continue;
+
+    if (gum_thread_details_from_proc (&thread, p, flags))
+      result = gum_thread_details_copy (&thread);
+    break;
+  }
+
+  g_free (threads);
+
+  return result;
 }
 
 gboolean
@@ -340,10 +373,33 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
                                 gpointer user_data,
                                 GumThreadFlags flags)
 {
-  int mib[4];
-  struct kinfo_proc * threads = NULL;
-  size_t size;
+  struct kinfo_proc * threads;
   guint n, i;
+
+  threads = gum_query_threads (&n);
+  if (threads == NULL)
+    return;
+
+  for (i = 0; i != n; i++)
+  {
+    GumThreadDetails thread = { 0, };
+
+    if (!gum_thread_details_from_proc (&thread, &threads[i], flags))
+      continue;
+
+    if (!func (&thread, user_data))
+      break;
+  }
+
+  g_free (threads);
+}
+
+static struct kinfo_proc *
+gum_query_threads (guint * count)
+{
+  struct kinfo_proc * threads = NULL;
+  int mib[4];
+  size_t size;
 
   mib[0] = CTL_KERN;
   mib[1] = KERN_PROC;
@@ -352,7 +408,7 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
 
   size = 0;
   if (sysctl (mib, G_N_ELEMENTS (mib), NULL, &size, NULL, 0) != 0)
-    goto beach;
+    return NULL;
 
   while (TRUE)
   {
@@ -367,48 +423,50 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
 
     still_too_small = errno == ENOMEM && size == previous_size;
     if (!still_too_small)
-      goto beach;
+    {
+      g_free (threads);
+      return NULL;
+    }
 
     size += size / 10;
   }
 
-  n = size / sizeof (struct kinfo_proc);
-  for (i = 0; i != n; i++)
+  *count = size / sizeof (struct kinfo_proc);
+
+  return threads;
+}
+
+static gboolean
+gum_thread_details_from_proc (GumThreadDetails * thread,
+                              const struct kinfo_proc * p,
+                              GumThreadFlags flags)
+{
+  thread->id = p->ki_tid;
+
+  if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
   {
-    struct kinfo_proc * p = &threads[i];
-    GumThreadDetails thread = { 0, };
-
-    thread.id = p->ki_tid;
-
-    if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
+    if (p->ki_tdname[0] != '\0')
     {
-      if (p->ki_tdname[0] != '\0')
-      {
-        thread.name = p->ki_tdname;
-        thread.flags |= GUM_THREAD_FLAGS_NAME;
-      }
+      thread->name = p->ki_tdname;
+      thread->flags |= GUM_THREAD_FLAGS_NAME;
     }
-
-    if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
-    {
-      thread.state = gum_thread_state_from_proc (p);
-      thread.flags |= GUM_THREAD_FLAGS_STATE;
-    }
-
-    if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
-    {
-      if (!gum_process_modify_thread (thread.id, gum_store_cpu_context,
-            &thread.cpu_context, GUM_MODIFY_THREAD_FLAGS_ABORT_SAFELY))
-        continue;
-      thread.flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
-    }
-
-    if (!func (&thread, user_data))
-      break;
   }
 
-beach:
-  g_free (threads);
+  if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
+  {
+    thread->state = gum_thread_state_from_proc (p);
+    thread->flags |= GUM_THREAD_FLAGS_STATE;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
+  {
+    if (!gum_process_modify_thread (thread->id, gum_store_cpu_context,
+          &thread->cpu_context, GUM_MODIFY_THREAD_FLAGS_ABORT_SAFELY))
+      return FALSE;
+    thread->flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
+  }
+
+  return TRUE;
 }
 
 static void

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -370,6 +370,11 @@ struct _GumFindFunctionByPrefixContext
 static gboolean gum_try_resolve_dynamic_symbol (const gchar * name,
     Dl_info * info);
 
+static void gum_collect_thread_entrypoint (GumThreadDetails * entry,
+    pthread_t thread, const GumLinuxPThreadSpec * spec, GumThreadFlags flags);
+static gboolean gum_fill_thread_details (GumThreadDetails * entry,
+    GumThreadFlags flags);
+
 static void gum_do_modify_thread (GumThreadId thread_id, GumRegs * regs,
     gpointer user_data);
 static gboolean gum_linux_modify_thread (GumThreadId thread_id,
@@ -541,6 +546,48 @@ gum_process_has_thread (GumThreadId thread_id)
   sprintf (path, "/proc/self/task/%" G_GSIZE_MODIFIER "u", thread_id);
 
   return g_file_test (path, G_FILE_TEST_EXISTS);
+}
+
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  GumThreadDetails * details = NULL;
+  const GumLinuxPThreadSpec * spec;
+  GumLinuxPThreadIter iter;
+  pthread_t thread;
+
+  spec = gum_linux_query_pthread_spec ();
+
+  gum_linux_lock_pthread_list (spec);
+
+  gum_linux_pthread_iter_init (&iter, spec);
+  while (gum_linux_pthread_iter_next (&iter, &thread))
+  {
+    if (gum_linux_query_pthread_tid (thread, spec) == thread_id)
+    {
+      details = g_slice_new0 (GumThreadDetails);
+      details->id = thread_id;
+      gum_collect_thread_entrypoint (details, thread, spec, flags);
+      break;
+    }
+  }
+
+  gum_linux_unlock_pthread_list (spec);
+
+  if (details == NULL)
+    return NULL;
+
+  if (!gum_fill_thread_details (details, flags))
+    goto fill_failed;
+
+  return details;
+
+fill_failed:
+  {
+    gum_thread_details_free (details);
+    return NULL;
+  }
 }
 
 gboolean
@@ -1076,26 +1123,9 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
   while (gum_linux_pthread_iter_next (&iter, &thread))
   {
     GumThreadDetails entry = { 0, };
-    gpointer start_routine;
 
     entry.id = gum_linux_query_pthread_tid (thread, spec);
-
-    start_routine = gum_linux_query_pthread_start_routine (thread, spec);
-    if (start_routine != NULL)
-    {
-      if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE) != 0)
-      {
-        entry.entrypoint.routine = GUM_ADDRESS (start_routine);
-        entry.flags |= GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE;
-      }
-
-      if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER) != 0)
-      {
-        entry.entrypoint.parameter = GUM_ADDRESS (
-            gum_linux_query_pthread_start_parameter (thread, spec));
-        entry.flags |= GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER;
-      }
-    }
+    gum_collect_thread_entrypoint (&entry, thread, spec, flags);
 
     g_array_append_val (entries, entry);
   }
@@ -1105,45 +1135,77 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
   for (i = 0; i != entries->len; i++)
   {
     GumThreadDetails * entry;
-    gchar * name = NULL;
     gboolean carry_on = TRUE;
 
     entry = &g_array_index (entries, GumThreadDetails, i);
 
-    if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
-    {
-      name = gum_linux_query_thread_name (entry->id);
-      if (name != NULL)
-      {
-        entry->name = name;
-        entry->flags |= GUM_THREAD_FLAGS_NAME;
-      }
-    }
+    if (gum_fill_thread_details (entry, flags))
+      carry_on = func (entry, user_data);
 
-    if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
-    {
-      if (!gum_linux_query_thread_state (entry->id, &entry->state))
-        goto skip;
-      entry->flags |= GUM_THREAD_FLAGS_STATE;
-    }
-
-    if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
-    {
-      if (!gum_linux_query_thread_cpu_context (entry->id, &entry->cpu_context))
-        goto skip;
-      entry->flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
-    }
-
-    carry_on = func (entry, user_data);
-
-skip:
-    g_free (name);
+    g_free ((gpointer) entry->name);
 
     if (!carry_on)
       break;
   }
 
   g_array_unref (entries);
+}
+
+static void
+gum_collect_thread_entrypoint (GumThreadDetails * entry,
+                               pthread_t thread,
+                               const GumLinuxPThreadSpec * spec,
+                               GumThreadFlags flags)
+{
+  gpointer start_routine;
+
+  start_routine = gum_linux_query_pthread_start_routine (thread, spec);
+  if (start_routine == NULL)
+    return;
+
+  if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE) != 0)
+  {
+    entry->entrypoint.routine = GUM_ADDRESS (start_routine);
+    entry->flags |= GUM_THREAD_FLAGS_ENTRYPOINT_ROUTINE;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER) != 0)
+  {
+    entry->entrypoint.parameter = GUM_ADDRESS (
+        gum_linux_query_pthread_start_parameter (thread, spec));
+    entry->flags |= GUM_THREAD_FLAGS_ENTRYPOINT_PARAMETER;
+  }
+}
+
+static gboolean
+gum_fill_thread_details (GumThreadDetails * entry,
+                         GumThreadFlags flags)
+{
+  if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
+  {
+    gchar * name = gum_linux_query_thread_name (entry->id);
+    if (name != NULL)
+    {
+      entry->name = name;
+      entry->flags |= GUM_THREAD_FLAGS_NAME;
+    }
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
+  {
+    if (!gum_linux_query_thread_state (entry->id, &entry->state))
+      return FALSE;
+    entry->flags |= GUM_THREAD_FLAGS_STATE;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
+  {
+    if (!gum_linux_query_thread_cpu_context (entry->id, &entry->cpu_context))
+      return FALSE;
+    entry->flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
+  }
+
+  return TRUE;
 }
 
 gboolean

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -33,6 +33,8 @@ static void gum_cpu_context_from_qnx (const debug_greg_t * gregs,
 static void gum_cpu_context_to_qnx (const GumCpuContext * ctx,
     debug_greg_t * gregs);
 
+static gboolean gum_collect_thread_details (GumThreadDetails * details,
+    const debug_thread_t * thread, GumThreadFlags flags, gchar * name_buffer);
 static GumThreadState gum_thread_state_from_system_thread_state (int state);
 
 static GumModule * gum_libc_module;
@@ -117,6 +119,32 @@ beach:
   close (fd);
 
   return found;
+}
+
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  GumThreadDetails * result = NULL;
+  gint fd;
+  debug_thread_t thread = { 0, };
+  GumThreadDetails details = { 0, };
+  gchar thread_name[_NTO_THREAD_NAME_MAX];
+
+  fd = open ("/proc/self/as", O_RDONLY);
+  g_assert (fd != -1);
+
+  thread.tid = thread_id;
+  if (devctl (fd, DCMD_PROC_TIDSTATUS, &thread, sizeof (thread), NULL) == 0 &&
+      thread.tid == thread_id && thread.state != STATE_DEAD)
+  {
+    if (gum_collect_thread_details (&details, &thread, flags, thread_name))
+      result = gum_thread_details_copy (&details);
+  }
+
+  close (fd);
+
+  return result;
 }
 
 gboolean
@@ -206,36 +234,46 @@ _gum_process_enumerate_threads (GumFoundThreadFunc func,
     if (thread.state == STATE_DEAD)
       continue;
 
-    details.id = thread.tid;
-
-    if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
-    {
-      if (pthread_getname_np (thread.tid, thread_name,
-            sizeof (thread_name)) == 0 && thread_name[0] != '\0')
-      {
-        details.name = thread_name;
-        details.flags |= GUM_THREAD_FLAGS_NAME;
-      }
-    }
-
-    if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
-    {
-      details.state = gum_thread_state_from_system_thread_state (thread.state);
-      details.flags |= GUM_THREAD_FLAGS_STATE;
-    }
-
-    if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
-    {
-      if (!gum_process_modify_thread (details.id, gum_store_cpu_context,
-            &details.cpu_context, GUM_MODIFY_THREAD_FLAGS_ABORT_SAFELY))
-        continue;
-      details.flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
-    }
-
-    carry_on = func (&details, user_data);
+    if (gum_collect_thread_details (&details, &thread, flags, thread_name))
+      carry_on = func (&details, user_data);
   }
 
   close (fd);
+}
+
+static gboolean
+gum_collect_thread_details (GumThreadDetails * details,
+                            const debug_thread_t * thread,
+                            GumThreadFlags flags,
+                            gchar * name_buffer)
+{
+  details->id = thread->tid;
+
+  if ((flags & GUM_THREAD_FLAGS_NAME) != 0)
+  {
+    if (pthread_getname_np (thread->tid, name_buffer,
+          _NTO_THREAD_NAME_MAX) == 0 && name_buffer[0] != '\0')
+    {
+      details->name = name_buffer;
+      details->flags |= GUM_THREAD_FLAGS_NAME;
+    }
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_STATE) != 0)
+  {
+    details->state = gum_thread_state_from_system_thread_state (thread->state);
+    details->flags |= GUM_THREAD_FLAGS_STATE;
+  }
+
+  if ((flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0)
+  {
+    if (!gum_process_modify_thread (details->id, gum_store_cpu_context,
+          &details->cpu_context, GUM_MODIFY_THREAD_FLAGS_ABORT_SAFELY))
+      return FALSE;
+    details->flags |= GUM_THREAD_FLAGS_CPU_CONTEXT;
+  }
+
+  return TRUE;
 }
 
 static void

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2009-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2024 Håvard Sørbø <havard@hsorbo.no>
  *
@@ -205,6 +205,23 @@ gum_process_has_thread (GumThreadId thread_id)
   }
 
   return found;
+}
+
+GumThreadDetails *
+gum_process_find_thread_by_id (GumThreadId thread_id,
+                               GumThreadFlags flags)
+{
+  GumThreadDetails * result = NULL;
+  GumThreadDetails thread;
+  gpointer storage;
+
+  if (gum_windows_query_thread_details (thread_id, flags, &thread, &storage))
+  {
+    result = gum_thread_details_copy (&thread);
+    g_free (storage);
+  }
+
+  return result;
 }
 
 gboolean

--- a/gum/gumprocess.c
+++ b/gum/gumprocess.c
@@ -280,6 +280,19 @@ gum_process_set_code_signing_policy (GumCodeSigningPolicy policy)
  */
 
 /**
+ * gum_process_find_thread_by_id:
+ * @thread_id: ID of the thread to find
+ * @flags: flags specifying the desired level of detail
+ *
+ * Looks up a single thread by its ID. Unlike
+ * [func@Gum.process_enumerate_threads], cloaked threads are not hidden: an
+ * explicit lookup by ID always returns the thread if it exists.
+ *
+ * Returns: (nullable) (transfer full): the thread's #GumThreadDetails, or %NULL
+ * if no such thread exists
+ */
+
+/**
  * gum_process_enumerate_threads:
  * @func: (scope call): function called with #GumThreadDetails
  * @user_data: data to pass to @func

--- a/gum/gumprocess.h
+++ b/gum/gumprocess.h
@@ -107,6 +107,8 @@ GUM_API gboolean gum_process_is_debugger_attached (void);
 GUM_API GumProcessId gum_process_get_id (void);
 GUM_API GumThreadId gum_process_get_current_thread_id (void);
 GUM_API gboolean gum_process_has_thread (GumThreadId thread_id);
+GUM_API GumThreadDetails * gum_process_find_thread_by_id (GumThreadId thread_id,
+    GumThreadFlags flags);
 GUM_API gboolean gum_process_modify_thread (GumThreadId thread_id,
     GumModifyThreadFunc func, gpointer user_data, GumModifyThreadFlags flags);
 GUM_API void gum_process_enumerate_threads (GumFoundThreadFunc func,

--- a/tests/core/process.c
+++ b/tests/core/process.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2015 Asger Hautop Drewsen <asgerdrewsen@gmail.com>
  * Copyright (C) 2023 Grant Douglas <me@hexplo.it>
@@ -34,6 +34,8 @@
     TESTENTRY_SIMPLE ("Core/Process", test_process, NAME)
 
 TESTLIST_BEGIN (process)
+  TESTENTRY (find_thread_by_id)
+  TESTENTRY (find_thread_by_id_includes_cloaked)
   TESTENTRY (process_threads)
   TESTENTRY (process_threads_exclude_cloaked)
   TESTENTRY (process_threads_should_include_name)
@@ -180,6 +182,57 @@ static gboolean section_found_cb (const GumSectionDetails * details,
     gpointer user_data);
 static gboolean dep_found_cb (const GumDependencyDetails * details,
     gpointer user_data);
+
+TESTCASE (find_thread_by_id)
+{
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  GumThreadId thread_id;
+  GumThreadDetails * details;
+
+  if (!check_thread_enumeration_testable ())
+    return;
+
+  thread = create_sleeping_dummy_thread_sync ("find-by-id", &done, &thread_id);
+
+  details = gum_process_find_thread_by_id (thread_id, GUM_THREAD_FLAGS_ALL);
+  g_assert_nonnull (details);
+  g_assert_cmpuint (details->id, ==, thread_id);
+  g_assert_true ((details->flags & GUM_THREAD_FLAGS_CPU_CONTEXT) != 0);
+  gum_thread_details_free (details);
+
+  details = gum_process_find_thread_by_id (G_MAXSIZE, GUM_THREAD_FLAGS_ALL);
+  g_assert_null (details);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
+
+TESTCASE (find_thread_by_id_includes_cloaked)
+{
+  volatile gboolean done = FALSE;
+  GThread * thread;
+  GumThreadId thread_id;
+  GumThreadDetails * details;
+
+  if (!check_thread_enumeration_testable ())
+    return;
+
+  thread = create_sleeping_dummy_thread_sync ("find-cloaked", &done,
+      &thread_id);
+
+  gum_cloak_add_thread (thread_id);
+
+  details = gum_process_find_thread_by_id (thread_id, GUM_THREAD_FLAGS_ALL);
+  g_assert_nonnull (details);
+  g_assert_cmpuint (details->id, ==, thread_id);
+  gum_thread_details_free (details);
+
+  gum_cloak_remove_thread (thread_id);
+
+  done = TRUE;
+  g_thread_join (thread);
+}
 
 TESTCASE (process_threads)
 {

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -184,6 +184,7 @@ TESTLIST_BEGIN (script)
     TESTENTRY (process_debugger_status_is_available)
     TESTENTRY (process_id_is_available)
     TESTENTRY (process_current_thread_id_is_available)
+    TESTENTRY (process_thread_can_be_looked_up_by_id)
     TESTENTRY (process_threads_can_be_enumerated)
     TESTENTRY (process_threads_have_names)
     TESTENTRY (process_modules_can_be_enumerated)
@@ -5832,6 +5833,47 @@ TESTCASE (process_current_thread_id_is_available)
 {
   COMPILE_AND_LOAD_SCRIPT ("send(typeof Process.getCurrentThreadId());");
   EXPECT_SEND_MESSAGE_WITH ("\"number\"");
+}
+
+TESTCASE (process_thread_can_be_looked_up_by_id)
+{
+#ifdef HAVE_LINUX
+  if (!check_exception_handling_testable ())
+    return;
+#endif
+
+#ifdef HAVE_MIPS
+  if (!g_test_slow ())
+  {
+    g_print ("<skipping, run in slow mode> ");
+    return;
+  }
+#endif
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const id = Process.getCurrentThreadId();"
+      "const t = Process.getThreadById(id);"
+      "send(t.id === id && t.context !== undefined);");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "try {"
+      "  Process.getThreadById(0x7fffffff);"
+      "  send('no throw');"
+      "} catch (e) {"
+      "  send(e instanceof Error);"
+      "}");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "const id = Process.getCurrentThreadId();"
+      "const t = Process.findThreadById(id);"
+      "send(t !== null && t.id === id && t.context !== undefined);");
+  EXPECT_SEND_MESSAGE_WITH ("true");
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "send(Process.findThreadById(0x7fffffff));");
+  EXPECT_SEND_MESSAGE_WITH ("null");
 }
 
 TESTCASE (process_threads_can_be_enumerated)

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -386,6 +386,7 @@ namespace Gum {
 		public Gum.ProcessId get_id ();
 		public Gum.ThreadId get_current_thread_id ();
 		public bool has_thread (Gum.ThreadId thread_id);
+		public Gum.ThreadDetails? find_thread_by_id (Gum.ThreadId thread_id, Gum.ThreadFlags flags = ALL);
 		public bool modify_thread (Gum.ThreadId thread_id, Gum.ModifyThreadFunc func, Gum.ModifyThreadFlags flags = NONE);
 		public void enumerate_threads (Gum.FoundThreadFunc func, Gum.ThreadFlags flags = ALL);
 		public unowned Module get_main_module ();


### PR DESCRIPTION
Add a way to look up a single thread by its ID without enumerating all
of them.

- `process: Add find_thread_by_id()` — native API across all backends
  (linux, darwin, freebsd, windows, qnx, barebone). Unlike
  `enumerate_threads()`, cloaked threads are not hidden: an explicit
  lookup always returns the thread if it exists.
- `gumjs: Add Process.findThreadById()` — expose the native lookup, plus
  a `getThreadById()` convenience that throws instead of returning null.
- `gumjs: Add Process.getFunctionRange()` — convenience that throws
  instead of returning null, completing the existing `findFunctionRange()`.
- `gumjs: Use template strings for errors` — modernize the remaining
  string-concatenated lookup error messages.