### PR TITLE
Re-enable CodeSegment on newer XNUs

### DIFF
--- a/gum/backend-darwin/gumcodesegment-darwin.c
+++ b/gum/backend-darwin/gumcodesegment-darwin.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2024 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -147,7 +148,12 @@ gum_code_segment_is_supported (void)
 {
 #if (defined (HAVE_MACOS) && defined (HAVE_ARM64)) || \
     defined (HAVE_IOS) || defined (HAVE_TVOS)
-  /* Not going to work on newer kernels, such as on iOS >= 15.6.1. */
+  /*
+   * Broke on newer kernels, such as on iOS >= 15.6.1, but works again on
+   * iOS >= 17.6 (xnu >= 10063.142.1).
+   */
+  if (gum_darwin_check_xnu_version (10063, 142, 1))
+    return TRUE;
   return !gum_darwin_check_xnu_version (8020, 142, 0);
 #else
   return FALSE;


### PR DESCRIPTION
The vm_remap OVERWRITE trick that ef6f67bb disabled for kernels >= 8020.142.0 (iOS >= 15.6.1) works again on newer iOS and macOS versions. My lowest test device is ipadOS 17.6 so that was chosen as cut-off. Test suite also runs on macOS 26.5.1

tested:
macOS 26.5.1: full suite.
ipadOS 17.6 (palera1n):  `/Core/Interceptor` and  `/Core/MemoryAccessMonitor`