### PR TITLE
interceptor: Don't reap live frames across stackful coroutines

### DIFF
--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -232,14 +232,17 @@ static GumInvocationStackEntry * gum_invocation_stack_push (
     gpointer caller_ret_addr, gpointer stack_address,
     gboolean only_invoke_unignorable_listeners);
 static gpointer gum_invocation_stack_pop (GumInvocationStack * stack);
+static void gum_invocation_stack_remove_entry (GumInvocationStack * stack,
+    GumFunctionContext * function_ctx, gpointer stack_address);
 static void gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
     gpointer live_stack_address);
-static void gum_invocation_stack_reap_unwound_above (
+static GumInvocationStackEntry * gum_invocation_stack_reap_unwound_above (
     GumInvocationStack * stack, GumFunctionContext * returning_ctx);
 static void gum_invocation_stack_entry_snapshot_cpu_context (
     GumInvocationStackEntry * entry, const GumCpuContext * cpu_context);
 static gboolean gum_invocation_stack_entry_was_unwound_past (
-    const GumInvocationStackEntry * entry, gpointer live_stack_address);
+    const GumInvocationStackEntry * entry, gpointer live_stack_address,
+    const GumMemoryRange * ranges, guint n_ranges);
 static void gum_invocation_stack_entry_release_trampoline (
     const GumInvocationStackEntry * entry);
 static GumInvocationStackEntry * gum_invocation_stack_peek_top (
@@ -2143,6 +2146,7 @@ _gum_function_context_end_invocation (GumFunctionContext * function_ctx,
   InterceptorThreadContext * interceptor_ctx;
   GumInvocationStackEntry * stack_entry;
   GumInvocationContext * invocation_ctx;
+  gpointer stack_address;
   GPtrArray * listener_entries;
   gboolean only_invoke_unignorable_listeners;
   guint i;
@@ -2159,11 +2163,22 @@ _gum_function_context_end_invocation (GumFunctionContext * function_ctx,
 
   interceptor_ctx = get_interceptor_thread_context ();
 
-  gum_invocation_stack_reap_unwound_above (interceptor_ctx->stack,
+  stack_entry = gum_invocation_stack_reap_unwound_above (interceptor_ctx->stack,
       function_ctx);
+  if (G_UNLIKELY (stack_entry == NULL))
+  {
+    /*
+     * The enter-side frame is gone, so the original return address is too.
+     * Never peek an empty invocation stack: that is UB, and compilers
+     * delete peek_top()'s NULL check, turning len==0 into a wild pointer.
+     */
+    *next_hop = NULL;
+    gum_tls_key_set_value (gum_interceptor_guard_key, NULL);
+    return;
+  }
 
-  stack_entry = gum_invocation_stack_peek_top (interceptor_ctx->stack);
   *next_hop = gum_sign_code_pointer (stack_entry->caller_ret_addr);
+  stack_address = stack_entry->stack_address;
 
   invocation_ctx = &stack_entry->invocation_context;
   invocation_ctx->cpu_context = cpu_context;
@@ -2211,7 +2226,8 @@ _gum_function_context_end_invocation (GumFunctionContext * function_ctx,
 
   gum_thread_set_system_error (invocation_ctx->system_error);
 
-  gum_invocation_stack_pop (interceptor_ctx->stack);
+  gum_invocation_stack_remove_entry (interceptor_ctx->stack, function_ctx,
+      stack_address);
 
   gum_tls_key_set_value (gum_interceptor_guard_key, NULL);
 
@@ -2529,9 +2545,36 @@ gum_invocation_stack_pop (GumInvocationStack * stack)
 }
 
 static void
+gum_invocation_stack_remove_entry (GumInvocationStack * stack,
+                                   GumFunctionContext * function_ctx,
+                                   gpointer stack_address)
+{
+  guint i;
+
+  for (i = stack->len; i != 0; i--)
+  {
+    GumInvocationStackEntry * entry;
+
+    entry = (GumInvocationStackEntry *)
+        &g_array_index (stack, GumInvocationStackEntry, i - 1);
+    if (entry->function_ctx == function_ctx &&
+        entry->stack_address == stack_address)
+    {
+      g_array_remove_index (stack, i - 1);
+      return;
+    }
+  }
+}
+
+static void
 gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
                                    gpointer live_stack_address)
 {
+  GumMemoryRange ranges[2];
+  guint n_ranges;
+
+  n_ranges = gum_thread_try_get_ranges (ranges, G_N_ELEMENTS (ranges));
+
   while (stack->len != 0)
   {
     GumInvocationStackEntry * entry;
@@ -2539,7 +2582,7 @@ gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
     entry = (GumInvocationStackEntry *)
         &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
     if (!gum_invocation_stack_entry_was_unwound_past (entry,
-        live_stack_address))
+        live_stack_address, ranges, n_ranges))
       break;
 
     gum_invocation_stack_entry_release_trampoline (entry);
@@ -2547,16 +2590,16 @@ gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
   }
 }
 
-static void
+static GumInvocationStackEntry *
 gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
                                          GumFunctionContext * returning_ctx)
 {
   /*
-   * Reap entries sitting above the frame we are about to return from, leaving
-   * that frame on top. Calls nest last-in-first-out, and entries that don't
-   * trap on leave are popped right away on enter, so any entry still stacked
-   * above our frame belongs to a deeper call that was unwound past by a C++
-   * exception or longjmp(), skipping its on-leave trampoline.
+   * Reap entries sitting above the frame we are about to return from. Calls
+   * nest last-in-first-out, and entries that don't trap on leave are popped
+   * right away on enter, so any entry still stacked above our frame belongs
+   * to a deeper call that was unwound past by a C++ exception or longjmp(),
+   * skipping its on-leave trampoline.
    *
    * We cannot lean on the leave-time stack pointer the way the on-enter path
    * does: a callee-clean calling convention such as x86 stdcall pops the
@@ -2564,19 +2607,57 @@ gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
    * recorded stack address, and a frame-pointer-omitting caller and callee
    * may even share one. Matching on the returning function context sidesteps
    * both pitfalls.
+   *
+   * Stackful coroutines / fibers multiplex several C stacks onto one OS
+   * thread, so a live frame from another stack may sit above ours. Only
+   * reap intervening entries that look unwound on the same OS thread stack;
+   * leave the rest in place and return our frame even if it is not on top.
    */
-  while (stack->len != 0)
+  guint i;
+  gint matching_index = -1;
+  GumMemoryRange ranges[2];
+  guint n_ranges;
+  GumInvocationStackEntry * matching;
+
+  for (i = stack->len; i != 0; i--)
   {
     GumInvocationStackEntry * entry;
 
     entry = (GumInvocationStackEntry *)
-        &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
+        &g_array_index (stack, GumInvocationStackEntry, i - 1);
     if (entry->function_ctx == returning_ctx)
+    {
+      matching_index = (gint) (i - 1);
       break;
+    }
+  }
+
+  if (matching_index < 0)
+    return NULL;
+
+  matching = (GumInvocationStackEntry *)
+      &g_array_index (stack, GumInvocationStackEntry, matching_index);
+
+  n_ranges = gum_thread_try_get_ranges (ranges, G_N_ELEMENTS (ranges));
+
+  i = stack->len;
+  while (i > (guint) matching_index + 1)
+  {
+    GumInvocationStackEntry * entry;
+
+    i--;
+    entry = (GumInvocationStackEntry *)
+        &g_array_index (stack, GumInvocationStackEntry, i);
+    if (!gum_invocation_stack_entry_was_unwound_past (entry,
+        matching->stack_address, ranges, n_ranges))
+      continue;
 
     gum_invocation_stack_entry_release_trampoline (entry);
-    g_array_set_size (stack, stack->len - 1);
+    g_array_remove_index (stack, i);
   }
+
+  return (GumInvocationStackEntry *)
+      &g_array_index (stack, GumInvocationStackEntry, matching_index);
 }
 
 static void
