### PR TITLE
darwin: Use jailbreak-provided memory hooks

### DIFF
--- a/gum/backend-darwin/gummemory-darwin.c
+++ b/gum/backend-darwin/gummemory-darwin.c
@@ -10,7 +10,9 @@
 #include "gum/gumdarwin.h"
 #include "gumdarwin-priv.h"
 #include "gummemory-priv.h"
+#include "gummemory-jailbreak.h"
 
+#include <dlfcn.h>
 #include <errno.h>
 #include <unistd.h>
 #include <libkern/OSCacheControl.h>
@@ -52,14 +54,32 @@ static gboolean gum_try_suggest_allocation_base (const GumMemoryRange * range,
 static gint gum_page_protection_to_bsd (GumPageProtection prot);
 static gboolean gum_page_is_freshly_allocated (gpointer page, gsize size);
 
+const GumJailbreakMemoryHooks * gum_jailbreak_memory_hooks = NULL;
+
 void
 _gum_memory_backend_init (void)
 {
+#ifdef HAVE_JAILBREAK
+  const GumJailbreakMemoryHooks * (* query) (guint32 version);
+  const GumJailbreakMemoryHooks * hooks;
+
+  query = dlsym (RTLD_DEFAULT, "jb_get_memory_hooks");
+  if (query == NULL)
+    return;
+
+  hooks = query (1);
+  if (hooks == NULL || hooks->version != 1 || hooks->size < sizeof (*hooks) ||
+      hooks->patch_code == NULL || hooks->protect == NULL)
+    return;
+
+  gum_jailbreak_memory_hooks = hooks;
+#endif
 }
 
 void
 _gum_memory_backend_deinit (void)
 {
+  gum_jailbreak_memory_hooks = NULL;
 }
 
 guint
@@ -373,6 +393,9 @@ gum_darwin_write (mach_port_t task,
 gboolean
 gum_memory_can_remap_writable (void)
 {
+  if (gum_jailbreak_memory_hooks != NULL)
+    return FALSE;
+
   return gum_darwin_is_debugger_mapping_enforced ();
 }
 
@@ -437,6 +460,12 @@ gum_mach_vm_protect (vm_map_t target_task,
                      boolean_t set_maximum,
                      vm_prot_t new_protection)
 {
+  if (gum_jailbreak_memory_hooks != NULL)
+  {
+    return gum_jailbreak_memory_hooks->protect (target_task, address, size,
+        set_maximum, new_protection);
+  }
+
 #if defined (HAVE_ARM)
   kern_return_t result;
   guint32 args[] = {

--- a/gum/backend-darwin/gummemory-jailbreak.h
+++ b/gum/backend-darwin/gummemory-jailbreak.h
@@ -1,0 +1,23 @@
+/* Optional process-local ABI, shared with Dopamine's memory_hooks.h. */
+
+#ifndef __GUM_MEMORY_JAILBREAK_H__
+#define __GUM_MEMORY_JAILBREAK_H__
+
+#include "gummemory.h"
+
+#include <mach/mach.h>
+
+typedef struct _GumJailbreakMemoryHooks GumJailbreakMemoryHooks;
+
+struct _GumJailbreakMemoryHooks
+{
+  guint32 version;
+  guint32 size;
+  kern_return_t (* patch_code) (void * address, const void * data, size_t size);
+  kern_return_t (* protect) (mach_port_t task, mach_vm_address_t address,
+      mach_vm_size_t size, boolean_t set_maximum, vm_prot_t protection);
+};
+
+G_GNUC_INTERNAL extern const GumJailbreakMemoryHooks * gum_jailbreak_memory_hooks;
+
+#endif

--- a/gum/gummemory.c
+++ b/gum/gummemory.c
@@ -56,6 +56,7 @@
 #endif
 #ifdef HAVE_DARWIN
 # include "backend-darwin/gumdarwin-priv.h"
+# include "backend-darwin/gummemory-jailbreak.h"
 # include "gum/gumdarwin.h"
 #endif
 
@@ -160,6 +161,11 @@ static gboolean gum_memory_patch_code_pages_via_code_segment (
     GumMemoryPatchPagesApplyFunc apply, gpointer apply_data);
 static gboolean gum_maybe_suspend_thread (const GumThreadDetails * details,
     gpointer user_data);
+#ifdef HAVE_DARWIN
+static gboolean gum_memory_patch_code_pages_via_jailbreak (
+    GPtrArray * sorted_addresses, gboolean coalesce,
+    GumMemoryPatchPagesApplyFunc apply, gpointer apply_data);
+#endif
 
 static void gum_memory_scan_raw (const GumMemoryRange * range,
     const GumMatchPattern * pattern, GumMemoryScanMatchFunc func,
@@ -442,6 +448,14 @@ gum_memory_patch_code_pages (GPtrArray * sorted_addresses,
   gsize page_size;
   gboolean rwx_supported;
 
+#ifdef HAVE_DARWIN
+  if (gum_jailbreak_memory_hooks != NULL)
+  {
+    return gum_memory_patch_code_pages_via_jailbreak (sorted_addresses, coalesce,
+        apply, apply_data);
+  }
+#endif
+
   rwx_supported = gum_query_is_rwx_supported ();
   page_size = gum_query_page_size ();
 
@@ -461,6 +475,125 @@ gum_memory_patch_code_pages (GPtrArray * sorted_addresses,
         coalesce, page_size, apply, apply_data);
   }
 }
+
+#ifdef HAVE_DARWIN
+static gboolean
+gum_memory_patch_code_pages_via_jailbreak (GPtrArray * sorted_addresses,
+                                         gboolean coalesce,
+                                         GumMemoryPatchPagesApplyFunc apply,
+                                         gpointer apply_data)
+{
+  gboolean success = FALSE;
+  gsize page_size, size;
+  guint8 * scratch, * pristine;
+  guint i;
+  GumSuspendOperation suspend_op = { 0, };
+  gboolean suspended = FALSE;
+
+  if (sorted_addresses->len == 0)
+    return TRUE;
+
+  page_size = gum_query_page_size ();
+  if (sorted_addresses->len > G_MAXSIZE / page_size)
+    return FALSE;
+  size = sorted_addresses->len * page_size;
+
+  scratch = gum_memory_allocate (NULL, size, page_size, GUM_PAGE_RW);
+  pristine = gum_memory_allocate (NULL, size, page_size, GUM_PAGE_RW);
+  if (scratch == NULL || pristine == NULL)
+    goto beach;
+
+  for (i = 0; i != sorted_addresses->len; i++)
+  {
+    memcpy (pristine + i * page_size,
+        g_ptr_array_index (sorted_addresses, i), page_size);
+  }
+  memcpy (scratch, pristine, size);
+
+  for (i = 0; i != sorted_addresses->len;)
+  {
+    guint first, count;
+    guint8 * target;
+
+    first = i++;
+    target = g_ptr_array_index (sorted_addresses, first);
+    if (coalesce)
+    {
+      while (i != sorted_addresses->len &&
+          g_ptr_array_index (sorted_addresses, i) ==
+              target + (i - first) * page_size)
+        i++;
+    }
+    count = i - first;
+
+    apply (scratch + first * page_size, target, count, apply_data);
+  }
+
+  gum_metal_array_init (&suspend_op.suspended_threads, sizeof (GumThreadId));
+  suspend_op.current_thread_id = gum_process_get_current_thread_id ();
+  _gum_process_enumerate_threads (gum_maybe_suspend_thread, &suspend_op,
+      GUM_THREAD_FLAGS_NONE);
+  suspended = TRUE;
+
+  for (i = 0; i != sorted_addresses->len; i++)
+  {
+    guint8 * target, * source, * original;
+    gsize offset;
+
+    target = g_ptr_array_index (sorted_addresses, i);
+    source = scratch + i * page_size;
+    original = pristine + i * page_size;
+
+    /* Preserve bytes outside the patch and never split an ARM64 instruction. */
+    for (offset = 0; offset != page_size;)
+    {
+      gsize start;
+      kern_return_t kr;
+
+      if (memcmp (source + offset, original + offset, 4) == 0)
+      {
+        offset += 4;
+        continue;
+      }
+
+      start = offset;
+      do
+      {
+        offset += 4;
+      }
+      while (offset != page_size &&
+          memcmp (source + offset, original + offset, 4) != 0);
+
+      kr = gum_jailbreak_memory_hooks->patch_code (target + start,
+          source + start, offset - start);
+      if (kr != KERN_SUCCESS)
+        goto beach;
+    }
+  }
+
+  success = TRUE;
+
+beach:
+  if (suspended)
+  {
+    for (i = 0; i != suspend_op.suspended_threads.length; i++)
+    {
+      GumThreadId * id = gum_metal_array_element_at (
+          &suspend_op.suspended_threads, i);
+
+      gum_thread_resume (*id, NULL);
+      mach_port_mod_refs (mach_task_self (), *id, MACH_PORT_RIGHT_SEND, -1);
+    }
+    gum_metal_array_free (&suspend_op.suspended_threads);
+  }
+  if (pristine != NULL)
+    gum_memory_free (pristine, size);
+  if (scratch != NULL)
+    gum_memory_free (scratch, size);
+
+  return success;
+}
+#endif
 
 static gboolean
 gum_memory_patch_code_pages_via_remap (GPtrArray * sorted_addresses,


### PR DESCRIPTION
Dopamine monkey-patches Frida's syscall instructions to route executable-memory changes through hookd. This workaround is broken with current Frida on iOS 26, where Frida operations can crash the iPhone and force a reboot.

Use an optional, versioned memory provider for explicit hookd calls during initialization, code patching, and VM protection. This removes the dependency on Frida's instruction layout and avoids debugger page-plan traps; existing behavior is retained without a provider.

Together with opa334/Dopamine#1000, addresses opa334/Dopamine#938, opa334/Dopamine#979, opa334/Dopamine#985 and frida/frida#3773.

Validated on an iPhone 11/iOS 26.0 standalone target: attach, patch, Interceptor replace/revert, detach, and full reboot.
