### PR TITLE
Add capstone 6 compatibility in gumdefs.h

### DIFF
--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -9,8 +9,13 @@
 #ifndef __GUMDEFS_H__
 #define __GUMDEFS_H__
 
+#include <capstone.h>
 #include <glib.h>
 #include <gum/gumenumtypes.h>
+
+#if CS_API_MAJOR >= 6
+# define CS_ARCH_ARM64 CS_ARCH_AARCH64
+#endif
 
 #if !defined (GUM_STATIC) && defined (G_OS_WIN32)
 #  ifdef GUM_EXPORTS


### PR DESCRIPTION
Capstone 6 renamed CS_ARCH_ARM64 -> CS_ARCH_AARCH64.  This adds a compatibility
#define using the CS_API_MAJOR version macro so frida-gum builds correctly with
both capstone 5 and 6.

The #if CS_API_MAJOR >= 6 guard ensures the alias is only defined when needed,
and !defined(CS_ARCH_ARM64) prevents redefinition if the capstone headers
already provide the backward-compatible alias.