@@ -2595,9 +2676,34 @@ gum_invocation_stack_entry_snapshot_cpu_context (
 static gboolean
 gum_invocation_stack_entry_was_unwound_past (
     const GumInvocationStackEntry * entry,
-    gpointer live_stack_address)
+    gpointer live_stack_address,
+    const GumMemoryRange * ranges,
+    guint n_ranges)
 {
-  return (guint8 *) entry->stack_address < (guint8 *) live_stack_address;
+  guint i;
+
+  if ((guint8 *) entry->stack_address >= (guint8 *) live_stack_address)
+    return FALSE;
+
+  /*
+   * Fiber / coroutine stacks are not the pthread/OS stack, so a live frame
+   * on a lower-address mmap region must not be treated as unwound just
+   * because the current SP is higher. When the backend cannot report a
+   * thread stack (bare metal, some QNX builds) keep the classic comparison.
+   */
+  if (n_ranges == 0)
+    return TRUE;
+
+  for (i = 0; i != n_ranges; i++)
+  {
+    const GumMemoryRange * r = &ranges[i];
+
+    if (GUM_MEMORY_RANGE_INCLUDES (r, GUM_ADDRESS (entry->stack_address)) &&
+        GUM_MEMORY_RANGE_INCLUDES (r, GUM_ADDRESS (live_stack_address)))
+      return TRUE;
+  }
+
+  return FALSE;
 }
 
 static void

--- a/gum/guminterceptor.c
+++ b/gum/guminterceptor.c
@@ -35,6 +35,8 @@
 #define GUM_INTERCEPTOR_LOCK(o) g_rec_mutex_lock (&(o)->mutex)
 #define GUM_INTERCEPTOR_UNLOCK(o) g_rec_mutex_unlock (&(o)->mutex)
 
+#define GUM_INTERCEPTOR_EXTRA_STACK_RANGES 8
+
 #if defined (HAVE_I386)
 # define GUM_INTERCEPTOR_CPU_CONTEXT_SP(c) \
     ((gpointer) GUM_CPU_CONTEXT_XSP (c))
@@ -123,6 +125,10 @@ struct _InterceptorThreadContext
 
   GumInvocationStack * stack;
 
+  GumMemoryRange extra_stack_ranges[GUM_INTERCEPTOR_EXTRA_STACK_RANGES];
+  guint n_extra_stack_ranges;
+  guint extra_stack_range_cursor;
+
   GArray * listener_data_slots;
 };
 
@@ -131,6 +137,7 @@ struct _GumInvocationStackEntry
   GumFunctionContext * function_ctx;
   gpointer caller_ret_addr;
   gpointer stack_address;
+  GumMemoryRange stack_range;
   GumInvocationContext invocation_context;
   GumCpuContext cpu_context;
 #ifdef GUM_CPU_CONTEXT_HAS_OUT_OF_LINE_VECTORS
@@ -227,26 +234,35 @@ static gpointer interceptor_thread_context_get_listener_data (
     gsize required_size);
 static void interceptor_thread_context_forget_listener_data (
     InterceptorThreadContext * self, GumInvocationListener * listener);
+static void gum_interceptor_resolve_stack_range (
+    InterceptorThreadContext * ctx, gpointer sp, GumMemoryRange * range);
+static gboolean gum_interceptor_find_range_containing (
+    const GumRangeDetails * details, gpointer user_data);
+static gboolean gum_memory_ranges_equal (const GumMemoryRange * a,
+    const GumMemoryRange * b);
 static GumInvocationStackEntry * gum_invocation_stack_push (
     GumInvocationStack * stack, GumFunctionContext * function_ctx,
     gpointer caller_ret_addr, gpointer stack_address,
+    const GumMemoryRange * stack_range,
     gboolean only_invoke_unignorable_listeners);
 static gpointer gum_invocation_stack_pop (GumInvocationStack * stack);
 static void gum_invocation_stack_remove_entry (GumInvocationStack * stack,
     GumFunctionContext * function_ctx, gpointer stack_address);
 static void gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
