### PR TITLE
x86: Expose XMM registers in x64 CpuContext

### DIFF
--- a/bindings/gumjs/gumquickcore.c
+++ b/bindings/gumjs/gumquickcore.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  * Copyright (C) 2024 Simon Zuckerbraun <Simon_Zuckerbraun@trendmicro.com>
  * Copyright (C) 2026 Thanos Petsas <thanpetsas@gmail.com>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -720,6 +721,36 @@ static const JSClassDef gumjs_cpu_context_def =
           sizeof (self->handle->R)); \
     }
 
+#define GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM(A, INDEX) \
+    GUMJS_DEFINE_GETTER (gumjs_cpu_context_get_##A) \
+    { \
+      GumQuickCpuContext * self; \
+      \
+      if (!_gum_quick_cpu_context_unwrap (ctx, this_val, core, &self)) \
+        return JS_EXCEPTION; \
+      \
+      if (self->handle->xmm == NULL) \
+        return JS_NULL; \
+      \
+      return JS_NewArrayBufferCopy (ctx, self->handle->xmm[INDEX].q, \
+          sizeof (self->handle->xmm[INDEX].q)); \
+    } \
+    \
+    GUMJS_DEFINE_SETTER (gumjs_cpu_context_set_##A) \
+    { \
+      GumQuickCpuContext * self; \
+      \
+      if (!_gum_quick_cpu_context_unwrap (ctx, this_val, core, &self)) \
+        return JS_EXCEPTION; \
+      \
+      if (self->handle->xmm == NULL) \
+        return _gum_quick_throw_literal (ctx, \
+            "vector registers are not available"); \
+      \
+      return gumjs_cpu_context_set_vector (self, ctx, val, \
+          self->handle->xmm[INDEX].q, sizeof (self->handle->xmm[INDEX].q)); \
+    }
+
 #define GUM_DEFINE_CPU_CONTEXT_ACCESSOR_DOUBLE(A, R) \
     GUMJS_DEFINE_GETTER (gumjs_cpu_context_get_##A) \
     { \
@@ -801,6 +832,15 @@ GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (esi)
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (edi)
 
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (eip)
+
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm0, 0)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm1, 1)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm2, 2)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm3, 3)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm4, 4)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm5, 5)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm6, 6)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm7, 7)
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (rax)
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (rcx)
@@ -821,6 +861,23 @@ GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (r14)
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (r15)
 
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (rip)
+
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm0, 0)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm1, 1)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm2, 2)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm3, 3)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm4, 4)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm5, 5)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm6, 6)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm7, 7)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm8, 8)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm9, 9)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm10, 10)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm11, 11)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm12, 12)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm13, 13)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm14, 14)
+GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm15, 15)
 #elif defined (HAVE_ARM)
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (pc)
 GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (sp)
@@ -1124,6 +1181,15 @@ static const JSCFunctionListEntry gumjs_cpu_context_entries[] =
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (edi),
 
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (eip),
+
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm0),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm1),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm2),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm3),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm4),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm5),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm6),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm7),
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR_ALIASED (pc, rip),
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR_ALIASED (sp, rsp),
@@ -1147,6 +1213,23 @@ static const JSCFunctionListEntry gumjs_cpu_context_entries[] =
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (r15),
 
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (rip),
+
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm0),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm1),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm2),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm3),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm4),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm5),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm6),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm7),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm8),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm9),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm10),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm11),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm12),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm13),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm14),
+  GUM_EXPORT_CPU_CONTEXT_ACCESSOR (xmm15),
 #elif defined (HAVE_ARM)
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (pc),
   GUM_EXPORT_CPU_CONTEXT_ACCESSOR (sp),

--- a/bindings/gumjs/gumv8core.cpp
+++ b/bindings/gumjs/gumv8core.cpp
@@ -6,6 +6,7 @@
  * Copyright (C) 2020 Marcus Mengs <mame8282@googlemail.com>
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  * Copyright (C) 2024 Simon Zuckerbraun <Simon_Zuckerbraun@trendmicro.com>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -402,6 +403,10 @@ GUMJS_DECLARE_GETTER (gumjs_cpu_context_get_gpr)
 GUMJS_DECLARE_SETTER (gumjs_cpu_context_set_gpr)
 G_GNUC_UNUSED GUMJS_DECLARE_GETTER (gumjs_cpu_context_get_vector)
 G_GNUC_UNUSED GUMJS_DECLARE_SETTER (gumjs_cpu_context_set_vector)
+#ifdef HAVE_I386
+GUMJS_DECLARE_GETTER (gumjs_cpu_context_get_xmm)
+GUMJS_DECLARE_SETTER (gumjs_cpu_context_set_xmm)
+#endif
 G_GNUC_UNUSED GUMJS_DECLARE_GETTER (gumjs_cpu_context_get_double)
 G_GNUC_UNUSED GUMJS_DECLARE_SETTER (gumjs_cpu_context_set_double)
 G_GNUC_UNUSED GUMJS_DECLARE_GETTER (gumjs_cpu_context_get_float)
@@ -740,6 +745,15 @@ _gum_v8_core_init (GumV8Core * self,
         DEFAULT, \
         DontDelete)
 
