### PR TITLE
x86: Preserve AVX-512 state in Stalker

### DIFF
--- a/gum/arch-x86/gumx86writer.c
+++ b/gum/arch-x86/gumx86writer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2009-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  *
@@ -79,6 +79,12 @@ static gboolean gum_x86_writer_put_near_jmp (GumX86Writer * self,
 static void gum_x86_writer_put_ud2 (GumX86Writer * self);
 static gboolean gum_x86_writer_put_fx_save_or_restore_reg_ptr (
     GumX86Writer * self, guint8 operation, GumX86Reg reg);
+static gboolean gum_x86_writer_put_vector_base_offset (GumX86Writer * self,
+    guint map, guint pp, gboolean w, guint length, guint8 opcode, guint reg,
+    guint vvvv, guint tuple, GumX86Reg base_reg, gssize offset,
+    gboolean has_imm, guint8 imm);
+static gboolean gum_x86_writer_put_kmov_base_offset (GumX86Writer * self,
+    guint8 opcode, guint mask_reg, GumX86Reg base_reg, gssize offset);
 static void gum_x86_writer_describe_cpu_reg (GumX86Writer * self,
     GumX86Reg reg, GumX86RegInfo * ri);
 
@@ -3082,6 +3088,174 @@ gum_x86_writer_put_fx_save_or_restore_reg_ptr (GumX86Writer * self,
 
   if (ri.index == 4)
     gum_x86_writer_put_u8 (self, 0x24);
+
+  return TRUE;
+}
+
+gboolean
+gum_x86_writer_put_vmovdqu64_reg_offset_ptr_zmm (GumX86Writer * self,
+                                                 GumX86Reg dst_base,
+                                                 gssize dst_offset,
+                                                 guint src_zmm)
+{
+  return gum_x86_writer_put_vector_base_offset (self, 1, 2, TRUE, 2, 0x7f,
+      src_zmm, 0, 64, dst_base, dst_offset, FALSE, 0);
+}
+
+gboolean
+gum_x86_writer_put_vmovdqu64_zmm_reg_offset_ptr (GumX86Writer * self,
+                                                 guint dst_zmm,
+                                                 GumX86Reg src_base,
+                                                 gssize src_offset)
+{
+  return gum_x86_writer_put_vector_base_offset (self, 1, 2, TRUE, 2, 0x6f,
+      dst_zmm, 0, 64, src_base, src_offset, FALSE, 0);
+}
+
+gboolean
+gum_x86_writer_put_vextracti64x4_reg_offset_ptr_zmm (GumX86Writer * self,
+                                                     GumX86Reg dst_base,
+                                                     gssize dst_offset,
+                                                     guint src_zmm,
+                                                     guint8 imm)
+{
+  return gum_x86_writer_put_vector_base_offset (self, 3, 1, TRUE, 2, 0x3b,
+      src_zmm, 0, 32, dst_base, dst_offset, TRUE, imm);
+}
+
+gboolean
+gum_x86_writer_put_vinserti64x4_zmm_reg_offset_ptr (GumX86Writer * self,
+                                                    guint dst_zmm,
+                                                    GumX86Reg src_base,
+                                                    gssize src_offset,
+                                                    guint8 imm)
+{
+  return gum_x86_writer_put_vector_base_offset (self, 3, 1, TRUE, 2, 0x3a,
+      dst_zmm, dst_zmm, 32, src_base, src_offset, TRUE, imm);
+}
+
+gboolean
+gum_x86_writer_put_kmovq_reg_offset_ptr_kreg (GumX86Writer * self,
+                                              GumX86Reg dst_base,
+                                              gssize dst_offset,
+                                              guint src_kreg)
+{
+  return gum_x86_writer_put_kmov_base_offset (self, 0x91, src_kreg, dst_base,
+      dst_offset);
+}
+
+gboolean
+gum_x86_writer_put_kmovq_kreg_reg_offset_ptr (GumX86Writer * self,
+                                              guint dst_kreg,
+                                              GumX86Reg src_base,
+                                              gssize src_offset)
+{
+  return gum_x86_writer_put_kmov_base_offset (self, 0x90, dst_kreg, src_base,
+      src_offset);
+}
+
+static gboolean
+gum_x86_writer_put_vector_base_offset (GumX86Writer * self,
+                                       guint map,
+                                       guint pp,
+                                       gboolean w,
+                                       guint length,
+                                       guint8 opcode,
+                                       guint reg,
+                                       guint vvvv,
+                                       guint tuple,
+                                       GumX86Reg base_reg,
+                                       gssize offset,
+                                       gboolean has_imm,
+                                       guint8 imm)
+{
+  GumX86RegInfo base;
+  guint r, x, b, r_prime, vvvv_field, v_prime, mod;
+  gboolean base_forces_disp, has_disp, disp_fits_in_i8;
+
+  gum_x86_writer_describe_cpu_reg (self, base_reg, &base);
+  if (base.width != 64)
+    return FALSE;
+
+  base_forces_disp = base.meta == GUM_X86_META_XBP;
+  has_disp = offset != 0 || base_forces_disp;
+  disp_fits_in_i8 = has_disp && offset % (gssize) tuple == 0 &&
+      GUM_IS_WITHIN_INT8_RANGE (offset / (gssize) tuple);
+  mod = !has_disp ? 0 : (disp_fits_in_i8 ? 1 : 2);
+
+  r = (reg & 8) ? 0 : 1;
+  x = 1;
+  b = base.index_is_extended ? 0 : 1;
+  r_prime = (reg & 16) ? 0 : 1;
+  vvvv_field = ~vvvv & 0xf;
+  v_prime = (vvvv & 16) ? 0 : 1;
+
+  gum_x86_writer_put_u8 (self, 0x62);
+  gum_x86_writer_put_u8 (self,
+      (r << 7) | (x << 6) | (b << 5) | (r_prime << 4) | (map & 0x3));
+  gum_x86_writer_put_u8 (self,
+      (w ? 0x80 : 0) | (vvvv_field << 3) | (1 << 2) | (pp & 0x3));
+  gum_x86_writer_put_u8 (self, ((length & 0x3) << 5) | (v_prime << 3));
+  gum_x86_writer_put_u8 (self, opcode);
+  gum_x86_writer_put_u8 (self,
+      (mod << 6) | ((reg & 0x7) << 3) | (base.index & 0x7));
+
+  if (base.index == 4)
+    gum_x86_writer_put_u8 (self, 0x24);
+
+  if (mod == 1)
+    gum_x86_writer_put_s8 (self, (gint8) (offset / (gssize) tuple));
+  else if (mod == 2)
+  {
+    *((gint32 *) self->code) = GINT32_TO_LE (offset);
+    gum_x86_writer_commit (self, 4);
+  }
+
+  if (has_imm)
+    gum_x86_writer_put_u8 (self, imm);
+
+  return TRUE;
+}
+
+static gboolean
+gum_x86_writer_put_kmov_base_offset (GumX86Writer * self,
+                                     guint8 opcode,
+                                     guint mask_reg,
+                                     GumX86Reg base_reg,
+                                     gssize offset)
+{
+  GumX86RegInfo base;
+  guint b, mod;
+  gboolean base_forces_disp, has_disp, disp_fits_in_i8;
+
+  gum_x86_writer_describe_cpu_reg (self, base_reg, &base);
+  if (base.width != 64)
+    return FALSE;
+
+  base_forces_disp = base.meta == GUM_X86_META_XBP;
+  has_disp = offset != 0 || base_forces_disp;
+  disp_fits_in_i8 = has_disp && GUM_IS_WITHIN_INT8_RANGE (offset);
+  mod = !has_disp ? 0 : (disp_fits_in_i8 ? 1 : 2);
+
+  b = base.index_is_extended ? 0 : 1;
+
+  gum_x86_writer_put_u8 (self, 0xc4);
+  gum_x86_writer_put_u8 (self, (1 << 7) | (1 << 6) | (b << 5) | 0x01);
+  gum_x86_writer_put_u8 (self, (1 << 7) | (0xf << 3));
+  gum_x86_writer_put_u8 (self, opcode);
+  gum_x86_writer_put_u8 (self,
+      (mod << 6) | ((mask_reg & 0x7) << 3) | (base.index & 0x7));
+
+  if (base.index == 4)
+    gum_x86_writer_put_u8 (self, 0x24);
+
+  if (mod == 1)
+    gum_x86_writer_put_s8 (self, (gint8) offset);
+  else if (mod == 2)
+  {
+    *((gint32 *) self->code) = GINT32_TO_LE (offset);
+    gum_x86_writer_commit (self, 4);
+  }
 
   return TRUE;
 }

--- a/gum/arch-x86/gumx86writer.h
+++ b/gum/arch-x86/gumx86writer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2009-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  *
@@ -356,6 +356,21 @@ GUM_API gboolean gum_x86_writer_put_fxsave_reg_ptr (GumX86Writer * self,
     GumX86Reg reg);
 GUM_API gboolean gum_x86_writer_put_fxrstor_reg_ptr (GumX86Writer * self,
     GumX86Reg reg);
+
+GUM_API gboolean gum_x86_writer_put_vmovdqu64_reg_offset_ptr_zmm (
+    GumX86Writer * self, GumX86Reg dst_base, gssize dst_offset, guint src_zmm);
+GUM_API gboolean gum_x86_writer_put_vmovdqu64_zmm_reg_offset_ptr (
+    GumX86Writer * self, guint dst_zmm, GumX86Reg src_base, gssize src_offset);
+GUM_API gboolean gum_x86_writer_put_vextracti64x4_reg_offset_ptr_zmm (
+    GumX86Writer * self, GumX86Reg dst_base, gssize dst_offset, guint src_zmm,
+    guint8 imm);
+GUM_API gboolean gum_x86_writer_put_vinserti64x4_zmm_reg_offset_ptr (
+    GumX86Writer * self, guint dst_zmm, GumX86Reg src_base, gssize src_offset,
+    guint8 imm);
+GUM_API gboolean gum_x86_writer_put_kmovq_reg_offset_ptr_kreg (
+    GumX86Writer * self, GumX86Reg dst_base, gssize dst_offset, guint src_kreg);
+GUM_API gboolean gum_x86_writer_put_kmovq_kreg_reg_offset_ptr (
+    GumX86Writer * self, guint dst_kreg, GumX86Reg src_base, gssize src_offset);
 
 GUM_API void gum_x86_writer_put_u8 (GumX86Writer * self, guint8 value);
 GUM_API void gum_x86_writer_put_s8 (GumX86Writer * self, gint8 value);

--- a/gum/backend-x86/gumstalker-x86.c
+++ b/gum/backend-x86/gumstalker-x86.c
@@ -3558,6 +3558,28 @@ gum_exec_ctx_write_prolog_helper (GumExecCtx * ctx,
   {
     gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 0x100);
     gum_x86_writer_put_bytes (cw, upper_ymm_saver, sizeof (upper_ymm_saver));
+
+#if GLIB_SIZEOF_VOID_P == 8
+    if ((ctx->stalker->cpu_features & GUM_CPU_AVX512) != 0)
+    {
+      guint i;
+
+      gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 16 * 32);
+      for (i = 0; i != 16; i++)
+        gum_x86_writer_put_vextracti64x4_reg_offset_ptr_zmm (cw, GUM_X86_XSP,
+            i * 32, i, 1);
+
+      gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 16 * 64);
+      for (i = 16; i != 32; i++)
+        gum_x86_writer_put_vmovdqu64_reg_offset_ptr_zmm (cw, GUM_X86_XSP,
+            (i - 16) * 64, i);
+
+      gum_x86_writer_put_sub_reg_imm (cw, GUM_X86_XSP, 8 * 8);
+      for (i = 0; i != 8; i++)
+        gum_x86_writer_put_kmovq_reg_offset_ptr_kreg (cw, GUM_X86_XSP,
+            i * 8, i);
+    }
+#endif
   }
 
   /* Jump to our caller but leave it on the stack */