-    gpointer live_stack_address);
+    gpointer live_stack_address, const GumMemoryRange * live_range);
 static GumInvocationStackEntry * gum_invocation_stack_reap_unwound_above (
-    GumInvocationStack * stack, GumFunctionContext * returning_ctx);
+    GumInvocationStack * stack, GumFunctionContext * returning_ctx,
+    const GumMemoryRange * live_range);
 static void gum_invocation_stack_entry_snapshot_cpu_context (
     GumInvocationStackEntry * entry, const GumCpuContext * cpu_context);
 static gboolean gum_invocation_stack_entry_was_unwound_past (
-    const GumInvocationStackEntry * entry, gpointer live_stack_address,
-    const GumMemoryRange * ranges, guint n_ranges);
+    const GumInvocationStackEntry * entry, gpointer live_stack_address);
 static void gum_invocation_stack_entry_release_trampoline (
     const GumInvocationStackEntry * entry);
-static GumInvocationStackEntry * gum_invocation_stack_peek_top (
-    GumInvocationStack * stack);
+static GumInvocationStackEntry * gum_invocation_stack_peek_top_on_stack (
+    GumInvocationStack * stack, const GumMemoryRange * range);
+static GumInvocationStackEntry * gum_invocation_stack_peek_current (
+    InterceptorThreadContext * ctx);
 
 static gpointer gum_interceptor_resolve (GumInterceptor * self,
     gpointer address);
@@ -1053,7 +1069,7 @@ gum_interceptor_get_current_invocation (void)
   GumInvocationStackEntry * entry;
 
   interceptor_ctx = get_interceptor_thread_context ();
-  entry = gum_invocation_stack_peek_top (interceptor_ctx->stack);
+  entry = gum_invocation_stack_peek_current (interceptor_ctx);
   if (entry == NULL)
     return NULL;
 
@@ -1077,7 +1093,7 @@ gum_interceptor_get_live_replacement_invocation (gpointer replacement_function)
   GumInvocationStackEntry * entry;
 
   interceptor_ctx = get_interceptor_thread_context ();
-  entry = gum_invocation_stack_peek_top (interceptor_ctx->stack);
+  entry = gum_invocation_stack_peek_current (interceptor_ctx);
   if (entry == NULL)
     return NULL;
   if (!entry->calling_replacement)