+#define GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM(A, INDEX) \
+    cpu_context_object->SetAccessor ( \
+        _gum_v8_string_new_ascii (isolate, G_STRINGIFY (A)), \
+        gumjs_cpu_context_get_xmm, \
+        gumjs_cpu_context_set_xmm, \
+        Integer::NewFromUnsigned (isolate, INDEX), \
+        DEFAULT, \
+        DontDelete)
+
 #define GUM_DEFINE_CPU_CONTEXT_ACCESSOR_DOUBLE(A, R) \
     cpu_context_object->SetAccessor ( \
         _gum_v8_string_new_ascii (isolate, G_STRINGIFY (A)), \
@@ -784,6 +798,15 @@ _gum_v8_core_init (GumV8Core * self,
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (edi);
 
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (eip);
+
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm0, 0);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm1, 1);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm2, 2);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm3, 3);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm4, 4);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm5, 5);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm6, 6);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm7, 7);
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR_ALIASED (pc, rip);
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR_ALIASED (sp, rsp);
@@ -807,6 +830,23 @@ _gum_v8_core_init (GumV8Core * self,
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (r15);
 
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (rip);
+
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm0, 0);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm1, 1);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm2, 2);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm3, 3);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm4, 4);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm5, 5);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm6, 6);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm7, 7);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm8, 8);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm9, 9);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm10, 10);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm11, 11);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm12, 12);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm13, 13);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm14, 14);
+  GUM_DEFINE_CPU_CONTEXT_ACCESSOR_XMM (xmm15, 15);
 #elif defined (HAVE_ARM)
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (pc);
   GUM_DEFINE_CPU_CONTEXT_ACCESSOR_GPR (sp);
@@ -4237,6 +4277,80 @@ gumjs_cpu_context_set_vector (Local<Name> property,
 
   g_bytes_unref (new_bytes);
 }
+
+#ifdef HAVE_I386
+
+static void
+gumjs_cpu_context_get_xmm (Local<Name> property,
+                           const PropertyCallbackInfo<Value> & info)
+{
+  auto wrapper = info.Holder ();
+  auto cpu_context =
+      (GumCpuContext *) wrapper->GetAlignedPointerFromInternalField (0);
+  guint index = info.Data ().As<Integer> ()->Value ();
+
+  if (cpu_context->xmm == NULL)
+  {
+    info.GetReturnValue ().SetNull ();
+    return;
+  }
+
+  GumX86VectorReg * reg = &cpu_context->xmm[index];
+
+  auto result = ArrayBuffer::New (info.GetIsolate (), sizeof (reg->q));
+  auto store = result.As<ArrayBuffer> ()->GetBackingStore ();
+  memcpy (store->Data (), reg->q, sizeof (reg->q));
+
+  info.GetReturnValue ().Set (result);
+}
+
+static void
+gumjs_cpu_context_set_xmm (Local<Name> property,
+                           Local<Value> value,
+                           const PropertyCallbackInfo<void> & info)
+{
+  auto isolate = info.GetIsolate ();
+  auto wrapper = info.Holder ();
+  auto core = (GumV8Core *) wrapper->GetAlignedPointerFromInternalField (2);
+  auto cpu_context =
+      (GumCpuContext *) wrapper->GetAlignedPointerFromInternalField (0);
+  bool is_mutable = wrapper->GetInternalField (1).As<Boolean> ()->Value ();
+  guint index = info.Data ().As<Integer> ()->Value ();
+
+  if (!is_mutable)
+  {
+    _gum_v8_throw_ascii_literal (isolate, "invalid operation");
+    return;
+  }
+
+  if (cpu_context->xmm == NULL)
+  {
+    _gum_v8_throw_ascii_literal (isolate,
+        "vector registers are not available");
+    return;
+  }
+
+  GumX86VectorReg * reg = &cpu_context->xmm[index];
+
+  GBytes * new_bytes = _gum_v8_bytes_get (value, core);
+  if (new_bytes == NULL)
+    return;
+
+  gsize new_size;
+  gconstpointer new_data = g_bytes_get_data (new_bytes, &new_size);
+  if (new_size != sizeof (reg->q))
+  {
+    g_bytes_unref (new_bytes);
+    _gum_v8_throw_ascii_literal (isolate, "incorrect vector size");
+    return;
+  }
+
+  memcpy (reg->q, new_data, new_size);
+
+  g_bytes_unref (new_bytes);
+}
+
+#endif
 
 static void
 gumjs_cpu_context_get_double (Local<Name> property,

--- a/bindings/gumjs/runtime/cmodule/gum/gumdefs.h
+++ b/bindings/gumjs/runtime/cmodule/gum/gumdefs.h
@@ -16,6 +16,7 @@ typedef guint GumArgType;
 typedef struct _GumArgument GumArgument;
 typedef guint GumBranchHint;
 typedef struct _GumCpuContext GumCpuContext;
+typedef union _GumX86VectorReg GumX86VectorReg;
 typedef union _GumArmVectorReg GumArmVectorReg;
 typedef union _GumArm64VectorReg GumArm64VectorReg;
 typedef struct _GumMemoryRange GumMemoryRange;
@@ -72,6 +73,13 @@ enum _GumBranchHint
   GUM_UNLIKELY
 };
 
