### PR TITLE
tests: Unload script before unref in bytecode test

### DIFF
--- a/tests/gumjs/script.c
+++ b/tests/gumjs/script.c
@@ -10998,6 +10998,8 @@ TESTCASE (script_can_be_compiled_to_bytecode)
 
     EXPECT_NO_MESSAGES ();
 
+    gum_script_unload_sync (script, NULL);
+
     g_object_unref (script);
   }
   else


### PR DESCRIPTION
script_can_be_compiled_to_bytecode loaded a script then dropped its last reference without unloading first. Unref'ing a loaded GumQuickScript defers teardown to an async multi-hop unload on the JS thread, so its GumExceptor release is still in flight when the next test runs. Under load this pollutes the shared exceptor refcount sampled by script_should_not_leak_if_destroyed_before_load, making it fail intermittently (ref_count 3 vs expected 2).

Call gum_script_unload_sync() before g_object_unref(), matching the fixture teardown convention.