@@ -3618,6 +3640,27 @@ gum_exec_ctx_write_epilog_helper (GumExecCtx * ctx,
   if ((ctx->stalker->cpu_features & GUM_CPU_AVX2) != 0 &&
       !_gum_windows_is_win7_wow64 ())
   {
+#if GLIB_SIZEOF_VOID_P == 8
+    if ((ctx->stalker->cpu_features & GUM_CPU_AVX512) != 0)
+    {
+      guint i;
+
+      for (i = 0; i != 8; i++)
+        gum_x86_writer_put_kmovq_kreg_reg_offset_ptr (cw, i, GUM_X86_XSP,
+            i * 8);
+      gum_x86_writer_put_add_reg_imm (cw, GUM_X86_XSP, 8 * 8);
+
+      for (i = 16; i != 32; i++)
+        gum_x86_writer_put_vmovdqu64_zmm_reg_offset_ptr (cw, i, GUM_X86_XSP,
+            (i - 16) * 64);
+      gum_x86_writer_put_add_reg_imm (cw, GUM_X86_XSP, 16 * 64);
+
+      for (i = 0; i != 16; i++)
+        gum_x86_writer_put_vinserti64x4_zmm_reg_offset_ptr (cw, i, GUM_X86_XSP,
+            i * 32, 1);
+      gum_x86_writer_put_add_reg_imm (cw, GUM_X86_XSP, 16 * 32);
+    }
+#endif
     gum_x86_writer_put_bytes (cw, upper_ymm_restorer,
         sizeof (upper_ymm_restorer));
     gum_x86_writer_put_add_reg_imm (cw, GUM_X86_XSP, 0x100);

--- a/gum/gum.c
+++ b/gum/gum.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 Ole André Vadla Ravnås <oleavr@nowsecure.com>
+ * Copyright (C) 2008-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Stefano Moioli <smxdev4@gmail.com>
  * Copyright (C) 2024 Yannis Juglaret <yjuglaret@mozilla.com>
  *
@@ -700,6 +700,7 @@ gum_do_query_cpu_features (void)
 {
   GumCpuFeatures features = 0;
   gboolean cpu_supports_avx2 = FALSE;
+  gboolean cpu_supports_avx512 = FALSE;
   gboolean cpu_supports_cet_ss = FALSE;
   gboolean os_enabled_xsave = FALSE;
   guint a, b, c, d;
@@ -707,6 +708,7 @@ gum_do_query_cpu_features (void)
   if (gum_get_cpuid (7, &a, &b, &c, &d))
   {
     cpu_supports_avx2 = (b & (1 << 5)) != 0;
+    cpu_supports_avx512 = (b & (1 << 16)) != 0;
     cpu_supports_cet_ss = (c & (1 << 7)) != 0;
   }
 
@@ -715,6 +717,9 @@ gum_do_query_cpu_features (void)
 
   if (cpu_supports_avx2 && os_enabled_xsave)
     features |= GUM_CPU_AVX2;
+
+  if (cpu_supports_avx512 && os_enabled_xsave)
+    features |= GUM_CPU_AVX512;
 
   if (cpu_supports_cet_ss)
     features |= GUM_CPU_CET_SS;

--- a/gum/gumdefs.h
+++ b/gum/gumdefs.h
@@ -191,12 +191,13 @@ typedef enum {
 enum _GumCpuFeatures
 {
   GUM_CPU_AVX2            = 1 << 0,
-  GUM_CPU_CET_SS          = 1 << 1,
-  GUM_CPU_THUMB_INTERWORK = 1 << 2,
-  GUM_CPU_VFP2            = 1 << 3,
-  GUM_CPU_VFP3            = 1 << 4,
-  GUM_CPU_VFPD32          = 1 << 5,
-  GUM_CPU_PTRAUTH         = 1 << 6,
+  GUM_CPU_AVX512          = 1 << 1,
+  GUM_CPU_CET_SS          = 1 << 2,
+  GUM_CPU_THUMB_INTERWORK = 1 << 3,
+  GUM_CPU_VFP2            = 1 << 4,
+  GUM_CPU_VFP3            = 1 << 5,
+  GUM_CPU_VFPD32          = 1 << 6,
+  GUM_CPU_PTRAUTH         = 1 << 7,
 };
 
 typedef enum {


### PR DESCRIPTION
## Problem

On AVX-512 hosts, running `/Core/Stalker` crashes deterministically inside `__libc_free` during `pthread_create`, freeing a pointer whose value is ASCII text. The crash is a reused thread's **DTV** (dynamic thread vector) corrupted with disassembly/string bytes.

## Root cause

Stalker's prolog preserves x87/SSE (`fxsave`) and the upper halves of `ymm0-15` (`vextracti128`), but has no concept of the AVX-512 extended state:

- the upper 256 bits of `zmm0-15`
- `zmm16-31` (invisible to `fxsave`/VEX)
- the `k0-k7` opmask registers

glibc's EVEX string routines (`__memmove_evex`/`__memset_evex`, selected by the ifunc resolver on AVX-512 CPUs and reached via `pthread_create` → `_dl_allocate_tls_init`) hold copy/fill data in `ymm16` and use opmask registers across instructions. When Stalker splices per-instruction event instrumentation between them, the handler path clobbers those registers, so the stalked routine writes garbage into the new thread's DTV. A later `pthread_create` that reuses the cached thread and frees that DTV then crashes.

This is why it only reproduces on AVX-512 hardware, and why it is heap-layout sensitive (the wrong-write target shifts with register/heap state).

## Fix

- Add `GUM_CPU_AVX512` detection (`CPUID.7:EBX.AVX512F` + OSXSAVE).
- In `gum_exec_ctx_write_prolog_helper`/epilog (x86-64), when AVX-512 is present, additionally save/restore the upper halves of `zmm0-15`, `zmm16-31`, and `k0-k7`, layered on top of the existing `fxsave`+`ymm` save.

## Validation

Reproduced on a Xeon Platinum 8358 (Ice Lake): `/Core/Stalker` crashed 30/40 without the fix, **0/60 with it**, full suite (425 tests) green. Also confirmed the crash vanishes when AVX-512 is disabled via `GLIBC_TUNABLES`, and that preserving these registers is both necessary and sufficient.

## Notes

- Guarded to `GLIB_SIZEOF_VOID_P == 8`; 32-bit AVX-512 (only `zmm0-7`, no `zmm16-31`) is left as a follow-up.
- The extra spill (~1.6 KB per prolog) applies only on AVX-512 hosts. A single `xsave`/`xrstor` would be terser and future-proof if preferred over the explicit form.