### PR TITLE
arm64: Dodge BTI where we have no landing pad

### DIFF
--- a/gum/arch-arm64/gumarm64relocator.c
+++ b/gum/arch-arm64/gumarm64relocator.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2026 Haiwei Wang <haiwei.wang1109@gmail.com>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -758,7 +759,7 @@ gum_arm64_relocator_rewrite_b (GumArm64Relocator * self,
 
   gum_arm64_writer_put_ldr_reg_address (ctx->output, ARM64_REG_X16,
       gum_arm64_writer_sign (ctx->output, target->imm));
-  gum_arm64_writer_put_br_reg (ctx->output, ARM64_REG_X16);
+  gum_arm64_writer_put_jmp_reg (ctx->output, ARM64_REG_X16);
 
   return TRUE;
 }
@@ -778,7 +779,7 @@ gum_arm64_relocator_rewrite_b_cond (GumArm64Relocator * self,
   gum_arm64_writer_put_label (ctx->output, is_true);
   gum_arm64_writer_put_ldr_reg_address (ctx->output, ARM64_REG_X16,
       gum_arm64_writer_sign (ctx->output, target->imm));
-  gum_arm64_writer_put_br_reg (ctx->output, ARM64_REG_X16);
+  gum_arm64_writer_put_jmp_reg (ctx->output, ARM64_REG_X16);
 
   gum_arm64_writer_put_label (ctx->output, is_false);
 
@@ -817,7 +818,7 @@ gum_arm64_relocator_rewrite_cbz (GumArm64Relocator * self,
   gum_arm64_writer_put_label (ctx->output, is_true);
   gum_arm64_writer_put_ldr_reg_address (ctx->output, ARM64_REG_X16,
       gum_arm64_writer_sign (ctx->output, target->imm));
-  gum_arm64_writer_put_br_reg (ctx->output, ARM64_REG_X16);
+  gum_arm64_writer_put_jmp_reg (ctx->output, ARM64_REG_X16);
 
   gum_arm64_writer_put_label (ctx->output, is_false);
 
@@ -850,7 +851,7 @@ gum_arm64_relocator_rewrite_tbz (GumArm64Relocator * self,
   gum_arm64_writer_put_label (ctx->output, is_true);
   gum_arm64_writer_put_ldr_reg_address (ctx->output, ARM64_REG_X16,
       gum_arm64_writer_sign (ctx->output, target->imm));
-  gum_arm64_writer_put_br_reg (ctx->output, ARM64_REG_X16);
+  gum_arm64_writer_put_jmp_reg (ctx->output, ARM64_REG_X16);
 
   gum_arm64_writer_put_label (ctx->output, is_false);
 

--- a/gum/arch-arm64/gumarm64writer.c
+++ b/gum/arch-arm64/gumarm64writer.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2019 Jon Wilson <jonwilson@zepler.net>
  * Copyright (C) 2023-2026 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -618,6 +619,35 @@ gum_arm64_writer_put_br_reg_no_auth (GumArm64Writer * self,
                                      arm64_reg reg)
 {
   return gum_arm64_writer_put_br_reg_with_extra (self, reg, 0);
+}
+
+/*
+ * Jump to the address held by the given register, by whichever means gets us
+ * there. BR traps on a BTI-guarded target that has no landing pad waiting for
+ * us -- the middle of a function we've hooked, say -- whereas RET performs the
+ * same jump and is exempt from the check.
+ *
+ * Where pointer authentication is available we are on arm64e, which doesn't
+ * guard pages this way, so we stick with BR.
+ */
+gboolean
+gum_arm64_writer_put_jmp_reg (GumArm64Writer * self,
+                              arm64_reg reg)
+{
+  if (self->ptrauth_support == GUM_PTRAUTH_SUPPORTED)
+    return gum_arm64_writer_put_br_reg (self, reg);
+
+  return gum_arm64_writer_put_ret_reg (self, reg);
+}
+
+gboolean
+gum_arm64_writer_put_jmp_reg_no_auth (GumArm64Writer * self,
+                                      arm64_reg reg)
+{
+  if (self->ptrauth_support == GUM_PTRAUTH_SUPPORTED)
+    return gum_arm64_writer_put_br_reg_no_auth (self, reg);
+
+  return gum_arm64_writer_put_ret_reg (self, reg);
 }
 
 static gboolean
@@ -1792,6 +1822,17 @@ void
 gum_arm64_writer_put_nop (GumArm64Writer * self)
 {
   gum_arm64_writer_put_instruction (self, 0xd503201f);
+}
+
+/*
+ * Emit a landing pad for the code we're about to generate, so that indirect
+ * branches may reach it on a BTI-guarded page. We accept both jumps and calls,
+ * as our entries are reached in both ways.
+ */
+void
+gum_arm64_writer_put_bti (GumArm64Writer * self)
+{
+  gum_arm64_writer_put_instruction (self, 0xd50324df);
 }
 
 void

--- a/gum/arch-arm64/gumarm64writer.h
+++ b/gum/arch-arm64/gumarm64writer.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2017 Antonio Ken Iannillo <ak.iannillo@gmail.com>
  * Copyright (C) 2023-2026 Håvard Sørbø <havard@hsorbo.no>
  * Copyright (C) 2023 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -125,6 +126,10 @@ GUM_API gboolean gum_arm64_writer_put_br_reg (GumArm64Writer * self,
     arm64_reg reg);
 GUM_API gboolean gum_arm64_writer_put_br_reg_no_auth (GumArm64Writer * self,
     arm64_reg reg);
+GUM_API gboolean gum_arm64_writer_put_jmp_reg (GumArm64Writer * self,
+    arm64_reg reg);
+GUM_API gboolean gum_arm64_writer_put_jmp_reg_no_auth (GumArm64Writer * self,
+    arm64_reg reg);
 GUM_API gboolean gum_arm64_writer_put_blr_reg (GumArm64Writer * self,
     arm64_reg reg);
 GUM_API gboolean gum_arm64_writer_put_blr_reg_no_auth (GumArm64Writer * self,
@@ -236,6 +241,7 @@ GUM_API gboolean gum_arm64_writer_put_pacia_reg_reg (GumArm64Writer * self,
     arm64_reg dst_reg, arm64_reg mod_reg);
 
 GUM_API void gum_arm64_writer_put_nop (GumArm64Writer * self);
+GUM_API void gum_arm64_writer_put_bti (GumArm64Writer * self);
 GUM_API void gum_arm64_writer_put_brk_imm (GumArm64Writer * self, guint16 imm);
 GUM_API gboolean gum_arm64_writer_put_mrs (GumArm64Writer * self,
     arm64_reg dst_reg, guint16 system_reg);

--- a/gum/backend-arm64/guminterceptor-arm64.c
+++ b/gum/backend-arm64/guminterceptor-arm64.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2022-2025 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -993,7 +994,7 @@ _gum_interceptor_backend_create_trampoline (GumInterceptorBackend * self,
     resume_at = gum_sign_code_address (
         GUM_ADDRESS (function_address) + reloc_bytes);
     gum_arm64_writer_put_ldr_reg_address (aw, data->scratch_reg, resume_at);
-    gum_arm64_writer_put_br_reg (aw, data->scratch_reg);
+    gum_arm64_writer_put_jmp_reg (aw, data->scratch_reg);
   }
 
   gum_arm64_writer_flush (aw);
@@ -1120,11 +1121,11 @@ _gum_interceptor_backend_activate_trampoline (GumInterceptorBackend * self,
         break;
       case 8:
         gum_arm64_writer_put_adrp_reg_address (aw, data->scratch_reg, on_enter);
-        gum_arm64_writer_put_br_reg_no_auth (aw, data->scratch_reg);
+        gum_arm64_writer_put_jmp_reg_no_auth (aw, data->scratch_reg);
         break;
       case GUM_INTERCEPTOR_FULL_REDIRECT_SIZE:
         gum_arm64_writer_put_ldr_reg_address (aw, data->scratch_reg, on_enter);
-        gum_arm64_writer_put_br_reg (aw, data->scratch_reg);
+        gum_arm64_writer_put_jmp_reg (aw, data->scratch_reg);
         break;
       default:
         g_assert_not_reached ();
@@ -1312,6 +1313,8 @@ static void
 gum_emit_enter_thunk (GumArm64Writer * aw,
                       arm64_reg scratch_reg)
 {
+  gum_arm64_writer_put_bti (aw);
+
   gum_arm64_writer_put_ldr_reg_reg_offset (aw, ARM64_REG_X17, ARM64_REG_SP, 0);
 
   gum_emit_prolog (aw);
@@ -1337,6 +1340,8 @@ static void
 gum_emit_leave_thunk (GumArm64Writer * aw,
                       arm64_reg scratch_reg)
 {
+  gum_arm64_writer_put_bti (aw);
+
   gum_arm64_writer_put_ldr_reg_reg_offset (aw, ARM64_REG_X17, ARM64_REG_SP, 0);
 
   gum_emit_prolog (aw);
@@ -1425,9 +1430,5 @@ gum_emit_epilog (GumArm64Writer * aw,
 
   gum_arm64_writer_put_ldr_reg_reg_offset_mode (aw, scratch_reg, ARM64_REG_SP,
       16, GUM_INDEX_POST_ADJUST);
-#ifndef HAVE_PTRAUTH
-  gum_arm64_writer_put_ret_reg (aw, scratch_reg);
-#else
-  gum_arm64_writer_put_br_reg (aw, scratch_reg);
-#endif
+  gum_arm64_writer_put_jmp_reg (aw, scratch_reg);
 }

--- a/gum/gumcodeallocator.c
+++ b/gum/gumcodeallocator.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2010-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2025 Francesco Tamagni <mrmacete@protonmail.ch>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -716,13 +717,13 @@ gum_insert_deflector (gpointer cave,
     gum_arm64_writer_put_push_reg_reg (&aw, ARM64_REG_X0, ARM64_REG_LR);
     gum_arm64_writer_put_ldr_reg_address (&aw, ARM64_REG_X0,
         GUM_ADDRESS (ctx->dedicated_target));
-    gum_arm64_writer_put_br_reg (&aw, ARM64_REG_X0);
+    gum_arm64_writer_put_jmp_reg (&aw, ARM64_REG_X0);
   }
   else
   {
     gum_arm64_writer_put_ldr_reg_address (&aw, ARM64_REG_X0,
         GUM_ADDRESS (gum_sign_code_pointer (dispatcher->thunk)));
-    gum_arm64_writer_put_br_reg (&aw, ARM64_REG_X0);
+    gum_arm64_writer_put_jmp_reg (&aw, ARM64_REG_X0);
   }
 
   gum_arm64_writer_flush (&aw);
@@ -799,7 +800,7 @@ gum_write_thunk (gpointer thunk,
   gum_arm64_writer_put_instruction (&aw, 0xacc117e4);
   gum_arm64_writer_put_instruction (&aw, 0xacc11fe6);
 
-  gum_arm64_writer_put_br_reg (&aw, ARM64_REG_X0);
+  gum_arm64_writer_put_jmp_reg (&aw, ARM64_REG_X0);
   gum_arm64_writer_clear (&aw);
 # else
   (void) gum_code_deflector_dispatcher_lookup;

--- a/tests/core/arch-arm64/arm64relocator.c
+++ b/tests/core/arch-arm64/arm64relocator.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2026 Haiwei Wang <haiwei.wang1109@gmail.com>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -245,7 +246,7 @@ TESTCASE (cbz_should_be_rewritten)
     GUINT32_TO_LE (0xb4000040), /* cbz x0, #+2       */
     GUINT32_TO_LE (0x14000003), /* b +3              */
     GUINT32_TO_LE (0x58000050), /* ldr x16, [pc, #8] */
-    GUINT32_TO_LE (0xd61f0200)  /* br x16            */
+    GUINT32_TO_LE (0xd65f0200)  /* ret x16           */
   };
   const cs_insn * insn;
 
@@ -268,7 +269,7 @@ TESTCASE (tbnz_should_be_rewritten)
     GUINT32_TO_LE (0x37480041), /* tbnz w1, #9, #+2  */
     GUINT32_TO_LE (0x14000003), /* b +3              */
     GUINT32_TO_LE (0x58000050), /* ldr x16, [pc, #8] */
-    GUINT32_TO_LE (0xd61f0200)  /* br x16            */
+    GUINT32_TO_LE (0xd65f0200)  /* ret x16           */
   };
   const cs_insn * insn;
 
@@ -291,7 +292,7 @@ TESTCASE (b_cond_should_be_rewritten)
     GUINT32_TO_LE (0x54000043), /* b.lo #+2          */
     GUINT32_TO_LE (0x14000003), /* b +3              */
     GUINT32_TO_LE (0x58000050), /* ldr x16, [pc, #8] */
-    GUINT32_TO_LE (0xd61f0200)  /* br x16            */
+    GUINT32_TO_LE (0xd65f0200)  /* ret x16           */
   };
   const cs_insn * insn;
 
@@ -328,7 +329,7 @@ TESTCASE (b_should_be_rewritten)
     { 0x17ffff5a }, 1,  /* b #-664            */
     {
       0x58000050,       /* ldr x16, [pc, #8]  */
-      0xd61f0200,       /* br x16             */
+      0xd65f0200,       /* ret x16            */
       0xffffffff,       /* <calculated PC     */
       0xffffffff        /*  goes here>        */
     }, 4,

--- a/tests/core/arch-arm64/arm64writer.c
+++ b/tests/core/arch-arm64/arm64writer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2026 Ole André Vadla Ravnås <oleavr@nowsecure.com>
  * Copyright (C) 2023 Håvard Sørbø <havard@hsorbo.no>
+ * Copyright (C) 2026 inforcqb <fanjiawei080615@qq.com>
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
@@ -16,6 +17,11 @@ TESTLIST_BEGIN (arm64writer)
   TESTENTRY (bl_imm)
   TESTENTRY (bl_label)
   TESTENTRY (br_reg)
+  TESTENTRY (jmp_reg)
+  TESTENTRY (jmp_reg_with_ptrauth)
+  TESTENTRY (jmp_reg_no_auth)
+  TESTENTRY (jmp_reg_no_auth_with_ptrauth)
+  TESTENTRY (bti)
   TESTENTRY (blr_reg)
   TESTENTRY (ret)
 
@@ -171,6 +177,40 @@ TESTCASE (br_reg)
 {
   gum_arm64_writer_put_br_reg (&fixture->aw, ARM64_REG_X3);
   assert_output_n_equals (0, 0xd61f0060);
+}
+
+TESTCASE (jmp_reg)
+{
+  gum_arm64_writer_put_jmp_reg (&fixture->aw, ARM64_REG_X3);
+  assert_output_n_equals (0, 0xd65f0060); /* ret x3 */
+}
+
+TESTCASE (jmp_reg_with_ptrauth)
+{
+  fixture->aw.ptrauth_support = GUM_PTRAUTH_SUPPORTED;
+
+  gum_arm64_writer_put_jmp_reg (&fixture->aw, ARM64_REG_X3);
+  assert_output_n_equals (0, 0xd61f087f); /* braaz x3 */
+}
+
+TESTCASE (jmp_reg_no_auth)
+{
+  gum_arm64_writer_put_jmp_reg_no_auth (&fixture->aw, ARM64_REG_X3);
+  assert_output_n_equals (0, 0xd65f0060); /* ret x3 */
+}
+
+TESTCASE (jmp_reg_no_auth_with_ptrauth)
+{
+  fixture->aw.ptrauth_support = GUM_PTRAUTH_SUPPORTED;
+
+  gum_arm64_writer_put_jmp_reg_no_auth (&fixture->aw, ARM64_REG_X3);
+  assert_output_n_equals (0, 0xd61f0060); /* br x3 */
+}
+
+TESTCASE (bti)
+{
+  gum_arm64_writer_put_bti (&fixture->aw);
+  assert_output_n_equals (0, 0xd50324df); /* bti jc */
 }
 
 TESTCASE (blr_reg)


### PR DESCRIPTION
## What

Stop `br` from trapping on BTI-guarded pages, so the runtime-generated
trampolines and thunks work on kernels built with `CONFIG_ARM64_BTI_KERNEL=y`.

Fixes #1147.

## Why

`br xN` faults with `Oops - BTI` unless the target begins with a `bti` landing
pad. Gum emits its trampolines, thunks and relocated code at run time without
one, and on the Linux kernel-module flavour the trampoline lives in vmalloc
while the hooked function lives in the module region (~73 GB apart), so the
redirect cannot use a direct `b` and falls back to `br`.

## Change

Split the problem by who owns the branch target.

**Targets that are ours** — the enter and leave thunks get a `bti` landing pad
and keep `br`. This is the same shape as the x86 side, where
`gum_x86_writer_put_endbr()` is a plain primitive and the backend decides where
pads go.

**Targets that aren't ours** — use `ret`, which is exempt from the BTI check,
for the branches Gum cannot annotate: resuming a hooked function, the
relocator's rewritten `b`/`b.cond`/`cbz`/`tbz`, the epilog's next hop, the
activation redirect (which for `GUM_INTERCEPTOR_TYPE_FAST` targets the caller's
replacement function), and the code deflector's dispatcher and thunk. This
generalises the trick `gum_emit_epilog()` already used behind `#ifndef
HAVE_PTRAUTH`, which now folds into the new API.

The writer stays a faithful assembler: `put_br_reg()` and `put_br_reg_no_auth()`
emit `br`, and callers opt into the exemption through a separate operation-level
pair.

```c
/* mnemonic layer */                  /* operation layer */
put_br_reg (aw, reg);                 put_jmp_reg (aw, reg);
put_br_reg_no_auth (aw, reg);         put_jmp_reg_no_auth (aw, reg);
```

`put_jmp_reg*` mean "get to this address by whatever survives BTI" — `br` where
pointer authentication is available, `ret` otherwise — so `_no_auth` stays a
single orthogonal modifier. Darwin arm64e is unchanged.

## Not covered

Stalker's block dispatch still uses `br`. Its targets are mostly its own blocks,
so it wants landing pads at block entries rather than the `ret` treatment:
routing its hot path through `ret` would pop the return-address stack on every
block transition and mispredict real returns process-wide. That touches slab
layout and `GUM_RESTORATION_PROLOG_SIZE`, so it is left for a follow-up, and a
kernel-flavour Stalker still trips BTI.

## Testing

`Arm64Writer` covers the new `put_jmp_reg*` and `put_bti`, and still asserts
that `put_br_reg` emits `br`. The `Arm64Relocator` expectations were updated by
hand from `br x16` to `ret x16`; they are gated behind `cs_support
(CS_ARCH_ARM64)` and need arm64 CI to confirm. Nothing here has been exercised
on a BTI-enforcing kernel yet.
