### PR TITLE
Arm64 writer movk pacia

### DIFF
--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2017 Antonio Ken Iannillo <ak.iannillo@gmail.com>
  * Copyright (C) 2019 Jon Wilson <jonwilson@zepler.net>
- * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2023-2026 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
  *
  * Licence: wxWindows Library Licence, Version 3.1

--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -1447,6 +1447,30 @@ gum_arm64_writer_put_mov_reg_reg (GumArm64Writer * self,
   return TRUE;
 }
 
+gboolean
+gum_arm64_writer_put_movk_reg_imm (GumArm64Writer * self,
+                                   arm64_reg reg,
+                                   guint16 imm,
+                                   guint shift)
+{
+  GumArm64RegInfo ri;
+  guint hw;
+
+  gum_arm64_writer_describe_reg (self, reg, &ri);
+
+  if (shift % 16 != 0 || shift > 48)
+    return FALSE;
+
+  hw = shift / 16;
+  if (ri.width == 32 && hw > 1)
+    return FALSE;
+
+  gum_arm64_writer_put_instruction (self,
+      ri.sf | 0x72800000 | (hw << 21) | (imm << 5) | ri.index);
+
+  return TRUE;
+}
+
 void
 gum_arm64_writer_put_mov_reg_nzcv (GumArm64Writer * self,
                                    arm64_reg reg)

--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -1769,6 +1769,25 @@ gum_arm64_writer_put_xpaci_reg (GumArm64Writer * self,
   return TRUE;
 }
 
+gboolean
+gum_arm64_writer_put_pacia_reg_reg (GumArm64Writer * self,
+                                    arm64_reg dst_reg,
+                                    arm64_reg mod_reg)
+{
+  GumArm64RegInfo rd, rm;
+
+  gum_arm64_writer_describe_reg (self, dst_reg, &rd);
+  gum_arm64_writer_describe_reg (self, mod_reg, &rm);
+
+  if (rd.width != 64 || rm.width != 64)
+    return FALSE;
+
+  gum_arm64_writer_put_instruction (self,
+      0xdac10000 | rd.index | (rm.index << 5));
+
+  return TRUE;
+}
+
 void
 gum_arm64_writer_put_nop (GumArm64Writer * self)
 {

--- a/gum/arch-arm64/gumarm64writer.h
+++ b/gum/arch-arm64/gumarm64writer.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014-2023 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2017 Antonio Ken Iannillo <ak.iannillo@gmail.com>
- * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2023-2026 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
  *
  * Licence: wxWindows Library Licence, Version 3.1

--- a/gum/arch-arm64/gumarm64writer.h
+++ b/gum/arch-arm64/gumarm64writer.h
@@ -203,6 +203,8 @@ GUM_API void gum_arm64_writer_put_mov_reg_nzcv (GumArm64Writer * self,
     arm64_reg reg);
 GUM_API void gum_arm64_writer_put_mov_nzcv_reg (GumArm64Writer * self,
     arm64_reg reg);
+GUM_API gboolean gum_arm64_writer_put_movk_reg_imm (GumArm64Writer * self,
+    arm64_reg reg, guint16 imm, guint shift);
 GUM_API gboolean gum_arm64_writer_put_uxtw_reg_reg (GumArm64Writer * self,
     arm64_reg dst_reg, arm64_reg src_reg);
 GUM_API gboolean gum_arm64_writer_put_add_reg_reg_imm (GumArm64Writer * self,

--- a/gum/arch-arm64/gumarm64writer.h
+++ b/gum/arch-arm64/gumarm64writer.h
@@ -232,6 +232,8 @@ GUM_API gboolean gum_arm64_writer_put_cmp_reg_reg (GumArm64Writer * self,
 
 GUM_API gboolean gum_arm64_writer_put_xpaci_reg (GumArm64Writer * self,
     arm64_reg reg);
+GUM_API gboolean gum_arm64_writer_put_pacia_reg_reg (GumArm64Writer * self,
+    arm64_reg dst_reg, arm64_reg mod_reg);
 
 GUM_API void gum_arm64_writer_put_nop (GumArm64Writer * self);
 GUM_API void gum_arm64_writer_put_brk_imm (GumArm64Writer * self, guint16 imm);


### PR DESCRIPTION
For a Swift instrumentation bridge, generated arm64e trampolines need to sign a pointer into a metadata slot whose ptrauth discriminator is only known at runtime — so the discriminator has to be blended (movk) and the pointer signed (pacia) in emitted code. The writer had neither.

Functions added

- `gum_arm64_writer_put_movk_reg_imm (self, reg, imm, shift)`
- `gum_arm64_writer_put_pacia_reg_reg (self, dst_reg, mod_reg)`