### PR TITLE
arm64: Fix Interceptor crash on functions with internal CBZ targets

### DIFF
--- a/gum/arch-arm64/gumarm64relocator.c
+++ b/gum/arch-arm64/gumarm64relocator.c
@@ -24,6 +24,7 @@ struct _GumCodeGenCtx
 
 static gboolean gum_arm64_relocator_register_is_free (
     const GumArm64Relocator * self, guint n, arm64_reg reg);
+static gpointer gum_arm64_relocator_extract_branch_target (const cs_insn * insn);
 
 static gboolean gum_arm64_branch_is_unconditional (const cs_insn * insn);
 
@@ -400,9 +401,51 @@ gum_arm64_relocator_can_relocate (gpointer address,
     size_t current_code_size;
     gpointer target;
     GHashTableIter iter;
+    guint insn_index;
+    guint num_insns;
 
     checked_targets = g_hash_table_new (NULL, NULL);
     targets_to_check = g_hash_table_new (NULL, NULL);
+
+    /*
+     * Relocated conditional/unconditional branches are rewritten as absolute
+     * jumps back to the original target address. If that target lies inside the
+     * range we are about to overwrite, the rewritten branch would land in the
+     * middle of the redirect patch. Shrink the range so every such target falls
+     * outside it. Also keep out-of-range targets queued for reachability checks
+     * below, since those paths must not jump back into the patch either.
+     */
+    num_insns = n / 4;
+    for (insn_index = 0; insn_index != num_insns; insn_index++)
+    {
+      const cs_insn * input_insn = rl.input_insns[insn_index];
+      gssize offset;
+
+      if (input_insn == NULL)
+        break;
+
+      /* Instruction was cut out by an earlier shrink. */
+      if (insn_index * 4 >= n)
+        break;
+
+      target = gum_arm64_relocator_extract_branch_target (input_insn);
+      if (target == NULL)
+        continue;
+
+      offset = (gssize) target - (gssize) address;
+      if (offset > 0 && offset < (gssize) n)
+        n = (guint) offset;
+      else if (offset >= (gssize) n)
+        g_hash_table_add (targets_to_check, target);
+    }
+
+    /*
+     * If an internal branch forced us to shrink n, rewind so the reachability
+     * scan below starts at the new relocatable boundary rather than wherever
+     * read_one() stopped when trying to satisfy min_bytes.
+     */
+    rl.input_cur = (const guint8 *) address + n;
+    rl.input_pc = GUM_ADDRESS (address) + n;
 
     cs_open (CS_ARCH_ARM64, GUM_DEFAULT_CS_ENDIAN, &capstone);
     cs_option (capstone, CS_OPT_DETAIL, CS_OPT_ON);
@@ -429,10 +472,8 @@ gum_arm64_relocator_can_relocate (gpointer address,
         {
           case ARM64_INS_B:
           {
-            cs_arm64_op * op = &d->operands[0];
-
-            g_assert (op->type == ARM64_OP_IMM);
-            target = GSIZE_TO_POINTER (op->imm);
+            target = gum_arm64_relocator_extract_branch_target (insn);
+            g_assert (target != NULL);
             if (!g_hash_table_contains (checked_targets, target))
               g_hash_table_add (targets_to_check, target);
 
@@ -443,23 +484,11 @@ gum_arm64_relocator_can_relocate (gpointer address,
           }
           case ARM64_INS_CBZ:
           case ARM64_INS_CBNZ:
-          {
-            cs_arm64_op * op = &d->operands[1];
-
-            g_assert (op->type == ARM64_OP_IMM);
-            target = GSIZE_TO_POINTER (op->imm);
-            if (!g_hash_table_contains (checked_targets, target))
-              g_hash_table_add (targets_to_check, target);
-
-            break;
-          }
           case ARM64_INS_TBZ:
           case ARM64_INS_TBNZ:
           {
-            cs_arm64_op * op = &d->operands[2];
-
-            g_assert (op->type == ARM64_OP_IMM);
-            target = GSIZE_TO_POINTER (op->imm);
+            target = gum_arm64_relocator_extract_branch_target (insn);
+            g_assert (target != NULL);
             if (!g_hash_table_contains (checked_targets, target))
               g_hash_table_add (targets_to_check, target);
 
@@ -579,6 +608,35 @@ gum_arm64_relocator_register_is_free (const GumArm64Relocator * self,
   }
 
   return TRUE;
+}
+
+static gpointer
+gum_arm64_relocator_extract_branch_target (const cs_insn * insn)
+{
+  const cs_arm64 * d = &insn->detail->arm64;
+  const cs_arm64_op * op;
+
+  switch (insn->id)
+  {
+    case ARM64_INS_B:
+      op = &d->operands[0];
+      break;
+    case ARM64_INS_CBZ:
+    case ARM64_INS_CBNZ:
+      op = &d->operands[1];
+      break;
+    case ARM64_INS_TBZ:
+    case ARM64_INS_TBNZ:
+      op = &d->operands[2];
+      break;
+    default:
+      return NULL;
+  }
+
+  if (op->type != ARM64_OP_IMM)
+    return NULL;
+
+  return GSIZE_TO_POINTER (op->imm);
 }
 
 guint

--- a/tests/core/arch-arm64/arm64relocator.c
+++ b/tests/core/arch-arm64/arm64relocator.c
@@ -20,6 +20,7 @@ TESTLIST_BEGIN (arm64relocator)
   TESTENTRY (b_should_be_rewritten)
   TESTENTRY (bl_should_be_rewritten)
   TESTENTRY (cannot_relocate_with_early_br)
+  TESTENTRY (cannot_relocate_with_internal_cbz_target)
   TESTENTRY (eob_and_eoi_on_br)
   TESTENTRY (eob_and_eoi_on_ret)
 TESTLIST_END ()
@@ -397,6 +398,33 @@ TESTCASE (cannot_relocate_with_early_br)
 
   g_assert_false (gum_arm64_relocator_can_relocate (input, 16,
       GUM_SCENARIO_OFFLINE, GUM_RELOCATION_CHECKED, NULL, NULL));
+}
+
+TESTCASE (cannot_relocate_with_internal_cbz_target)
+{
+  /*
+   * Mirrors libdispatch's dispatch_mach_msg_get_msg(): a leading cbz that lands
+   * inside the first 16 bytes. A full redirect would overwrite the target and
+   * the rewritten cbz would jump into the middle of the patch.
+   */
+  guint32 input[] = {
+    GUINT32_TO_LE (0xb4000061), /* cbz x1, #+12 */
+    GUINT32_TO_LE (0xf9402808), /* ldr x8, [x0, #0x50] */
+    GUINT32_TO_LE (0xf9000028), /* str x8, [x1] */
+    GUINT32_TO_LE (0xb9404808), /* ldr w8, [x0, #0x48] */
+    GUINT32_TO_LE (0x91016000), /* add x0, x0, #0x58 */
+    GUINT32_TO_LE (0x34000048), /* cbz w8, #+8 */
+    GUINT32_TO_LE (0xf9400000), /* ldr x0, [x0] */
+    GUINT32_TO_LE (0xd65f03c0)  /* ret */
+  };
+  guint maximum = 0;
+
+  g_assert_false (gum_arm64_relocator_can_relocate (input, 16,
+      GUM_SCENARIO_OFFLINE, GUM_RELOCATION_CHECKED, &maximum, NULL));
+  g_assert_cmpuint (maximum, ==, 12);
+  g_assert_true (gum_arm64_relocator_can_relocate (input, 8,
+      GUM_SCENARIO_OFFLINE, GUM_RELOCATION_CHECKED, &maximum, NULL));
+  g_assert_cmpuint (maximum, >=, 8);
 }
 
 TESTCASE (eob_and_eoi_on_br)


### PR DESCRIPTION
Hooking short ARM64 functions whose prologue contains a conditional branch into the same 16-byte window (notably
`dispatch_mach_msg_get_msg` in libdispatch, macOS) can crash the target with`EXC_BAD_INSTRUCTION` / `SIGILL`.

On macOS, attaching Interceptor to `dispatch_mach_msg_get_msg` and exercising the `x1 == NULL` path crashes, 
e.g. in process `lsd`:

 ```
 exception: EXC_BAD_INSTRUCTION
 frame:     dispatch_mach_msg_get_msg + 12
 x1 = 0
```

The function looks like:

```asm
dispatch_mach_msg_get_msg:
    cbz  x1, +12
    ldr  x8, [x0, #0x50]
    str  x8, [x1]
    ldr  w8, [x0, #0x48]   ; +12
    add  x0, x0, #0x58
    ...
    ret
```

Root cause:

 1. Interceptor prefers a 16-byte full redirect when
    gum_arm64_relocator_can_relocate(..., 16, CHECKED, ...) succeeds.
 2. Relocated cbz/tbz/b.cond are rewritten as absolute jumps back to
    the original target address.
 3. With x1 == NULL, the rewritten CBZ jumps to function+12, which
    sits inside the 16-byte patch (part of the absolute address literal)
    → illegal instruction.

 GUM_RELOCATION_CHECKED was supposed to prevent branches into the
 middle of the patch, but it only started its reachability scan at
 rl.input_cur (after the bytes already chosen for relocation). It never
 inspected branches inside the relocated instructions themselves, so
 the leading cbz x1, +12 was invisible and can_relocate(16) returned
 true.

 Fix:

 In gum_arm64_relocator_can_relocate() under GUM_RELOCATION_CHECKED:

 - Scan already-read instructions for B/CBZ/TBZ targets.
 - If a target falls inside (0, n), shrink n so the target is outside
   the patch; queue out-of-range targets for the existing walk.
 - Rewind rl.input_cur / rl.input_pc to the new boundary before the
   post-range reachability scan.
 - Factor branch-target extraction into
   gum_arm64_relocator_extract_branch_target().

 For dispatch_mach_msg_get_msg, can_relocate(16) now fails with
 maximum == 12, and Interceptor falls back to an 8-byte near redirect
 that leaves +12 intact.

Testcase cannot_relocate_with_internal_cbz_target is added for covering this prologue shape.
