### PR TITLE
module-registry: discard function contexts when module unloads

### DIFF
--- a/gum/guminterceptor-priv.h
+++ b/gum/guminterceptor-priv.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
+ * Copyright (C) 2026 Sam Sun <samsun@nvidia.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -12,6 +13,7 @@
 #include "guminterceptor.h"
 
 #include "gumcodeallocator.h"
+#include "gummemory.h"
 #include "gumspinlock.h"
 #include "gumtls.h"
 
@@ -79,6 +81,9 @@ struct _GumFunctionContext
 
 G_GNUC_INTERNAL void _gum_interceptor_init (void);
 G_GNUC_INTERNAL void _gum_interceptor_deinit (void);
+
+G_GNUC_INTERNAL void _gum_interceptor_forget_all_hooks_in_range (
+    const GumMemoryRange * range);
 
 G_GNUC_INTERNAL gboolean _gum_function_context_begin_invocation (
     GumFunctionContext * function_ctx, GumCpuContext * cpu_context,

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2008 Christian Berentsen <jc.berentsen@gmail.com>
  * Copyright (C) 2024-2025 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
+ * Copyright (C) 2026 Sam Sun <samsun@nvidia.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -193,6 +194,7 @@ static GumFunctionContext * gum_function_context_new (
     GumInterceptorType type);
 static void gum_function_context_finalize (GumFunctionContext * function_ctx);
 static void gum_function_context_destroy (GumFunctionContext * function_ctx);
+static void gum_function_context_discard (GumFunctionContext * function_ctx);
 static void gum_function_context_perform_destroy (
     GumFunctionContext * function_ctx);
 static gboolean gum_function_context_is_empty (
@@ -245,6 +247,8 @@ static gpointer gum_interceptor_resolve (GumInterceptor * self,
     gpointer address);
 static gboolean gum_interceptor_has (GumInterceptor * self,
     gpointer function_address);
+static void gum_interceptor_discard_function_contexts_in_range (
+    GumInterceptor * self, const GumMemoryRange * range);
 
 static gpointer gum_page_address_from_pointer (gpointer ptr);
 static gint gum_page_address_compare (gconstpointer * a, gconstpointer * b);
@@ -1323,6 +1327,56 @@ gum_interceptor_detect_hook_size (gconstpointer code,
   return _gum_interceptor_backend_detect_hook_size (code, capstone, insn);
 }
 
+void
+_gum_interceptor_forget_all_hooks_in_range (const GumMemoryRange * range)
+{
+  GumInterceptor * interceptor;
+
+  g_mutex_lock (&_gum_interceptor_lock);
+  interceptor = (_the_interceptor != NULL)
+      ? g_object_ref (_the_interceptor)
+      : NULL;
+  g_mutex_unlock (&_gum_interceptor_lock);
+
+  if (interceptor == NULL)
+    return;
+
+  gum_interceptor_discard_function_contexts_in_range (interceptor, range);
+
+  g_object_unref (interceptor);
+}
+
+static void
+gum_interceptor_discard_function_contexts_in_range (
+    GumInterceptor * self,
+    const GumMemoryRange * range)
+{
+  GHashTableIter iter;
+  gpointer value;
+
+  GUM_INTERCEPTOR_LOCK (self);
+  gum_interceptor_transaction_begin (&self->current_transaction);
+
+  g_hash_table_iter_init (&iter, self->function_by_address);
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+  {
+    GumFunctionContext * function_ctx = value;
+    GumAddress function_address = GUM_ADDRESS (
+        _gum_interceptor_backend_get_function_address (function_ctx));
+
+    if (!GUM_MEMORY_RANGE_INCLUDES (range, function_address))
+      continue;
+
+    self->current_transaction.is_dirty = TRUE;
+
+    g_hash_table_iter_steal (&iter);
+    gum_function_context_discard (function_ctx);
+  }
+
+  gum_interceptor_transaction_end (&self->current_transaction);
+  GUM_INTERCEPTOR_UNLOCK (self);
+}
+
 gpointer
 _gum_interceptor_peek_top_caller_return_address (void)
 {
@@ -1745,6 +1799,19 @@ gum_function_context_destroy (GumFunctionContext * function_ctx)
     gum_interceptor_transaction_schedule_update (transaction, function_ctx,
         gum_interceptor_deactivate);
   }
+
+  gum_interceptor_transaction_schedule_destroy (transaction, function_ctx,
+      (GDestroyNotify) gum_function_context_perform_destroy, function_ctx);
+}
+
+static void
+gum_function_context_discard (GumFunctionContext * function_ctx)
+{
+  GumInterceptorTransaction * transaction =
+      &function_ctx->interceptor->current_transaction;
+
+  function_ctx->destroyed = TRUE;
+  function_ctx->activated = FALSE;
 
   gum_interceptor_transaction_schedule_destroy (transaction, function_ctx,
       (GDestroyNotify) gum_function_context_perform_destroy, function_ctx);

--- a/gum/gummoduleregistry.c
+++ b/gum/gummoduleregistry.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2026 Sam Sun <samsun@nvidia.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -8,6 +9,7 @@
 
 #include "gum-init.h"
 #include "gumcloak.h"
+#include "guminterceptor-priv.h"
 #include "gummoduleregistry-priv.h"
 
 #define GUM_MODULE_REGISTRY_LOCK(r) g_rec_mutex_lock (&(r)->mutex)
@@ -382,6 +384,8 @@ _gum_module_registry_unregister (GumModuleRegistry * self,
   }
 
   GUM_MODULE_REGISTRY_UNLOCK (self);
+
+  _gum_interceptor_forget_all_hooks_in_range (gum_module_get_range (mod));
 
   if (being_observed && !gum_is_cloaked_module (mod))
     g_signal_emit (self, gum_module_registry_signals[MODULE_REMOVED], 0, mod);

--- a/tests/core/moduleregistry.c
+++ b/tests/core/moduleregistry.c
@@ -1,12 +1,19 @@
 /*
  * Copyright (C) 2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2026 Sam Sun <samsun@nvidia.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
 #include "gummoduleregistry.h"
 
+#include "guminterceptor.h"
 #include "testutil.h"
+
+#ifdef HAVE_LINUX
+# include "interceptor-callbacklistener.h"
+# include <dlfcn.h>
+#endif
 
 #define TESTCASE(NAME) \
     void test_module_registry_ ## NAME (void)
@@ -15,12 +22,33 @@
 
 TESTLIST_BEGIN (module_registry)
   TESTENTRY (module_registry_should_emit_signal_on_add)
+  TESTENTRY (hooks_should_be_discarded_when_module_unloads)
 TESTLIST_END ()
 
 static void on_module_added (GumModuleRegistry * registry, GumModule * module,
     gpointer user_data);
 static void on_module_removed (GumModuleRegistry * registry, GumModule * module,
     gpointer user_data);
+
+#ifdef HAVE_LINUX
+
+# define GUM_TARGET_MODULE_FILENAME "module-registry-target.so"
+
+typedef struct _TestModuleHooks TestModuleHooks;
+
+struct _TestModuleHooks
+{
+  gboolean seen_add;
+  gboolean seen_remove;
+};
+
+static void on_target_module_added (GumModuleRegistry * registry,
+    GumModule * module, gpointer user_data);
+static void on_target_module_removed (GumModuleRegistry * registry,
+    GumModule * module, gpointer user_data);
+static gboolean is_target_module (GumModule * module);
+
+#endif
 
 TESTCASE (module_registry_should_emit_signal_on_add)
 {
@@ -42,6 +70,65 @@ TESTCASE (module_registry_should_emit_signal_on_add)
     g_usleep (60 * G_USEC_PER_SEC);
 }
 
+TESTCASE (hooks_should_be_discarded_when_module_unloads)
+{
+#ifdef HAVE_LINUX
+  GumModuleRegistry * registry;
+  GumInterceptor * interceptor;
+  TestCallbackListener * listener;
+  TestModuleHooks hooks = { 0, };
+  gulong added_handler, removed_handler;
+  gchar * data_dir, * target_path;
+  void * handle;
+  gpointer target;
+  GumAttachReturn result;
+
+  registry = gum_module_registry_obtain ();
+  interceptor = gum_interceptor_obtain ();
+  listener = test_callback_listener_new ();
+
+  added_handler = g_signal_connect (registry, "module-added",
+      G_CALLBACK (on_target_module_added), &hooks);
+  removed_handler = g_signal_connect (registry, "module-removed",
+      G_CALLBACK (on_target_module_removed), &hooks);
+
+  data_dir = test_util_get_data_dir ();
+  target_path = g_build_filename (data_dir, GUM_TARGET_MODULE_FILENAME, NULL);
+
+  handle = dlopen (target_path, RTLD_NOW | RTLD_LOCAL);
+  g_assert_nonnull (handle);
+  g_assert_true (hooks.seen_add);
+
+  target = dlsym (handle, "gum_module_registry_target_function");
+  g_assert_nonnull (target);
+
+  result = gum_interceptor_attach (interceptor, target,
+      GUM_INVOCATION_LISTENER (listener), NULL);
+  g_assert_cmpint (result, ==, GUM_ATTACH_OK);
+
+  dlclose (handle);
+
+  /*
+   * If the C library unloaded the module (glibc does; musl keeps it resident),
+   * its live hook must have been discarded without restoring the now-unmapped
+   * prologue, so detaching afterwards has to be a safe no-op.
+   */
+  gum_interceptor_detach (interceptor, GUM_INVOCATION_LISTENER (listener));
+
+  if (!hooks.seen_remove)
+    g_test_skip ("dlclose did not unload the module on this platform");
+
+  g_signal_handler_disconnect (registry, added_handler);
+  g_signal_handler_disconnect (registry, removed_handler);
+  g_object_unref (listener);
+
+  g_free (target_path);
+  g_free (data_dir);
+#else
+  g_test_skip ("only supported on Linux");
+#endif
+}
+
 static void
 on_module_added (GumModuleRegistry * registry,
                  GumModule * module,
@@ -57,3 +144,36 @@ on_module_removed (GumModuleRegistry * registry,
 {
   g_printerr ("%s: path=\"%s\"\n", G_STRFUNC, gum_module_get_path (module));
 }
+
+#ifdef HAVE_LINUX
+
+static void
+on_target_module_added (GumModuleRegistry * registry,
+                        GumModule * module,
+                        gpointer user_data)
+{
+  TestModuleHooks * hooks = user_data;
+
+  if (is_target_module (module))
+    hooks->seen_add = TRUE;
+}
+
+static void
+on_target_module_removed (GumModuleRegistry * registry,
+                          GumModule * module,
+                          gpointer user_data)
+{
+  TestModuleHooks * hooks = user_data;
+
+  if (is_target_module (module))
+    hooks->seen_remove = TRUE;
+}
+
+static gboolean
+is_target_module (GumModule * module)
+{
+  return g_str_has_suffix (gum_module_get_path (module),
+      G_DIR_SEPARATOR_S GUM_TARGET_MODULE_FILENAME);
+}
+
+#endif

--- a/tests/data/meson.build
+++ b/tests/data/meson.build
@@ -39,6 +39,10 @@ if host_os_family != 'windows'
   shared_module('prebuiltcmodule', 'prebuiltcmodule.c',
     name_prefix: '',
   )
+
+  shared_module('module-registry-target', 'module-registry-target.c',
+    name_prefix: '',
+  )
 else
   test_data_stamp = []
 endif

--- a/tests/data/module-registry-target.c
+++ b/tests/data/module-registry-target.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2026 Sam Sun <samsun@nvidia.com>
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+int
+gum_module_registry_target_function (void)
+{
+  return 42;
+}


### PR DESCRIPTION
Discard function context when unloading modules.

Added a global registry for interceptor instances.

Added test that tests if the unmapped code will be touched during interceptor destruction.