+union _GumX86VectorReg
+{
+  guint8 q[16];
+  gdouble d[2];
+  gfloat s[4];
+};
+
 union _GumArmVectorReg
 {
   guint8 q[16];
@@ -101,6 +109,8 @@ struct _GumCpuContext
   guint32 edx;
   guint32 ecx;
   guint32 eax;
+
+  GumX86VectorReg * xmm;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   guint64 rip;
 
@@ -121,6 +131,8 @@ struct _GumCpuContext
   guint64 rdx;
   guint64 rcx;
   guint64 rax;
+
+  GumX86VectorReg * xmm;
 #elif defined (HAVE_ARM)
   guint32 pc;
   guint32 sp;

--- a/gum/backend-arm/gumcpucontext-arm.c
+++ b/gum/backend-arm/gumcpucontext-arm.c
@@ -1,10 +1,25 @@
 /*
- * Copyright (C) 2010 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2010-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
 #include "gumdefs.h"
+
+G_DEFINE_BOXED_TYPE (GumCpuContext, gum_cpu_context, gum_cpu_context_copy,
+    gum_cpu_context_free)
+
+GumCpuContext *
+gum_cpu_context_copy (const GumCpuContext * cpu_context)
+{
+  return g_memdup2 (cpu_context, sizeof (GumCpuContext));
+}
+
+void
+gum_cpu_context_free (GumCpuContext * cpu_context)
+{
+  g_free (cpu_context);
+}
 
 gpointer
 gum_cpu_context_get_nth_argument (GumCpuContext * self,

--- a/gum/backend-arm64/gumcpucontext-arm64.c
+++ b/gum/backend-arm64/gumcpucontext-arm64.c
@@ -1,10 +1,25 @@
 /*
- * Copyright (C) 2014-2015 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
 #include "gumdefs.h"
+
+G_DEFINE_BOXED_TYPE (GumCpuContext, gum_cpu_context, gum_cpu_context_copy,
+    gum_cpu_context_free)
+
+GumCpuContext *
+gum_cpu_context_copy (const GumCpuContext * cpu_context)
+{
+  return g_memdup2 (cpu_context, sizeof (GumCpuContext));
+}
+
+void
+gum_cpu_context_free (GumCpuContext * cpu_context)
+{
+  g_free (cpu_context);
+}
 
 gpointer
 gum_cpu_context_get_nth_argument (GumCpuContext * self,

--- a/gum/backend-darwin/gumprocess-darwin.c
+++ b/gum/backend-darwin/gumprocess-darwin.c
@@ -1392,7 +1392,11 @@ gum_darwin_modify_thread (mach_port_t thread,
   mach_msg_type_number_t state_count = GUM_DARWIN_THREAD_STATE_COUNT;
   thread_state_flavor_t state_flavor = GUM_DARWIN_THREAD_STATE_FLAVOR;
   GumCpuContext cpu_context, original_cpu_context;
-# if defined (HAVE_ARM) || defined (HAVE_ARM64)
+# if defined (HAVE_I386)
+  GumDarwinNativeFloatState float_state, original_float_state;
+  mach_msg_type_number_t float_state_count = GUM_DARWIN_FLOAT_STATE_COUNT;
+  thread_state_flavor_t float_state_flavor = GUM_DARWIN_FLOAT_STATE_FLAVOR;
+# elif defined (HAVE_ARM) || defined (HAVE_ARM64)
   GumDarwinNativeNeonState neon_state;
   mach_msg_type_number_t neon_state_count = GUM_DARWIN_NEON_STATE_COUNT;
   thread_state_flavor_t neon_state_flavor = GUM_DARWIN_NEON_STATE_FLAVOR;
@@ -1418,7 +1422,15 @@ gum_darwin_modify_thread (mach_port_t thread,
 
   gum_darwin_parse_unified_thread_state (&state, &cpu_context);
 
-# if defined (HAVE_ARM) || defined (HAVE_ARM64)
+# if defined (HAVE_I386)
+  kr = thread_get_state (thread, float_state_flavor,
+      (thread_state_t) &float_state, &float_state_count);
+  if (kr != KERN_SUCCESS)
+    goto beach;
+
+  cpu_context.xmm = (GumX86VectorReg *) &float_state.__fpu_xmm0;
+  memcpy (&original_float_state, &float_state, sizeof (float_state));
+# elif defined (HAVE_ARM) || defined (HAVE_ARM64)
   kr = thread_get_state (thread, neon_state_flavor,
       (thread_state_t) &neon_state, &neon_state_count);
   if (kr != KERN_SUCCESS)
@@ -1447,6 +1459,16 @@ gum_darwin_modify_thread (mach_port_t thread,
         (thread_state_t) &neon_state, neon_state_count);
 # endif
   }
+
+# if defined (HAVE_I386)
+  if (memcmp (&float_state, &original_float_state, sizeof (float_state)) != 0)
+  {
+    kr = thread_set_state (thread, float_state_flavor,
+        (thread_state_t) &float_state, float_state_count);
+    if (kr != KERN_SUCCESS)
+      goto beach;
+  }
+# endif
 
 beach:
   if (is_suspended)
@@ -2831,6 +2853,8 @@ gum_darwin_parse_native_thread_state (const GumDarwinNativeThreadState * ts,
   ctx->edx = ts->__edx;
   ctx->ecx = ts->__ecx;
   ctx->eax = ts->__eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   ctx->rip = ts->__rip;
 
@@ -2851,6 +2875,8 @@ gum_darwin_parse_native_thread_state (const GumDarwinNativeThreadState * ts,
   ctx->rdx = ts->__rdx;
   ctx->rcx = ts->__rcx;
   ctx->rax = ts->__rax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_ARM)
   guint n;
 

--- a/gum/backend-darwin/include/gum/gumdarwin.h
+++ b/gum/backend-darwin/include/gum/gumdarwin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2010-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2022 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2022-2025 Francesco Tamagni <mrmacete@protonmail.ch>
  *
@@ -104,10 +104,16 @@ typedef struct nlist_64 gum_nlist_t;
 typedef x86_thread_state_t GumDarwinUnifiedThreadState;
 # if GLIB_SIZEOF_VOID_P == 4
 typedef x86_thread_state32_t GumDarwinNativeThreadState;
+typedef x86_float_state32_t GumDarwinNativeFloatState;
 typedef x86_debug_state32_t GumDarwinNativeDebugState;
+#  define GUM_DARWIN_FLOAT_STATE_COUNT x86_FLOAT_STATE32_COUNT
+#  define GUM_DARWIN_FLOAT_STATE_FLAVOR x86_FLOAT_STATE32
 # else
 typedef x86_thread_state64_t GumDarwinNativeThreadState;
+typedef x86_float_state64_t GumDarwinNativeFloatState;
 typedef x86_debug_state64_t GumDarwinNativeDebugState;
+#  define GUM_DARWIN_FLOAT_STATE_COUNT x86_FLOAT_STATE64_COUNT
+#  define GUM_DARWIN_FLOAT_STATE_FLAVOR x86_FLOAT_STATE64
 # endif
 # define GUM_DARWIN_THREAD_STATE_COUNT x86_THREAD_STATE_COUNT
 # define GUM_DARWIN_THREAD_STATE_FLAVOR x86_THREAD_STATE

--- a/gum/backend-freebsd/gumprocess-freebsd.c
+++ b/gum/backend-freebsd/gumprocess-freebsd.c
@@ -807,6 +807,8 @@ gum_freebsd_parse_ucontext (const ucontext_t * uc,
   ctx->edx = mc->mc_edx;
   ctx->ecx = mc->mc_ecx;
   ctx->eax = mc->mc_eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   const mcontext_t * mc = &uc->uc_mcontext;
 
@@ -829,6 +831,9 @@ gum_freebsd_parse_ucontext (const ucontext_t * uc,
   ctx->rdx = mc->mc_rdx;
   ctx->rcx = mc->mc_rcx;
   ctx->rax = mc->mc_rax;
+
+  ctx->xmm = (GumX86VectorReg *)
+      ((const guint8 *) mc->mc_fpstate + GUM_FXSAVE_OFFSET_XMM);
 #elif defined (HAVE_ARM64)
   const struct gpregs * gp = &uc->uc_mcontext.mc_gpregs;
   gsize i;
@@ -924,6 +929,8 @@ gum_freebsd_parse_regs (const struct reg * regs,
   ctx->edx = regs->r_edx;
   ctx->ecx = regs->r_ecx;
   ctx->eax = regs->r_eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   ctx->rip = regs->r_rip;
 
@@ -944,6 +951,8 @@ gum_freebsd_parse_regs (const struct reg * regs,
   ctx->rdx = regs->r_rdx;
   ctx->rcx = regs->r_rcx;
   ctx->rax = regs->r_rax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_ARM64)
   gsize i;
 

--- a/gum/backend-linux/gumprocess-linux.c
+++ b/gum/backend-linux/gumprocess-linux.c
@@ -2459,6 +2459,8 @@ gum_linux_parse_ucontext (const ucontext_t * uc,
   ctx->edx = gr[REG_EDX];
   ctx->ecx = gr[REG_ECX];
   ctx->eax = gr[REG_EAX];
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   const greg_t * gr = uc->uc_mcontext.gregs;
 
@@ -2481,6 +2483,8 @@ gum_linux_parse_ucontext (const ucontext_t * uc,
   ctx->rdx = gr[REG_RDX];
   ctx->rcx = gr[REG_RCX];
   ctx->rax = gr[REG_RAX];
+
+  ctx->xmm = (GumX86VectorReg *) uc->uc_mcontext.fpregs->_xmm;
 #elif defined (HAVE_ARM) && defined (HAVE_LEGACY_MCONTEXT)
   const elf_greg_t * gr = uc->uc_mcontext.gregs;
 
@@ -2800,6 +2804,8 @@ gum_parse_gp_regs (const GumGPRegs * regs,
   ctx->edx = regs->edx;
   ctx->ecx = regs->ecx;
   ctx->eax = regs->eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   ctx->rip = regs->rip;
 
@@ -2820,6 +2826,8 @@ gum_parse_gp_regs (const GumGPRegs * regs,
   ctx->rdx = regs->rdx;
   ctx->rcx = regs->rcx;
   ctx->rax = regs->rax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_ARM)
   gsize i;
 

--- a/gum/backend-mips/gumcpucontext-mips.c
+++ b/gum/backend-mips/gumcpucontext-mips.c
@@ -1,11 +1,26 @@
 /*
- * Copyright (C) 2014-2015 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C)      2019 Jon Wilson <jonwilson@zepler.net>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
 #include "gumdefs.h"
+
+G_DEFINE_BOXED_TYPE (GumCpuContext, gum_cpu_context, gum_cpu_context_copy,
+    gum_cpu_context_free)
+
+GumCpuContext *
+gum_cpu_context_copy (const GumCpuContext * cpu_context)
+{
+  return g_memdup2 (cpu_context, sizeof (GumCpuContext));
+}
+
+void
+gum_cpu_context_free (GumCpuContext * cpu_context)
+{
+  g_free (cpu_context);
+}
 
 #if GLIB_SIZEOF_VOID_P == 4
 

--- a/gum/backend-posix/gumexceptor-posix.c
+++ b/gum/backend-posix/gumexceptor-posix.c
@@ -588,6 +588,9 @@ gum_parse_context (gconstpointer context,
   const ucontext_t * uc = context;
 
   gum_darwin_parse_native_thread_state (&uc->uc_mcontext->__ss, ctx);
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+  ctx->xmm = (GumX86VectorReg *) &uc->uc_mcontext->__fs.__fpu_xmm0;
+#endif
 }
 
 static void

--- a/gum/backend-qnx/gumprocess-qnx.c
+++ b/gum/backend-qnx/gumprocess-qnx.c
@@ -686,6 +686,8 @@ gum_cpu_context_from_qnx (const debug_greg_t * gregs,
   ctx->edx = regs->edx;
   ctx->ecx = regs->ecx;
   ctx->eax = regs->eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_ARM)
   const ARM_CPU_REGISTERS * regs = &gregs->arm;
 
@@ -798,6 +800,8 @@ gum_qnx_parse_ucontext (const ucontext_t * uc,
   ctx->edx = cpu->edx;
   ctx->ecx = cpu->ecx;
   ctx->eax = cpu->eax;
+
+  ctx->xmm = NULL;
 #elif defined (HAVE_ARM)
   const ARM_CPU_REGISTERS * cpu = &uc->uc_mcontext.cpu;
   guint i;

--- a/gum/backend-windows/gumexceptor-windows.c
+++ b/gum/backend-windows/gumexceptor-windows.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2015-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -169,6 +169,9 @@ gum_exceptor_backend_dispatch (EXCEPTION_POINTERS * exception_info)
   }
 
   gum_windows_parse_context (context, cpu_context);
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+  cpu_context->xmm = (GumX86VectorReg *) &context->Xmm0;
+#endif
   ed.native_context = context;
 
   g_private_set (&gum_active_context_key, context);

--- a/gum/backend-windows/gumprocess-windows.c
+++ b/gum/backend-windows/gumprocess-windows.c
@@ -250,11 +250,15 @@ gum_process_modify_thread (GumThreadId thread_id,
   if (SuspendThread (thread) == (DWORD) -1)
     goto beach;
 
-  context.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+  context.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER |
+      CONTEXT_FLOATING_POINT;
   if (!GetThreadContext (thread, &context))
     goto beach;
 
   gum_windows_parse_context (&context, &cpu_context);
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+  cpu_context.xmm = (GumX86VectorReg *) &context.Xmm0;
+#endif
   func (thread_id, &cpu_context, user_data);
   gum_windows_unparse_context (&cpu_context, &context);
 
@@ -1159,6 +1163,8 @@ gum_windows_parse_context (const CONTEXT * context,
   cpu_context->edx = context->Edx;
   cpu_context->ecx = context->Ecx;
   cpu_context->eax = context->Eax;
+
+  cpu_context->xmm = NULL;
 #elif defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
   cpu_context->rip = context->Rip;
 
@@ -1179,6 +1185,8 @@ gum_windows_parse_context (const CONTEXT * context,
   cpu_context->rdx = context->Rdx;
   cpu_context->rcx = context->Rcx;
   cpu_context->rax = context->Rax;
+
+  cpu_context->xmm = NULL;
 #else
   guint i;
 

--- a/gum/backend-x86/gumcpucontext-x86.c
+++ b/gum/backend-x86/gumcpucontext-x86.c
@@ -1,10 +1,37 @@
 /*
- * Copyright (C) 2008-2017 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
 #include "gumdefs.h"
+
+#include <string.h>
+
+G_DEFINE_BOXED_TYPE (GumCpuContext, gum_cpu_context, gum_cpu_context_copy,
+    gum_cpu_context_free)
+
+GumCpuContext *
+gum_cpu_context_copy (const GumCpuContext * cpu_context)
+{
+  gsize vectors_size;
+  GumCpuContext * copy;
+
+  vectors_size = GUM_X86_XMM_REG_COUNT * sizeof (GumX86VectorReg);
+
+  copy = g_malloc (sizeof (GumCpuContext) + vectors_size);
+  *copy = *cpu_context;
+  copy->xmm = (GumX86VectorReg *) (copy + 1);
+  memcpy (copy->xmm, cpu_context->xmm, vectors_size);
+
+  return copy;
+}
+
+void
+gum_cpu_context_free (GumCpuContext * cpu_context)
+{
+  g_free (cpu_context);
+}
 
 gpointer
 gum_cpu_context_get_nth_argument (GumCpuContext * self,

--- a/gum/backend-x86/guminterceptor-x86.c
+++ b/gum/backend-x86/guminterceptor-x86.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  * Copyright (C) 2025 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -575,11 +576,13 @@ gum_emit_prolog (GumX86Writer * cw,
    * [cpu_flags]
    * [cpu_context] <-- xbx points to the start of the cpu_context
    * [alignment_padding]
-   * [extended_context]
+   * [extended_context] <-- cpu_context.xmm points into the fxsave image here
    */
   gum_x86_writer_put_pushfx (cw);
   gum_x86_writer_put_cld (cw); /* C ABI mandates this */
-  gum_x86_writer_put_pushax (cw); /* all of GumCpuContext except for xip */
+  gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP,
+      sizeof (((GumCpuContext *) NULL)->xmm)); /* GumCpuContext.xmm */
+  gum_x86_writer_put_pushax (cw); /* all of GumCpuContext except for xip/xmm */
   gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XSP,
       GUM_X86_XSP, -((gssize) sizeof (gpointer))); /* GumCpuContext.xip */
 
