### PR TITLE
Allow wildcards at the beginning or end of a pattern

### DIFF
--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2021 Abdelrahman Eid <hot3eed@gmail.com>
  * Copyright (C) 2025 Francesco Tamagni <mrmacete@protonmail.ch>
  * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2026 Ricardo Marques <marquessricardo@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -1422,23 +1423,13 @@ gum_match_pattern_push_token (GumMatchPattern * self,
 static gboolean
 gum_match_pattern_seal (GumMatchPattern * self)
 {
-  GumMatchToken * token;
-
   gum_match_pattern_update_computed_size (self);
 
   if (self->size == 0)
     return FALSE;
 
-  token = (GumMatchToken *) g_ptr_array_index (self->tokens, 0);
-  if (token->type == GUM_MATCH_WILDCARD)
-    return FALSE;
-
-  token = (GumMatchToken *) g_ptr_array_index (self->tokens,
-      self->tokens->len - 1);
-  if (token->type == GUM_MATCH_WILDCARD)
-    return FALSE;
-
-  return TRUE;
+  return gum_match_pattern_get_longest_token (self, GUM_MATCH_EXACT) != NULL ||
+      gum_match_pattern_get_longest_token (self, GUM_MATCH_MASK) != NULL;
 }
 
 static GumMatchToken *

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -1032,8 +1032,8 @@ gum_memory_scan_raw (const GumMemoryRange * range,
   needle_len = needle->bytes->len;
   pattern_size = gum_match_pattern_get_size (pattern);
 
-  cur = GSIZE_TO_POINTER (range->base_address);
-  end_address = cur + range->size - (pattern_size - needle->offset) + 1;
+  cur = (guint8 *) GSIZE_TO_POINTER (range->base_address) + needle->offset;
+  end_address = cur + range->size - pattern_size + 1;
 
   for (; cur < end_address; cur++)
   {
@@ -1064,7 +1064,7 @@ gum_memory_scan_raw (const GumMemoryRange * range,
       if (!func (GUM_ADDRESS (start), pattern_size, user_data))
         return;
 
-      cur = start + pattern_size - 1;
+      cur = start + pattern_size + needle->offset - 1;
     }
   }
 }

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2026 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2026 Ricardo Marques <marquessricardo@gmail.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -29,6 +30,8 @@ TESTLIST_BEGIN (memory)
   TESTENTRY (scan_range_finds_three_regex_matches)
   TESTENTRY (scan_range_ignores_match_starting_before_range)
   TESTENTRY (scan_range_skips_overlapping_matches)
+  TESTENTRY (scan_range_finds_three_leading_wildcard_matches)
+  TESTENTRY (scan_range_finds_three_trailing_wildcard_matches)
   TESTENTRY (find_pointers_finds_exact_value)
   TESTENTRY (find_pointers_finds_multiple_values)
   TESTENTRY (find_pointers_finds_many_values)
@@ -248,9 +251,18 @@ TESTCASE (match_pattern_from_string_does_proper_validation)
   g_assert_null (pattern);
 
   pattern = gum_match_pattern_new_from_string ("?? 13");
-  g_assert_null (pattern);
+  g_assert_nonnull (pattern);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 2);
+  gum_match_pattern_unref (pattern);
 
   pattern = gum_match_pattern_new_from_string ("13 ??");
+  g_assert_nonnull (pattern);
+  g_assert_cmpuint (gum_match_pattern_get_size (pattern), ==, 2);
+  g_assert_cmpuint (gum_match_pattern_get_tokens (pattern)->len, ==, 2);
+  gum_match_pattern_unref (pattern);
+
+  pattern = gum_match_pattern_new_from_string ("?? ?? ??");
   g_assert_null (pattern);
 
   pattern = gum_match_pattern_new_from_string (" ");
@@ -478,6 +490,72 @@ TESTCASE (scan_range_skips_overlapping_matches)
   gum_memory_scan (&range, pattern, match_found_cb, &ctx);
 
   g_assert_cmpuint (ctx.number_of_calls, ==, 1);
