### PR TITLE
gumjs: Add Checksum copy and peek methods

### DIFF
--- a/bindings/gumjs/gumquickchecksum.c
+++ b/bindings/gumjs/gumquickchecksum.c
@@ -24,11 +24,16 @@ GUMJS_DECLARE_FUNCTION (gumjs_checksum_compute)
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_checksum_construct)
 GUMJS_DECLARE_FINALIZER (gumjs_checksum_finalize)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_update)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_copy)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_get_string)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_peek_string)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_get_digest)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_peek_digest)
 
 static GumChecksum * gum_checksum_new (GChecksumType type);
 static void gum_checksum_free (GumChecksum * self);
+
+static GumChecksum * gum_checksum_copy (GumChecksum *self);
 
 static gboolean gum_quick_checksum_type_get (JSContext * ctx,
     const gchar * name, GChecksumType * type);
@@ -47,8 +52,11 @@ static const JSCFunctionListEntry gumjs_checksum_module_entries[] =
 static const JSCFunctionListEntry gumjs_checksum_entries[] =
 {
   JS_CFUNC_DEF ("update", 1, gumjs_checksum_update),
+  JS_CFUNC_DEF ("copy", 0, gumjs_checksum_copy),
   JS_CFUNC_DEF ("getString", 0, gumjs_checksum_get_string),
+  JS_CFUNC_DEF ("peekString", 0, gumjs_checksum_peek_string),
   JS_CFUNC_DEF ("getDigest", 0, gumjs_checksum_get_digest),
+  JS_CFUNC_DEF ("peekDigest", 0, gumjs_checksum_peek_digest),
 };
 
 void
@@ -224,6 +232,21 @@ invalid_operation:
   }
 }
 
+GUMJS_DEFINE_FUNCTION (gumjs_checksum_copy)
+{
+  GumChecksum * self;
+  JSValue wrapper;
+
+  if (!gum_checksum_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  wrapper = JS_NewObjectClass (ctx,
+      gumjs_get_parent_module (core)->checksum_class);
+  JS_SetOpaque (wrapper, gum_checksum_copy (self));
+
+  return wrapper;
+}
+
 GUMJS_DEFINE_FUNCTION (gumjs_checksum_get_string)
 {
   GumChecksum * self;
@@ -234,6 +257,22 @@ GUMJS_DEFINE_FUNCTION (gumjs_checksum_get_string)
   self->closed = TRUE;
 
   return JS_NewString (ctx, g_checksum_get_string (self->handle));
+}
+
+GUMJS_DEFINE_FUNCTION (gumjs_checksum_peek_string)
+{
+  JSValue result;
+  GumChecksum * self;
+  GChecksum * clone;
+
+  if (!gum_checksum_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  clone = g_checksum_copy (self->handle);
+  result = JS_NewString (ctx, g_checksum_get_string (clone));
+  g_checksum_free (clone);
+
+  return result;
 }
 
 GUMJS_DEFINE_FUNCTION (gumjs_checksum_get_digest)
@@ -258,6 +297,30 @@ GUMJS_DEFINE_FUNCTION (gumjs_checksum_get_digest)
   return result;
 }
 
+GUMJS_DEFINE_FUNCTION (gumjs_checksum_peek_digest)
+{
+  JSValue result;
+  GumChecksum * self;
+  GChecksum * clone;
+  gsize length;
+  guint8 * data;
+
+  if (!gum_checksum_get (ctx, this_val, core, &self))
+    return JS_EXCEPTION;
+
+  clone = g_checksum_copy (self->handle);
+
+  length = g_checksum_type_get_length (self->type);
+  data = g_malloc (length);
+  result = JS_NewArrayBuffer (ctx, data, length, _gum_quick_array_buffer_free,
+      data, FALSE);
+
+  g_checksum_get_digest (clone, data, &length);
+  g_checksum_free (clone);
+
+  return result;
+}
+
 static GumChecksum *
 gum_checksum_new (GChecksumType type)
 {
@@ -267,6 +330,19 @@ gum_checksum_new (GChecksumType type)
   cs->handle = g_checksum_new (type);
   cs->type = type;
   cs->closed = FALSE;
+
+  return cs;
+}
+
+static GumChecksum *
+gum_checksum_copy (GumChecksum *self)
+{
+  GumChecksum * cs;
+
+  cs = g_slice_new (GumChecksum);
+  cs->handle = g_checksum_copy (self->handle);
+  cs->type = self->type;
+  cs->closed = self->closed;
 
   return cs;
 }

--- a/bindings/gumjs/gumquickchecksum.c
+++ b/bindings/gumjs/gumquickchecksum.c
@@ -33,7 +33,7 @@ GUMJS_DECLARE_FUNCTION (gumjs_checksum_peek_digest)
 static GumChecksum * gum_checksum_new (GChecksumType type);
 static void gum_checksum_free (GumChecksum * self);
 
-static GumChecksum * gum_checksum_copy (GumChecksum *self);
+static GumChecksum * gum_checksum_copy (GumChecksum * self);
 
 static gboolean gum_quick_checksum_type_get (JSContext * ctx,
     const gchar * name, GChecksumType * type);
@@ -335,7 +335,7 @@ gum_checksum_new (GChecksumType type)
 }
 
 static GumChecksum *