@@ -594,6 +597,12 @@ gum_emit_prolog (GumX86Writer * cw,
   gum_x86_writer_put_and_reg_u32 (cw, GUM_X86_XSP, (guint32) ~(16 - 1));
   gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 512);
   gum_x86_writer_put_bytes (cw, fxsave, sizeof (fxsave));
+
+  gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XAX,
+      GUM_X86_XSP, GUM_FXSAVE_OFFSET_XMM);
+  gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
+      GUM_X86_XBX, G_STRUCT_OFFSET (GumCpuContext, xmm),
+      GUM_X86_XAX);
 }
 
 static void
@@ -611,6 +620,8 @@ gum_emit_epilog (GumX86Writer * cw,
       GUM_X86_XSP, sizeof (gpointer)); /* discard
                                           GumCpuContext.xip */
   gum_x86_writer_put_popax (cw);
+  gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XSP, GUM_X86_XSP,
+      sizeof (((GumCpuContext *) NULL)->xmm)); /* discard GumCpuContext.xmm */
   gum_x86_writer_put_popfx (cw);
 
   if (point_cut == GUM_POINT_LEAVE)

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2009-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2010-2013 Karl Trygve Kalleberg <karltk@boblycat.org>
  * Copyright (C) 2020      Duy Phan Thanh <phanthanhduypr@gmail.com>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -70,6 +71,8 @@
 #endif
 #define GUM_MINIMAL_PROLOG_RETURN_OFFSET \
     ((GUM_STATE_PRESERVE_TOPMOST_REGISTER_INDEX + 2) * sizeof (gpointer))