+
+  gum_match_pattern_unref (pattern);
+}
+
+TESTCASE (scan_range_finds_three_leading_wildcard_matches)
+{
+  guint8 buf[] = {
+    0xaa, 0x13, 0x37,
+    0x12,
+    0xbb, 0x13, 0x37,
+    0xcc, 0x13, 0x37
+  };
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  TestForEachContext ctx;
+
+  range.base_address = GUM_ADDRESS (buf);
+  range.size = sizeof (buf);
+
+  pattern = gum_match_pattern_new_from_string ("?? 13 37");
+  g_assert_nonnull (pattern);
+
+  ctx.number_of_calls = 0;
+  ctx.value_to_return = TRUE;
+
+  ctx.expected_address[0] = buf + 0;
+  ctx.expected_address[1] = buf + 4;
+  ctx.expected_address[2] = buf + 7;
+  ctx.expected_size = 3;
+
+  gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+
+  g_assert_cmpuint (ctx.number_of_calls, ==, 3);
+
+  gum_match_pattern_unref (pattern);
+}
+
+TESTCASE (scan_range_finds_three_trailing_wildcard_matches)
+{
+  guint8 buf[] = {
+    0x13, 0x37, 0xaa,
+    0x12,
+    0x13, 0x37, 0xbb,
+    0x13, 0x37, 0xcc
+  };
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  TestForEachContext ctx;
+
+  range.base_address = GUM_ADDRESS (buf);
+  range.size = sizeof (buf);
+
+  pattern = gum_match_pattern_new_from_string ("13 37 ??");
+  g_assert_nonnull (pattern);
+
+  ctx.number_of_calls = 0;
+  ctx.value_to_return = TRUE;
+
+  ctx.expected_address[0] = buf + 0;
+  ctx.expected_address[1] = buf + 4;
+  ctx.expected_address[2] = buf + 7;
+  ctx.expected_size = 3;
+
+  gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+
+  g_assert_cmpuint (ctx.number_of_calls, ==, 3);
 
   gum_match_pattern_unref (pattern);
 }

--- a/tests/core/memory.c
+++ b/tests/core/memory.c
@@ -27,6 +27,8 @@ TESTLIST_BEGIN (memory)
   TESTENTRY (scan_range_finds_three_wildcarded_matches)
   TESTENTRY (scan_range_finds_three_masked_matches)
   TESTENTRY (scan_range_finds_three_regex_matches)
+  TESTENTRY (scan_range_ignores_match_starting_before_range)
+  TESTENTRY (scan_range_skips_overlapping_matches)
   TESTENTRY (find_pointers_finds_exact_value)
   TESTENTRY (find_pointers_finds_multiple_values)
   TESTENTRY (find_pointers_finds_many_values)
@@ -421,6 +423,61 @@ TESTCASE (scan_range_finds_three_regex_matches)
   gum_memory_scan (&range, pattern, match_found_cb, &ctx);
 
   g_assert_cmpuint (ctx.number_of_calls, ==, 3);
+
+  gum_match_pattern_unref (pattern);
+}
+
+TESTCASE (scan_range_ignores_match_starting_before_range)
+{
+  guint8 buf[] = {
+    0x13, 0x00, 0x37, 0x37,
+    0x00, 0x00, 0x00, 0x00
+  };
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  TestForEachContext ctx;
+
+  range.base_address = GUM_ADDRESS (buf + 2);
+  range.size = 2;
+
+  pattern = gum_match_pattern_new_from_string ("13 ?? 37 37");
+  g_assert_nonnull (pattern);
+
+  ctx.number_of_calls = 0;
+  ctx.value_to_return = TRUE;
+
+  gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+
+  g_assert_cmpuint (ctx.number_of_calls, ==, 0);
+
+  gum_match_pattern_unref (pattern);
+}
+
+TESTCASE (scan_range_skips_overlapping_matches)
+{
+  guint8 buf[] = {
+    0x13, 0x00, 0x13, 0x37,
+    0x13, 0x37
+  };
+  GumMemoryRange range;
+  GumMatchPattern * pattern;
+  TestForEachContext ctx;
+
+  range.base_address = GUM_ADDRESS (buf);
+  range.size = sizeof (buf);
+
+  pattern = gum_match_pattern_new_from_string ("13 ?? 13 37");
+  g_assert_nonnull (pattern);
+
+  ctx.number_of_calls = 0;
+  ctx.value_to_return = TRUE;
+
+  ctx.expected_address[0] = buf + 0;
+  ctx.expected_size = 4;
+
+  gum_memory_scan (&range, pattern, match_found_cb, &ctx);
+
+  g_assert_cmpuint (ctx.number_of_calls, ==, 1);
 
   gum_match_pattern_unref (pattern);
 }


### PR DESCRIPTION
- Let patterns start or end with a wildcard
- Added tests for patterns with leading and trailing wildcards
- Fixes frida/frida-gum#1144