-gum_checksum_copy (GumChecksum *self)
+gum_checksum_copy (GumChecksum * self)
 {
   GumChecksum * cs;
 

--- a/bindings/gumjs/gumv8checksum.cpp
+++ b/bindings/gumjs/gumv8checksum.cpp
@@ -25,11 +25,16 @@ GUMJS_DECLARE_FUNCTION (gumjs_checksum_compute)
 
 GUMJS_DECLARE_CONSTRUCTOR (gumjs_checksum_construct)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_update)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_copy)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_get_string)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_peek_string)
 GUMJS_DECLARE_FUNCTION (gumjs_checksum_get_digest)
+GUMJS_DECLARE_FUNCTION (gumjs_checksum_peek_digest)
 
 static GumChecksum * gum_checksum_new (Local<Object> wrapper,
     GChecksumType type, GumV8Checksum * module);
+static Local<Object> gum_checksum_copy (GumChecksum * self);
+
 static void gum_checksum_free (GumChecksum * self);
 static void gum_checksum_on_weak_notify (
     const WeakCallbackInfo<GumChecksum> & info);
@@ -47,8 +52,11 @@ static const GumV8Function gumjs_checksum_module_functions[] =
 static const GumV8Function gumjs_checksum_functions[] =
 {
   { "update", gumjs_checksum_update },
+  { "copy", gumjs_checksum_copy },
   { "getString", gumjs_checksum_get_string },
+  { "peekString", gumjs_checksum_peek_string },
   { "getDigest", gumjs_checksum_get_digest },
+  { "peekDigest", gumjs_checksum_peek_digest },
 
   { NULL, NULL }
 };
@@ -210,12 +218,27 @@ GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_update, GumChecksum)
   info.GetReturnValue ().Set (info.This ());
 }
 
+GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_copy, GumChecksum)
+{
+  info.GetReturnValue ().Set (gum_checksum_copy (self));
+}
+
 GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_get_string, GumChecksum)
 {
   self->closed = TRUE;
 
   info.GetReturnValue ().Set (
       _gum_v8_string_new_ascii (isolate, g_checksum_get_string (self->handle)));
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_peek_string, GumChecksum)
+{
+  auto clone = g_checksum_copy (self->handle);
+
+  info.GetReturnValue ().Set (
+      _gum_v8_string_new_ascii (isolate, g_checksum_get_string (clone)));
+
+  g_checksum_free (clone);
 }
 
 GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_get_digest, GumChecksum)
@@ -227,6 +250,19 @@ GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_get_digest, GumChecksum)
   auto store = result.As<ArrayBuffer> ()->GetBackingStore ();
 
   g_checksum_get_digest (self->handle, (guint8 *) store->Data (), &length);