+#define GUM_FULL_PROLOG_GPR_TOP_OFFSET \
+    (GUM_CPU_CONTEXT_OFFSET_XAX + sizeof (gpointer))
 #define GUM_FULL_PROLOG_RETURN_OFFSET \
     (sizeof (GumCpuContext) + sizeof (gpointer))
 #define GUM_X86_THUNK_ARGLIST_STACK_RESERVE 64 /* x64 ABI compatibility */
@@ -3511,7 +3514,9 @@ gum_exec_ctx_write_prolog_helper (GumExecCtx * ctx,
   }
   else /* GUM_PROLOG_FULL */
   {
-    gum_x86_writer_put_pushax (cw); /* All of GumCpuContext except for xip */
+    gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP,
+        sizeof (((GumCpuContext *) NULL)->xmm)); /* GumCpuContext.xmm */
+    gum_x86_writer_put_pushax (cw); /* All of GumCpuContext except xip/xmm */
     /* GumCpuContext.xip gets filled out later */
     gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XSP, GUM_X86_XSP,
         -(gssize) sizeof (gpointer));
@@ -3530,6 +3535,15 @@ gum_exec_ctx_write_prolog_helper (GumExecCtx * ctx,
   gum_x86_writer_put_and_reg_u32 (cw, GUM_X86_XSP, (guint32) ~(16 - 1));
   gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 512);
   gum_x86_writer_put_bytes (cw, fxsave, sizeof (fxsave));