@@ -1385,14 +1401,13 @@ gum_interceptor_discard_function_contexts_in_range (
 gpointer
 _gum_interceptor_peek_top_caller_return_address (void)
 {
-  GumInvocationStack * stack;
+  InterceptorThreadContext * interceptor_ctx;
   GumInvocationStackEntry * entry;
 
-  stack = gum_interceptor_get_current_stack ();
-  if (stack->len == 0)
+  interceptor_ctx = get_interceptor_thread_context ();
+  entry = gum_invocation_stack_peek_current (interceptor_ctx);
+  if (entry == NULL)
     return NULL;
-
-  entry = &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
 
   return entry->caller_ret_addr;
 }
@@ -1400,14 +1415,13 @@ _gum_interceptor_peek_top_caller_return_address (void)
 gpointer
 _gum_interceptor_translate_top_return_address (gpointer return_address)
 {
-  GumInvocationStack * stack;
+  InterceptorThreadContext * interceptor_ctx;
   GumInvocationStackEntry * entry;
 
-  stack = gum_interceptor_get_current_stack ();
-  if (stack->len == 0)
+  interceptor_ctx = get_interceptor_thread_context ();
+  entry = gum_invocation_stack_peek_current (interceptor_ctx);
+  if (entry == NULL)
     goto fallback;
-
-  entry = &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
   if (entry->function_ctx->on_leave_trampoline != return_address)
     goto fallback;
 
@@ -1980,6 +1994,7 @@ _gum_function_context_begin_invocation (GumFunctionContext * function_ctx,
   GumInvocationStackEntry * stack_entry;
   GumInvocationContext * invocation_ctx = NULL;
   gpointer stack_address;
+  GumMemoryRange stack_range;
   gint system_error;
   gboolean invoke_listeners = TRUE;
   gboolean only_invoke_unignorable_listeners = FALSE;
@@ -2002,8 +2017,11 @@ _gum_function_context_begin_invocation (GumFunctionContext * function_ctx,
 
   interceptor_ctx = get_interceptor_thread_context ();
   stack = interceptor_ctx->stack;
+  stack_address = GUM_INTERCEPTOR_CPU_CONTEXT_SP (cpu_context);
+  gum_interceptor_resolve_stack_range (interceptor_ctx, stack_address,
+      &stack_range);
 
-  stack_entry = gum_invocation_stack_peek_top (stack);
+  stack_entry = gum_invocation_stack_peek_top_on_stack (stack, &stack_range);
   if (stack_entry != NULL &&
       stack_entry->calling_replacement &&
       gum_strip_code_pointer (GUM_FUNCPTR_TO_POINTER (
@@ -2036,21 +2054,21 @@ _gum_function_context_begin_invocation (GumFunctionContext * function_ctx,
     only_invoke_unignorable_listeners = TRUE;
   }
 
-  stack_address = GUM_INTERCEPTOR_CPU_CONTEXT_SP (cpu_context);
-  gum_invocation_stack_reap_unwound (stack, stack_address);
+  gum_invocation_stack_reap_unwound (stack, stack_address, &stack_range);
 
   will_trap_on_leave = function_ctx->replacement_function != NULL ||
       (invoke_listeners && function_ctx->has_on_leave_listener);
   if (will_trap_on_leave)
   {
     stack_entry = gum_invocation_stack_push (stack, function_ctx,
-        *caller_ret_addr, stack_address, only_invoke_unignorable_listeners);
+        *caller_ret_addr, stack_address, &stack_range,
+        only_invoke_unignorable_listeners);
     invocation_ctx = &stack_entry->invocation_context;
   }
   else if (invoke_listeners)
   {
     stack_entry = gum_invocation_stack_push (stack, function_ctx,
-        function_ctx->function_address, stack_address,
+        function_ctx->function_address, stack_address, &stack_range,
         only_invoke_unignorable_listeners);
     invocation_ctx = &stack_entry->invocation_context;
   }
@@ -2147,6 +2165,7 @@ _gum_function_context_end_invocation (GumFunctionContext * function_ctx,
   GumInvocationStackEntry * stack_entry;
   GumInvocationContext * invocation_ctx;
   gpointer stack_address;
+  GumMemoryRange stack_range;
   GPtrArray * listener_entries;
   gboolean only_invoke_unignorable_listeners;
   guint i;
@@ -2162,16 +2181,14 @@ _gum_function_context_end_invocation (GumFunctionContext * function_ctx,
 #endif
 
   interceptor_ctx = get_interceptor_thread_context ();
+  stack_address = GUM_INTERCEPTOR_CPU_CONTEXT_SP (cpu_context);
+  gum_interceptor_resolve_stack_range (interceptor_ctx, stack_address,
+      &stack_range);
 
   stack_entry = gum_invocation_stack_reap_unwound_above (interceptor_ctx->stack,
-      function_ctx);
-  if (G_UNLIKELY (stack_entry == NULL))
+      function_ctx, &stack_range);
+  if (stack_entry == NULL)
   {
-    /*
-     * The enter-side frame is gone, so the original return address is too.
-     * Never peek an empty invocation stack: that is UB, and compilers
-     * delete peek_top()'s NULL check, turning len==0 into a wild pointer.
-     */
     *next_hop = NULL;
     gum_tls_key_set_value (gum_interceptor_guard_key, NULL);
     return;
@@ -2316,10 +2333,26 @@ gum_interceptor_invocation_get_thread_id (GumInvocationContext * context)
 static guint
 gum_interceptor_invocation_get_depth (GumInvocationContext * context)
 {
-  InterceptorThreadContext * interceptor_ctx =
-      (InterceptorThreadContext *) context->backend->state;
+  InterceptorThreadContext * interceptor_ctx;
+  GumInvocationStackEntry * current;
+  guint depth, i;
 
-  return interceptor_ctx->stack->len - 1;
+  interceptor_ctx = (InterceptorThreadContext *) context->backend->state;
+  current = gum_invocation_stack_peek_current (interceptor_ctx);
+  if (current == NULL)
+    return 0;
+
+  depth = 0;
+  for (i = 0; i != interceptor_ctx->stack->len; i++)
+  {
+    GumInvocationStackEntry * entry;
+
+    entry = &g_array_index (interceptor_ctx->stack, GumInvocationStackEntry, i);
+    if (gum_memory_ranges_equal (&entry->stack_range, &current->stack_range))
+      depth++;
+  }
+
+  return depth - 1;
 }
 
 static gpointer
@@ -2504,11 +2537,95 @@ interceptor_thread_context_forget_listener_data (
   }
 }
 
+typedef struct _GumFindStackRangeContext GumFindStackRangeContext;
+
+struct _GumFindStackRangeContext
+{
+  GumAddress sp;
+  GumMemoryRange * range;
+  gboolean found;
+};
+
+static void
+gum_interceptor_resolve_stack_range (InterceptorThreadContext * ctx,
+                                     gpointer sp,
+                                     GumMemoryRange * range)
+{
+  GumMemoryRange os_ranges[2];
+  guint n, i;
+  GumFindStackRangeContext find;
+
+  n = gum_thread_try_get_ranges (os_ranges, G_N_ELEMENTS (os_ranges));
+  for (i = 0; i != n; i++)
+  {
+    if (GUM_MEMORY_RANGE_INCLUDES (&os_ranges[i], GUM_ADDRESS (sp)))
+    {
+      *range = os_ranges[i];
+      return;
+    }
+  }
+
+  for (i = 0; i != ctx->n_extra_stack_ranges; i++)
+  {
+    if (GUM_MEMORY_RANGE_INCLUDES (&ctx->extra_stack_ranges[i],
+        GUM_ADDRESS (sp)))
+    {
+      *range = ctx->extra_stack_ranges[i];
+      return;
+    }
+  }
+
+  find.sp = GUM_ADDRESS (sp);
+  find.range = range;
+  find.found = FALSE;
+  _gum_process_enumerate_ranges (GUM_PAGE_RW,
+      gum_interceptor_find_range_containing, &find);
+  if (find.found)
+  {
+    guint slot;
+
+    if (ctx->n_extra_stack_ranges != G_N_ELEMENTS (ctx->extra_stack_ranges))
+      slot = ctx->n_extra_stack_ranges++;
+    else
+      slot = ctx->extra_stack_range_cursor++ %
+          G_N_ELEMENTS (ctx->extra_stack_ranges);
+    ctx->extra_stack_ranges[slot] = *range;
+    return;
+  }
+
+  range->base_address = 0;
+  range->size = (gsize) -1;
+}
+
+static gboolean
+gum_interceptor_find_range_containing (const GumRangeDetails * details,
+                                       gpointer user_data)
+{
+  GumFindStackRangeContext * ctx = user_data;
+
+  if (GUM_MEMORY_RANGE_INCLUDES (details->range, ctx->sp))
+  {
+    *ctx->range = *details->range;
+    ctx->found = TRUE;
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static gboolean
+gum_memory_ranges_equal (const GumMemoryRange * a,
+                         const GumMemoryRange * b)
+{
+  return a->base_address == b->base_address && a->size == b->size;
+}
+
 static GumInvocationStackEntry *
 gum_invocation_stack_push (GumInvocationStack * stack,
                            GumFunctionContext * function_ctx,
                            gpointer caller_ret_addr,
                            gpointer stack_address,
+                           const GumMemoryRange * stack_range,
                            gboolean only_invoke_unignorable_listeners)
 {
   GumInvocationStackEntry * entry;
@@ -2520,6 +2637,7 @@ gum_invocation_stack_push (GumInvocationStack * stack,
   entry->function_ctx = function_ctx;
   entry->caller_ret_addr = caller_ret_addr;
   entry->stack_address = stack_address;
+  entry->stack_range = *stack_range;
   entry->only_invoke_unignorable_listeners = only_invoke_unignorable_listeners;
 
   ctx = &entry->invocation_context;
@@ -2568,38 +2686,42 @@ gum_invocation_stack_remove_entry (GumInvocationStack * stack,
 
 static void
 gum_invocation_stack_reap_unwound (GumInvocationStack * stack,
-                                   gpointer live_stack_address)
+                                   gpointer live_stack_address,
+                                   const GumMemoryRange * live_range)
 {
-  GumMemoryRange ranges[2];
-  guint n_ranges;
+  guint i;
 
-  n_ranges = gum_thread_try_get_ranges (ranges, G_N_ELEMENTS (ranges));
-
-  while (stack->len != 0)
+  i = stack->len;
+  while (i != 0)
   {
     GumInvocationStackEntry * entry;
 
+    i--;
     entry = (GumInvocationStackEntry *)
-        &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
+        &g_array_index (stack, GumInvocationStackEntry, i);
+    if (!gum_memory_ranges_equal (&entry->stack_range, live_range))
+      continue;
+
     if (!gum_invocation_stack_entry_was_unwound_past (entry,
-        live_stack_address, ranges, n_ranges))
+        live_stack_address))
       break;
 
     gum_invocation_stack_entry_release_trampoline (entry);
-    g_array_set_size (stack, stack->len - 1);
+    g_array_remove_index (stack, i);
   }
 }
 
 static GumInvocationStackEntry *
 gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
-                                         GumFunctionContext * returning_ctx)
+                                         GumFunctionContext * returning_ctx,
+                                         const GumMemoryRange * live_range)
 {
   /*
-   * Reap entries sitting above the frame we are about to return from. Calls
-   * nest last-in-first-out, and entries that don't trap on leave are popped
-   * right away on enter, so any entry still stacked above our frame belongs
-   * to a deeper call that was unwound past by a C++ exception or longjmp(),
-   * skipping its on-leave trampoline.
+   * Reap same-stack entries sitting above the frame we are about to return
+   * from. Calls nest last-in-first-out, and entries that don't trap on leave
+   * are popped right away on enter, so any same-stack entry still stacked
+   * after ours belongs to a deeper call that was unwound past by a C++
+   * exception or longjmp(), skipping its on-leave trampoline.
    *
    * We cannot lean on the leave-time stack pointer the way the on-enter path
    * does: a callee-clean calling convention such as x86 stdcall pops the
@@ -2609,23 +2731,23 @@ gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
    * both pitfalls.
    *
    * Stackful coroutines / fibers multiplex several C stacks onto one OS
-   * thread, so a live frame from another stack may sit above ours. Only
-   * reap intervening entries that look unwound on the same OS thread stack;
-   * leave the rest in place and return our frame even if it is not on top.
+   * thread. Each frame records the memory range of its C stack at enter;
+   * we only match and reap within that range, so a live frame on another
+   * stack is never discarded, including when two fibers call the same
+   * hooked function.
    */
   guint i;
-  gint matching_index = -1;
-  GumMemoryRange ranges[2];
-  guint n_ranges;
-  GumInvocationStackEntry * matching;
+  gint matching_index;
 
+  matching_index = -1;
   for (i = stack->len; i != 0; i--)
   {
     GumInvocationStackEntry * entry;
 
     entry = (GumInvocationStackEntry *)
         &g_array_index (stack, GumInvocationStackEntry, i - 1);
-    if (entry->function_ctx == returning_ctx)
+    if (entry->function_ctx == returning_ctx &&
+        gum_memory_ranges_equal (&entry->stack_range, live_range))
     {
       matching_index = (gint) (i - 1);
       break;
@@ -2635,11 +2757,6 @@ gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
   if (matching_index < 0)
     return NULL;
 
-  matching = (GumInvocationStackEntry *)
-      &g_array_index (stack, GumInvocationStackEntry, matching_index);
-
-  n_ranges = gum_thread_try_get_ranges (ranges, G_N_ELEMENTS (ranges));
-
   i = stack->len;
   while (i > (guint) matching_index + 1)
   {
@@ -2648,8 +2765,7 @@ gum_invocation_stack_reap_unwound_above (GumInvocationStack * stack,
     i--;
     entry = (GumInvocationStackEntry *)
         &g_array_index (stack, GumInvocationStackEntry, i);
-    if (!gum_invocation_stack_entry_was_unwound_past (entry,
-        matching->stack_address, ranges, n_ranges))
+    if (!gum_memory_ranges_equal (&entry->stack_range, live_range))
       continue;
 
     gum_invocation_stack_entry_release_trampoline (entry);
@@ -2676,34 +2792,9 @@ gum_invocation_stack_entry_snapshot_cpu_context (
 static gboolean
 gum_invocation_stack_entry_was_unwound_past (
     const GumInvocationStackEntry * entry,
-    gpointer live_stack_address,
-    const GumMemoryRange * ranges,
-    guint n_ranges)
+    gpointer live_stack_address)
 {
-  guint i;
-
-  if ((guint8 *) entry->stack_address >= (guint8 *) live_stack_address)
-    return FALSE;
-
-  /*
-   * Fiber / coroutine stacks are not the pthread/OS stack, so a live frame
-   * on a lower-address mmap region must not be treated as unwound just
-   * because the current SP is higher. When the backend cannot report a
-   * thread stack (bare metal, some QNX builds) keep the classic comparison.
-   */
-  if (n_ranges == 0)
-    return TRUE;
-
-  for (i = 0; i != n_ranges; i++)
-  {
-    const GumMemoryRange * r = &ranges[i];
-
-    if (GUM_MEMORY_RANGE_INCLUDES (r, GUM_ADDRESS (entry->stack_address)) &&
-        GUM_MEMORY_RANGE_INCLUDES (r, GUM_ADDRESS (live_stack_address)))
-      return TRUE;
-  }
-
-  return FALSE;
+  return (guint8 *) entry->stack_address < (guint8 *) live_stack_address;
 }
 
 static void
@@ -2714,12 +2805,31 @@ gum_invocation_stack_entry_release_trampoline (
 }
 
 static GumInvocationStackEntry *
-gum_invocation_stack_peek_top (GumInvocationStack * stack)
+gum_invocation_stack_peek_top_on_stack (GumInvocationStack * stack,
+                                        const GumMemoryRange * range)
 {
-  if (stack->len == 0)
-    return NULL;
+  guint i;
 
-  return &g_array_index (stack, GumInvocationStackEntry, stack->len - 1);
+  for (i = stack->len; i != 0; i--)
+  {
+    GumInvocationStackEntry * entry;
+
+    entry = &g_array_index (stack, GumInvocationStackEntry, i - 1);
+    if (gum_memory_ranges_equal (&entry->stack_range, range))
+      return entry;
+  }
+
+  return NULL;
+}
+
+static GumInvocationStackEntry *
+gum_invocation_stack_peek_current (InterceptorThreadContext * ctx)
+{
+  guint8 probe;
+  GumMemoryRange range;
+
+  gum_interceptor_resolve_stack_range (ctx, &probe, &range);
+  return gum_invocation_stack_peek_top_on_stack (ctx->stack, &range);
 }
 
 static gpointer

--- a/tests/core/interceptor-fixture.c
+++ b/tests/core/interceptor-fixture.c
@@ -120,7 +120,7 @@ struct _TestInterceptorFixture
 {
   GumInterceptor * interceptor;
   GString * result;
-  ListenerContext * listener_context[2];
+  ListenerContext * listener_context[4];
 };
 
 static GumAttachReturn interceptor_fixture_try_attach_with_options (

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -10,6 +10,7 @@
 
 #include <setjmp.h>
 #if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+# include <sys/mman.h>
 # include <ucontext.h>
 #endif
 
@@ -42,6 +43,8 @@ TESTLIST_BEGIN (interceptor)
   TESTENTRY (longjmp_reaps_skipped_leave)
 #if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
   TESTENTRY (stackful_coroutine_does_not_reap_live_frames)
+  TESTENTRY (stackful_coroutine_same_function)
+  TESTENTRY (stackful_coroutine_longjmp_reaps_on_fiber)
 #endif
 #ifdef G_OS_UNIX
   TESTENTRY (attach_to_pthread_key_create)
@@ -134,6 +137,8 @@ gum_test_longjmp_outer (void)
 static ucontext_t gum_test_uctx_main;
 static ucontext_t gum_test_uctx_a;
 static ucontext_t gum_test_uctx_b;
+static gchar gum_test_fiber_tag;
+static jmp_buf gum_test_fiber_jmp;
 
 GUM_HOOK_TARGET static void
 gum_test_fiber_a_work (void)
@@ -151,6 +156,34 @@ gum_test_fiber_b_work (void)
   g_string_append_c (gum_test_unwind_log, 'b');
 }
 
+GUM_HOOK_TARGET static void
+gum_test_fiber_shared_work (void)
+{
+  g_string_append_c (gum_test_unwind_log, gum_test_fiber_tag);
+  if (gum_test_fiber_tag == 'A')
+    swapcontext (&gum_test_uctx_a, &gum_test_uctx_b);
+  else
+    swapcontext (&gum_test_uctx_b, &gum_test_uctx_a);
+  g_string_append_c (gum_test_unwind_log, gum_test_fiber_tag + ('a' - 'A'));
+}
+
+GUM_HOOK_TARGET static void
+gum_test_fiber_inner (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'i');
+  longjmp (gum_test_fiber_jmp, 1);
+}
+
+GUM_HOOK_TARGET static void
+gum_test_fiber_b_with_longjmp (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'B');
+  if (setjmp (gum_test_fiber_jmp) == 0)
+    gum_test_fiber_inner ();
+  swapcontext (&gum_test_uctx_b, &gum_test_uctx_a);
+  g_string_append_c (gum_test_unwind_log, 'b');
+}
+
 static void
 gum_test_fiber_a_start (void)
 {
@@ -162,6 +195,27 @@ static void
 gum_test_fiber_b_start (void)
 {
   gum_test_fiber_b_work ();
+}
+
+static void
+gum_test_fiber_a_shared_start (void)
+{
+  gum_test_fiber_tag = 'A';
+  gum_test_fiber_shared_work ();
+  swapcontext (&gum_test_uctx_a, &gum_test_uctx_b);
+}
+
+static void
+gum_test_fiber_b_shared_start (void)
+{
+  gum_test_fiber_tag = 'B';
+  gum_test_fiber_shared_work ();
+}
+
+static void
+gum_test_fiber_b_longjmp_start (void)
+{
+  gum_test_fiber_b_with_longjmp ();
 }
 #endif
 
@@ -218,6 +272,20 @@ TESTCASE (longjmp_reaps_skipped_leave)
 
 #if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
 
+static void
+gum_test_setup_fiber (ucontext_t * ctx,
+                      gpointer stack,
+                      gsize stack_size,
+                      void (* func) (void),
+                      ucontext_t * link)
+{
+  g_assert_cmpint (getcontext (ctx), ==, 0);
+  ctx->uc_stack.ss_sp = stack;
+  ctx->uc_stack.ss_size = stack_size;
+  ctx->uc_link = link;
+  makecontext (ctx, func, 0);
+}
+
 TESTCASE (stackful_coroutine_does_not_reap_live_frames)
 {
   const gsize stack_size = 64 * 1024;
@@ -228,26 +296,79 @@ TESTCASE (stackful_coroutine_does_not_reap_live_frames)
   interceptor_fixture_attach (fixture, 0, gum_test_fiber_a_work, '>', '<');
   interceptor_fixture_attach (fixture, 1, gum_test_fiber_b_work, '[', ']');
 
-  stack_a = g_malloc (stack_size);
-  stack_b = g_malloc (stack_size);
+  stack_a = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  stack_b = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  g_assert_true (stack_a != MAP_FAILED && stack_b != MAP_FAILED);
 
-  g_assert_cmpint (getcontext (&gum_test_uctx_a), ==, 0);
-  gum_test_uctx_a.uc_stack.ss_sp = stack_a;
-  gum_test_uctx_a.uc_stack.ss_size = stack_size;
-  gum_test_uctx_a.uc_link = NULL;
-  makecontext (&gum_test_uctx_a, gum_test_fiber_a_start, 0);
-
-  g_assert_cmpint (getcontext (&gum_test_uctx_b), ==, 0);
-  gum_test_uctx_b.uc_stack.ss_sp = stack_b;
-  gum_test_uctx_b.uc_stack.ss_size = stack_size;
-  gum_test_uctx_b.uc_link = &gum_test_uctx_main;
-  makecontext (&gum_test_uctx_b, gum_test_fiber_b_start, 0);
+  gum_test_setup_fiber (&gum_test_uctx_a, stack_a, stack_size,
+      gum_test_fiber_a_start, NULL);
+  gum_test_setup_fiber (&gum_test_uctx_b, stack_b, stack_size,
+      gum_test_fiber_b_start, &gum_test_uctx_main);
 
   g_assert_cmpint (swapcontext (&gum_test_uctx_main, &gum_test_uctx_a), ==, 0);
   g_assert_cmpstr (fixture->result->str, ==, ">A[Ba<b]");
 
-  g_free (stack_a);
-  g_free (stack_b);
+  munmap (stack_a, stack_size);
+  munmap (stack_b, stack_size);
+}
+
+TESTCASE (stackful_coroutine_same_function)
+{
+  const gsize stack_size = 64 * 1024;
+  gpointer stack_a, stack_b;
+
+  gum_test_unwind_log = fixture->result;
+
+  interceptor_fixture_attach (fixture, 0, gum_test_fiber_shared_work, '>', '<');
+
+  stack_a = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  stack_b = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  g_assert_true (stack_a != MAP_FAILED && stack_b != MAP_FAILED);
+
+  gum_test_setup_fiber (&gum_test_uctx_a, stack_a, stack_size,
+      gum_test_fiber_a_shared_start, NULL);
+  gum_test_setup_fiber (&gum_test_uctx_b, stack_b, stack_size,
+      gum_test_fiber_b_shared_start, &gum_test_uctx_main);
+
+  g_assert_cmpint (swapcontext (&gum_test_uctx_main, &gum_test_uctx_a), ==, 0);
+  g_assert_cmpstr (fixture->result->str, ==, ">A>Ba<b<");
+
+  munmap (stack_a, stack_size);
+  munmap (stack_b, stack_size);
+}
+
+TESTCASE (stackful_coroutine_longjmp_reaps_on_fiber)
+{
+  const gsize stack_size = 64 * 1024;
+  gpointer stack_a, stack_b;
+
+  gum_test_unwind_log = fixture->result;
+
+  interceptor_fixture_attach (fixture, 0, gum_test_fiber_a_work, '>', '<');
+  interceptor_fixture_attach (fixture, 1, gum_test_fiber_b_with_longjmp,
+      '[', ']');
+  interceptor_fixture_attach (fixture, 2, gum_test_fiber_inner, '{', '}');
+
+  stack_a = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  stack_b = mmap (NULL, stack_size, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  g_assert_true (stack_a != MAP_FAILED && stack_b != MAP_FAILED);
+
+  gum_test_setup_fiber (&gum_test_uctx_a, stack_a, stack_size,
+      gum_test_fiber_a_start, NULL);
+  gum_test_setup_fiber (&gum_test_uctx_b, stack_b, stack_size,
+      gum_test_fiber_b_longjmp_start, &gum_test_uctx_main);
+
+  g_assert_cmpint (swapcontext (&gum_test_uctx_main, &gum_test_uctx_a), ==, 0);
+  g_assert_cmpstr (fixture->result->str, ==, ">A[B{ia<b]");
+
+  munmap (stack_a, stack_size);
+  munmap (stack_b, stack_size);
 }
 
 #endif

--- a/tests/core/interceptor.c
+++ b/tests/core/interceptor.c
@@ -8,6 +8,11 @@
 
 #include "interceptor-fixture.c"
 
+#include <setjmp.h>
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+# include <ucontext.h>
+#endif
+
 #if defined (HAVE_I386)
 # include "gumx86writer.h"
 #elif defined (HAVE_ARM64)
@@ -34,6 +39,10 @@ TESTLIST_BEGIN (interceptor)
   TESTENTRY (attach_two)
   TESTENTRY (attach_to_recursive_function)
   TESTENTRY (attach_to_special_function)
+  TESTENTRY (longjmp_reaps_skipped_leave)
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+  TESTENTRY (stackful_coroutine_does_not_reap_live_frames)
+#endif
 #ifdef G_OS_UNIX
   TESTENTRY (attach_to_pthread_key_create)
 #endif
@@ -102,6 +111,60 @@ static gpointer replacement_target_function_fast (GString * str);
 static gdouble gum_test_xmm_clobber (gdouble x);
 #endif
 
+static GString * gum_test_unwind_log = NULL;
+static jmp_buf gum_test_longjmp_buf;
+
+GUM_HOOK_TARGET static void
+gum_test_longjmp_inner (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'i');
+  longjmp (gum_test_longjmp_buf, 1);
+}
+
+GUM_HOOK_TARGET static void
+gum_test_longjmp_outer (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'o');
+  if (setjmp (gum_test_longjmp_buf) == 0)
+    gum_test_longjmp_inner ();
+  g_string_append_c (gum_test_unwind_log, 'O');
+}
+
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+static ucontext_t gum_test_uctx_main;
+static ucontext_t gum_test_uctx_a;
+static ucontext_t gum_test_uctx_b;
+
+GUM_HOOK_TARGET static void
+gum_test_fiber_a_work (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'A');
+  swapcontext (&gum_test_uctx_a, &gum_test_uctx_b);
+  g_string_append_c (gum_test_unwind_log, 'a');
+}
+
+GUM_HOOK_TARGET static void
+gum_test_fiber_b_work (void)
+{
+  g_string_append_c (gum_test_unwind_log, 'B');
+  swapcontext (&gum_test_uctx_b, &gum_test_uctx_a);
+  g_string_append_c (gum_test_unwind_log, 'b');
+}
+
+static void
+gum_test_fiber_a_start (void)
+{
+  gum_test_fiber_a_work ();
+  swapcontext (&gum_test_uctx_a, &gum_test_uctx_b);
+}
+
+static void
+gum_test_fiber_b_start (void)
+{
+  gum_test_fiber_b_work ();
+}
+#endif
+
 TESTCASE (attach_one)
 {
   interceptor_fixture_attach (fixture, 0, target_function, '>', '<');
@@ -140,6 +203,54 @@ TESTCASE (attach_to_special_function)
   special_function (fixture->result);
   g_assert_cmpstr (fixture->result->str, ==, ">|<");
 }
+
+TESTCASE (longjmp_reaps_skipped_leave)
+{
+  gum_test_unwind_log = fixture->result;
+
+  interceptor_fixture_attach (fixture, 0, gum_test_longjmp_outer, '>', '<');
+  interceptor_fixture_attach (fixture, 1, gum_test_longjmp_inner, '[', ']');
+
+  gum_test_longjmp_outer ();
+
+  g_assert_cmpstr (fixture->result->str, ==, ">o[iO<");
+}
+
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+
+TESTCASE (stackful_coroutine_does_not_reap_live_frames)
+{
+  const gsize stack_size = 64 * 1024;
+  gpointer stack_a, stack_b;
+
+  gum_test_unwind_log = fixture->result;
+
+  interceptor_fixture_attach (fixture, 0, gum_test_fiber_a_work, '>', '<');
+  interceptor_fixture_attach (fixture, 1, gum_test_fiber_b_work, '[', ']');
+
+  stack_a = g_malloc (stack_size);
+  stack_b = g_malloc (stack_size);
+
+  g_assert_cmpint (getcontext (&gum_test_uctx_a), ==, 0);
+  gum_test_uctx_a.uc_stack.ss_sp = stack_a;
+  gum_test_uctx_a.uc_stack.ss_size = stack_size;
+  gum_test_uctx_a.uc_link = NULL;
+  makecontext (&gum_test_uctx_a, gum_test_fiber_a_start, 0);
+
+  g_assert_cmpint (getcontext (&gum_test_uctx_b), ==, 0);
+  gum_test_uctx_b.uc_stack.ss_sp = stack_b;
+  gum_test_uctx_b.uc_stack.ss_size = stack_size;
+  gum_test_uctx_b.uc_link = &gum_test_uctx_main;
+  makecontext (&gum_test_uctx_b, gum_test_fiber_b_start, 0);
+
+  g_assert_cmpint (swapcontext (&gum_test_uctx_main, &gum_test_uctx_a), ==, 0);
+  g_assert_cmpstr (fixture->result->str, ==, ">A[Ba<b]");
+
+  g_free (stack_a);
+  g_free (stack_b);
+}
+
+#endif
 
 #ifdef G_OS_UNIX
 


### PR DESCRIPTION
## Summary

Fixes #1142.

On a target that multiplexes several C stacks onto one OS thread (`swapcontext` / fibers / stackful coroutines), Interceptor 17.x can `SIGSEGV` in `_gum_function_context_end_invocation` because reap treated `stack_address < live_sp` as proof a frame was unwound — including a still-live frame on another C stack.

## Approach

Each invocation-stack frame records the **memory range of its own C stack** at enter:

1. `gum_thread_try_get_ranges()` when the SP is on the pthread / Darwin thread stack / current Windows fiber (`GetCurrentThreadStackLimits`).
2. Otherwise the RW mapping that contains the SP (`_gum_process_enumerate_ranges`).

Reap and leave matching are **per range**:

- **Enter:** only SP-compare frames that share the live range. Frames on other stacks are skipped, even if they sit at a lower address or above us in the mixed invocation array.
- **Leave:** find the returning `function_ctx` **on that same range** (two fibers can call the same hooked function). Reap only intervening frames on that range (exception / `longjmp` on that C stack). `onLeave` runs on the matching frame; it is removed by index, so another fiber may remain stacked above it.
- **Current invocation / depth / replacement bypass** look at the top frame of the *current* C stack, not the mixed array top.

If the matching frame is missing, `next_hop` is not taken from a wild `peek_top()` (that path is UB and compilers delete the NULL check). That is an invariant failure, not a substitute for identifying the stack.

If the OS cannot describe any mapping (bare metal), the address space is one stack — the correct model when there is only one C stack, not a return to the old cross-stack SP compare.

## Tests

- `longjmp_reaps_skipped_leave` — thread stack: inner `onLeave` skipped by `longjmp` is reaped when the outer frame returns.
- `stackful_coroutine_does_not_reap_live_frames` — Linux, two `mmap` fibers, different hooked functions.
- `stackful_coroutine_same_function` — two fibers enter/leave the **same** hooked function; leave must not bind the other fiber's frame.
- `stackful_coroutine_longjmp_reaps_on_fiber` — `longjmp` on fiber B reaps B's inner frame and leaves fiber A intact.