+
+  info.GetReturnValue ().Set (result);
+}
+
+GUMJS_DEFINE_CLASS_METHOD (gumjs_checksum_peek_digest, GumChecksum)
+{
+  size_t length = g_checksum_type_get_length (self->type);
+  auto result = ArrayBuffer::New (isolate, length);
+  auto store = result.As<ArrayBuffer> ()->GetBackingStore ();
+
+  auto clone = g_checksum_copy (self->handle);
+  g_checksum_get_digest (clone, (guint8 *) store->Data (), &length);
+  g_checksum_free (clone);
 
   info.GetReturnValue ().Set (result);
 }
@@ -248,6 +284,28 @@ gum_checksum_new (Local<Object> wrapper,
   g_hash_table_add (module->checksums, cs);
 
   return cs;
+}
+
+static Local<Object>
+gum_checksum_copy (GumChecksum * self)
+{
+  auto cs = g_slice_new (GumChecksum);
+  auto clone = Local<Object>::New (self->module->core->isolate,
+          *self->wrapper)->Clone ();
+  cs->wrapper = new Global<Object> (self->module->core->isolate,
+      clone);
+  cs->handle = g_checksum_copy (self->handle);
+  cs->type = self->type;
+  cs->closed = self->closed;
+  cs->module = self->module;
+
+  cs->wrapper->SetWeak (cs, gum_checksum_on_weak_notify,
+      WeakCallbackType::kParameter);
+  clone->SetAlignedPointerInInternalField (0, cs);
+
+  g_hash_table_add (self->module->checksums, cs);
+
+  return clone;
 }
 
 static void

--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -463,6 +463,8 @@ TESTLIST_BEGIN (script)
     TESTENTRY (sha384_can_be_computed_for_string)
     TESTENTRY (sha512_can_be_computed_for_string)
     TESTENTRY (requesting_unknown_checksum_for_string_should_throw)
+    TESTENTRY (checksum_can_be_copied)
+    TESTENTRY (checksum_can_be_peeked)
   TESTGROUP_END ()
 
 #ifdef HAVE_SQLITE
@@ -4335,6 +4337,53 @@ TESTCASE (requesting_unknown_checksum_for_string_should_throw)
   COMPILE_AND_LOAD_SCRIPT ("send(Checksum.compute('bogus', 'abc'));");
   EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER,
       "Error: unsupported checksum type");
+}
+
+TESTCASE (checksum_can_be_copied)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "const checksum = new Checksum('md5');"
+      "checksum.update('ab');"
+      "const copied = checksum.copy();"
+
+      "send(checksum.update('c').getString());"
+      "send(copied.update('c').getString());"
+
+      "const closed = checksum.copy();"
+      "closed.update('d');"
+      );
+
+  EXPECT_SEND_MESSAGE_WITH ("\"900150983cd24fb0d6963f7d28e17f72\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"900150983cd24fb0d6963f7d28e17f72\"");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: checksum is closed");
+  EXPECT_NO_MESSAGES ();
+}
+
+TESTCASE (checksum_can_be_peeked)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "const checksum = new Checksum('md5');"
+      "checksum.update('ab');"
+
+      "const view = new DataView(checksum.peekDigest());"
+      "send(["
+      "  view.getUint32(0).toString(16),"
+      "  view.getUint32(4).toString(16),"
+      "  view.getUint32(8).toString(16),"
+      "  view.getUint32(12).toString(16)"
+      "].join(''));"
+
+      "send(checksum.peekString());"
+      "send(checksum.update('c').getString());"
+
+      "checksum.update('d');"
+      );
+
+  EXPECT_SEND_MESSAGE_WITH ("\"187ef4436122d1cc2f40dc2b92f0eba0\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"187ef4436122d1cc2f40dc2b92f0eba0\"");
+  EXPECT_SEND_MESSAGE_WITH ("\"900150983cd24fb0d6963f7d28e17f72\"");
+  EXPECT_ERROR_MESSAGE_WITH (ANY_LINE_NUMBER, "Error: checksum is closed");
+  EXPECT_NO_MESSAGES ();
 }
 
 #ifdef HAVE_SQLITE


### PR DESCRIPTION
Add new `copy()`, `peekString()` and `peekDigest()` methods.

Copying a closed checksum keeps the closed state.