+
+  if (type == GUM_PROLOG_FULL)
+  {
+    gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XAX,
+        GUM_X86_XSP, GUM_FXSAVE_OFFSET_XMM);
+    gum_x86_writer_put_mov_reg_offset_ptr_reg (cw,
+        GUM_X86_XBX, G_STRUCT_OFFSET (GumCpuContext, xmm),
+        GUM_X86_XAX);
+  }
 
   /*
    * Skip the YMM upper-half save on Windows 7 32-bit (WoW64) processes.
@@ -3633,6 +3647,8 @@ gum_exec_ctx_write_epilog_helper (GumExecCtx * ctx,
     gum_x86_writer_put_pop_reg (cw, GUM_X86_XAX); /* Discard
                                                      GumCpuContext.xip */
     gum_x86_writer_put_popax (cw);
+    gum_x86_writer_put_lea_reg_reg_offset (cw, GUM_X86_XSP, GUM_X86_XSP,
+        sizeof (((GumCpuContext *) NULL)->xmm)); /* Discard GumCpuContext.xmm */
   }
 
   gum_x86_writer_put_popfx (cw);
@@ -3858,20 +3874,20 @@ gum_exec_ctx_load_real_register_from_full_frame_into (GumExecCtx * ctx,
   if (source_meta >= GUM_X86_XAX && source_meta <= GUM_X86_XBX)
   {
     gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, target_register,
-        GUM_X86_XBX, sizeof (GumCpuContext) -
+        GUM_X86_XBX, GUM_FULL_PROLOG_GPR_TOP_OFFSET -
         ((source_meta - GUM_X86_XAX + 1) * sizeof (gpointer)));
   }
   else if (source_meta >= GUM_X86_XBP && source_meta <= GUM_X86_XDI)
   {
     gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, target_register,
-        GUM_X86_XBX, sizeof (GumCpuContext) -
+        GUM_X86_XBX, GUM_FULL_PROLOG_GPR_TOP_OFFSET -
         ((source_meta - GUM_X86_XAX + 1) * sizeof (gpointer)));
   }
 #if GLIB_SIZEOF_VOID_P == 8
   else if (source_meta >= GUM_X86_R8 && source_meta <= GUM_X86_R15)
   {
     gum_x86_writer_put_mov_reg_reg_offset_ptr (cw, target_register,
-        GUM_X86_XBX, sizeof (GumCpuContext) -
+        GUM_X86_XBX, GUM_FULL_PROLOG_GPR_TOP_OFFSET -
         ((source_meta - GUM_X86_RAX + 1) * sizeof (gpointer)));
   }
 #endif

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
- * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2023-2026 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
@@ -54,6 +54,7 @@ typedef struct _GumArgument GumArgument;
 typedef guint GumBranchHint;
 typedef struct _GumIA32CpuContext GumIA32CpuContext;
 typedef struct _GumX64CpuContext GumX64CpuContext;
+typedef union _GumX86VectorReg GumX86VectorReg;
 typedef struct _GumArmCpuContext GumArmCpuContext;
 typedef union _GumArmVectorReg GumArmVectorReg;
 typedef struct _GumArm64CpuContext GumArm64CpuContext;
@@ -69,6 +70,9 @@ typedef guint GumRelocationScenario;
  * GUM_DEFAULT_CS_MODE: (skip)
  */
 # define GUM_DEFAULT_CS_MODE CS_MODE_32
+# define GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS 1
+# define GUM_X86_XMM_REG_COUNT 8
+# define GUM_FXSAVE_OFFSET_XMM 160
 typedef GumIA32CpuContext GumCpuContext;
 #elif defined (_M_X64) || defined (__x86_64__)
 # define GUM_NATIVE_CPU GUM_CPU_AMD64
@@ -78,6 +82,9 @@ typedef GumIA32CpuContext GumCpuContext;
  * GUM_DEFAULT_CS_MODE: (skip)
  */
 # define GUM_DEFAULT_CS_MODE CS_MODE_64
+# define GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS 1
+# define GUM_X86_XMM_REG_COUNT 16
+# define GUM_FXSAVE_OFFSET_XMM 160
 typedef GumX64CpuContext GumCpuContext;
 #elif defined (_M_ARM) || defined (__arm__)
 # define GUM_NATIVE_CPU GUM_CPU_ARM
@@ -227,6 +234,13 @@ enum _GumBranchHint
   GUM_UNLIKELY
 };
 
+union _GumX86VectorReg
+{
+  guint8 q[16];
+  gdouble d[2];
+  gfloat s[4];
+};
+
 struct _GumIA32CpuContext
 {
   guint32 eip;
@@ -239,6 +253,8 @@ struct _GumIA32CpuContext
   guint32 edx;
   guint32 ecx;
   guint32 eax;
+
+  GumX86VectorReg * xmm;
 };
 
 struct _GumX64CpuContext
@@ -262,6 +278,8 @@ struct _GumX64CpuContext
   guint64 rdx;
   guint64 rcx;
   guint64 rax;
+
+  GumX86VectorReg * xmm;
 };
 
 union _GumArmVectorReg
@@ -577,6 +595,12 @@ GUM_API void gum_cpu_context_replace_nth_argument (GumCpuContext * self,
 GUM_API gpointer gum_cpu_context_get_return_value (GumCpuContext * self);
 GUM_API void gum_cpu_context_replace_return_value (GumCpuContext * self,
     gpointer value);
+
+#define GUM_TYPE_CPU_CONTEXT (gum_cpu_context_get_type ())
+GUM_API GType gum_cpu_context_get_type (void) G_GNUC_CONST;
+GUM_API GumCpuContext * gum_cpu_context_copy (
+    const GumCpuContext * cpu_context);
+GUM_API void gum_cpu_context_free (GumCpuContext * cpu_context);
 
 GUM_API GType gum_address_get_type (void) G_GNUC_CONST;
 

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -130,6 +130,9 @@ struct _GumInvocationStackEntry
   gpointer stack_address;
   GumInvocationContext invocation_context;
   GumCpuContext cpu_context;
+#ifdef GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS
+  GumX86VectorReg cpu_context_vectors[GUM_X86_XMM_REG_COUNT];
+#endif
   guint8 listener_invocation_data[GUM_MAX_LISTENERS_PER_FUNCTION]
       [GUM_MAX_LISTENER_DATA];
   gboolean calling_replacement;
@@ -229,6 +232,8 @@ static void gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
     gpointer live_stack_address);
 static void gum_invocation_stack_reap_unwound_above (
     GumInvocationStack * stack, GumFunctionContext * returning_ctx);
+static void gum_invocation_stack_entry_snapshot_cpu_context (
+    GumInvocationStackEntry * entry, const GumCpuContext * cpu_context);
 static gboolean gum_invocation_stack_entry_was_unwound_past (
     const GumInvocationStackEntry * entry, gpointer live_stack_address);
 static void gum_invocation_stack_entry_release_trampoline (
@@ -2038,7 +2043,7 @@ _gum_function_context_begin_invocation (GumFunctionContext * function_ctx,
   if (function_ctx->replacement_function != NULL)
   {
     stack_entry->calling_replacement = TRUE;
-    stack_entry->cpu_context = *cpu_context;
+    gum_invocation_stack_entry_snapshot_cpu_context (stack_entry, cpu_context);
     stack_entry->original_system_error = system_error;
     invocation_ctx->cpu_context = &stack_entry->cpu_context;
     invocation_ctx->backend = &interceptor_ctx->replacement_backend;
@@ -2503,6 +2508,19 @@ gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
     gum_invocation_stack_entry_release_trampoline (entry);
     g_array_set_size (stack, stack->len - 1);
   }
+}
+
+static void
+gum_invocation_stack_entry_snapshot_cpu_context (
+    GumInvocationStackEntry * entry,
+    const GumCpuContext * cpu_context)
+{
+  entry->cpu_context = *cpu_context;
+#ifdef GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS
+  gum_memcpy (entry->cpu_context_vectors, cpu_context->xmm,
+      sizeof (entry->cpu_context_vectors));
+  entry->cpu_context.xmm = entry->cpu_context_vectors;
+#endif
 }
 
 static gboolean

--- a/tests/core/interceptor-fixture.c
+++ b/tests/core/interceptor-fixture.c
@@ -111,6 +111,9 @@ struct _ListenerContext
   gsize last_seen_argument;
   gpointer last_return_value;
   GumCpuContext last_on_enter_cpu_context;
+#ifdef GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS
+  GumX86VectorReg last_on_enter_cpu_context_vectors[GUM_X86_XMM_REG_COUNT];
+#endif
 };
 
 struct _TestInterceptorFixture
@@ -323,6 +326,12 @@ listener_context_on_enter (ListenerContext * self,
   self->last_seen_argument = (gsize)
       gum_invocation_context_get_nth_argument (context, 0);
   self->last_on_enter_cpu_context = *context->cpu_context;
+#ifdef GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS
+  memcpy (self->last_on_enter_cpu_context_vectors, context->cpu_context->xmm,
+      sizeof (self->last_on_enter_cpu_context_vectors));
+  self->last_on_enter_cpu_context.xmm =
+      self->last_on_enter_cpu_context_vectors;
+#endif
 
   self->last_thread_id = gum_invocation_context_get_thread_id (context);
 }

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -52,6 +53,7 @@ TESTLIST_BEGIN (interceptor)
   TESTENTRY (function_arguments)
   TESTENTRY (function_return_value)
   TESTENTRY (function_cpu_context_on_enter)
+  TESTENTRY (function_cpu_context_xmm_on_enter)
   TESTENTRY (ignore_current_thread)
   TESTENTRY (ignore_current_thread_nested)
   TESTENTRY (ignore_other_threads)
@@ -93,6 +95,9 @@ static gpointer replacement_malloc (gsize size);
 static gpointer replacement_target_function (GString * str);
 static gpointer (* target_function_fast) (GString * str) = NULL;
 static gpointer replacement_target_function_fast (GString * str);
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+static gdouble gum_test_xmm_clobber (gdouble x);
+#endif
 
 TESTCASE (attach_one)
 {
@@ -309,6 +314,25 @@ TESTCASE (function_cpu_context_on_enter)
   }
 #else
   g_print ("<skipping, missing code for current architecture> ");
+#endif
+}
+
+TESTCASE (function_cpu_context_xmm_on_enter)
+{
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+  GumCpuContext * cpu_context;
+
+  interceptor_fixture_attach (fixture, 0, gum_test_xmm_clobber, 'a', 'b');
+
+  g_assert_cmpfloat (gum_test_xmm_clobber (4.5), ==, 9.0);
+  g_assert_cmpstr (fixture->result->str, ==, "ab");
+
+  cpu_context = &fixture->listener_context[0]->last_on_enter_cpu_context;
+  g_assert_cmpfloat (cpu_context->xmm[0].d[0], ==, 4.5);
+
+  interceptor_fixture_detach (fixture, 0);
+#else
+  g_print ("<skipping, not applicable to current architecture> ");
 #endif
 }
 
@@ -1190,3 +1214,13 @@ TESTCASE (fast_interceptor_performance)
   g_print ("<duration_fast=%f duration_default=%f ratio=%f> ",
       duration_fast, duration_default, duration_fast / duration_default);
 }
+
+#if defined (HAVE_I386) && GLIB_SIZEOF_VOID_P == 8
+
+static gdouble GUM_NOINLINE
+gum_test_xmm_clobber (gdouble x)
+{
+  return x * 2.0;
+}
+
+#endif

--- a/tests/lowlevelhelpers.c
+++ b/tests/lowlevelhelpers.c
@@ -443,7 +443,7 @@ gum_emit_test_clobber_regs_function (gpointer mem,
 # if GLIB_SIZEOF_VOID_P == 4
   /* Load first argument */
   gum_x86_writer_put_mov_reg_reg_offset_ptr (&cw, GUM_X86_ECX,
-      GUM_X86_ESP, sizeof (GumCpuContext) + 4);
+      GUM_X86_ESP, GUM_CPU_CONTEXT_OFFSET_XAX + sizeof (gpointer) + 4);
 
   gum_x86_writer_put_mov_reg_reg_offset_ptr (&cw, GUM_X86_EAX,
       GUM_X86_ECX, G_STRUCT_OFFSET (GumCpuContext, eax));
@@ -519,7 +519,7 @@ gum_emit_test_clobber_regs_function (gpointer mem,
 # if GLIB_SIZEOF_VOID_P == 4
   /* Load second argument */
   gum_x86_writer_put_mov_reg_reg_offset_ptr (&cw, GUM_X86_ECX,
-      GUM_X86_ESP, 4 + sizeof (GumCpuContext) + 8);
+      GUM_X86_ESP, 4 + GUM_CPU_CONTEXT_OFFSET_XAX + sizeof (gpointer) + 8);
 
   gum_x86_writer_put_mov_reg_offset_ptr_reg (&cw,
       GUM_X86_ECX, G_STRUCT_OFFSET (GumCpuContext, eax),

--- a/vapi/frida-gum-1.0.vapi
+++ b/vapi/frida-gum-1.0.vapi
@@ -520,6 +520,14 @@ namespace Gum {
 		public uint32 edx;
 		public uint32 ecx;
 		public uint32 eax;
+
+		public Gum.X86VectorReg * xmm;
+	}
+
+	public struct X86VectorReg {
+		public uint8 q[16];
+		public double d[2];
+		public float s[4];
 	}
 
 	public struct X64CpuContext {
@@ -542,6 +550,8 @@ namespace Gum {
 		public uint64 rdx;
 		public uint64 rcx;
 		public uint64 rax;
+
+		public Gum.X86VectorReg * xmm;
 	}
 
 	public struct ArmCpuContext {


### PR DESCRIPTION
Add an xmm[16] field to GumX64CpuContext, backed by a new GumX64VectorReg union. The Interceptor prolog harvests XMM0-15 from the fxsave image into the context, and the epilog folds any changes back before fxrstor.

Stalker's full-prolog offsets now derive from
GUM_FULL_PROLOG_FRAME_SIZE (based on the XAX offset) rather than sizeof (GumCpuContext), so the new trailing field doesn't shift the pushed register frame.

Exposed through GumJS (QuickJS and V8) accessors and the Vala bindings, and covered by a new interceptor test.